### PR TITLE
redefine signalk-client dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bootstrap-slider": "^4.8.0",
     "nanomodal": "^5.1.0",
     "bootstrap-select": "^1.6.3",
-    "signalk-client": "^0.1.0",
+    "signalk-client": "git://github.com/SignalK/signalk-js-client.git#master",
     "web-audio-daw": "^2.3.1",
     "xml2js": "^0.4.16",
     "d3": "^4.1.1",


### PR DESCRIPTION
module not available at https://www.npmjs.com, redifine dependency
from github directly.

```
pi@freeboard:~/signalk-java/signalk-static/freeboard-sk $ npm install
npm ERR! Linux 4.4.21-v7+
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install"
npm ERR! node v6.9.1
npm ERR! npm  v3.10.8
npm ERR! code E404

npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/signalk-client
npm ERR! 404
npm ERR! 404  'signalk-client' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 It was specified as a dependency of 'freeboardk'
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/pi/signalk-java/signalk-static/freeboard-sk/npm-debug.log
```