### PR TITLE
Remove unused dependencies to fix npm install on new Node.js versions

### DIFF
--- a/lib/vesselPosition.js
+++ b/lib/vesselPosition.js
@@ -4,7 +4,6 @@ var ol = require('openlayers');
 //var tween = require('./tween-min.js');
 var util = require('./util.js');
 var d3 = require('d3');
-var d3gauge = require('d3-gauge');
 
 
 var vesselPos = new ol.Feature();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "jquery": "^2.1.3",
     "font-awesome": "^4.6.3",
     "bluebird": "^2.9.24",
-    "ws": "^0.7.1",
     "browser": "^0.2.6",
     "debug": "^2.1.3",
     "simplify-js": "^1.2.1",
@@ -22,8 +21,7 @@
     "signalk-client": "signalk/signalk-js-client",
     "web-audio-daw": "^2.3.1",
     "xml2js": "^0.4.16",
-    "d3": "^4.1.1",
-    "d3-gauge": "git://github.com/rob42/d3-gauge.git#master"
+    "d3": "^4.1.1"
   },
   "browser": {
     "bootstrap-drawer": "./node_modules/bootstrap-drawer/dist/js/drawer.js",


### PR DESCRIPTION
ws & d3-gauge pull in some old dependencies (bufferutil, contextify) that fail to install
in new Node.js versions.

As both ws & d3-gauge are unused, they can just be removed.

With this version `npm install` succeeds without compile errors with Node 6.9.1 on macOS.