### PR TITLE
chore: change to Signal K npm org and tweak name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "freeboardk",
+  "name": "@signalk/freeboard-SK",
   "version": "0.0.1",
-  "description": "Openlayers chartplotter implementation",
+  "description": "Openlayers chartplotter implementation for Signal K",
   "main": "index.js",
   "dependencies": {
     "openlayers": "~3.16.0",


### PR DESCRIPTION
We now have https://www.npmjs.com/org/signalk so let's publish things there.

Name was out of sync with the repo - is this ok?