### PR TITLE
Fixed adding route to ol feature layer- removed reference to array index

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -222,7 +222,7 @@ function addFeatures(map, feature, filter){
 			            	console.log("data:"+JSON.stringify(data));
 			            	
 							var layerSource = new ol.source.Vector({
-								features: (new ol.format.GeoJSON()).readFeatures(data.feature[0],{ dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' })
+								features: (new ol.format.GeoJSON()).readFeatures(data.feature,{ dataProjection: 'EPSG:4326', featureProjection: 'EPSG:3857' })
 							});
 							
 							console.log("layerSource complete");


### PR DESCRIPTION
Signal K spec defines route.feature as an object not an array.
Found route was not displaying on chart view due to this line silently failing.

Removed reference to array[index] and route displayed on chart.