### PR TITLE
Fixed onmessage(delta) to address vessel data display issues

### DIFF
--- a/lib/aisVessels.js
+++ b/lib/aisVessels.js
@@ -24,7 +24,7 @@ function onmessage(delta) {
 	var vessel = delta.context;
 	//dont do self
 	//console.log(delta);
-	if(vessel === 'vessels.'+window.ownVessel || vessel === 'vessels.self') {
+	if(vessel === window.ownVessel || vessel === 'vessels.self') {
 		//console.log('Ignore '+vessel+',  uuid:'+window.ownVessel);
 		return;
 	}

--- a/lib/anchorControl.js
+++ b/lib/anchorControl.js
@@ -211,7 +211,7 @@ function onmessage(delta) {
 	      //console.log("Invalid msg for vesselPositon");
 	      return;
 	    }
-    if (delta.context !== 'vessels.' + window.ownVessel && delta.context !== 'vessels.self' ) {
+    if (delta.context !==  window.ownVessel && delta.context !== 'vessels.self' ) {
         //console.log('Ignore '+delta.context+', not:'+window.ownVessel);
         //console.log('Ignore '+delta.context);
         return;

--- a/lib/vesselPosition.js
+++ b/lib/vesselPosition.js
@@ -154,7 +154,7 @@ function onmessage(delta) {
 		//console.log("Invalid msg for vesselPositon");
 		return;
 	}
-	if (delta.context !== 'vessels.' + window.ownVessel && delta.context !== 'vessels.self') {
+	if (delta.context !== window.ownVessel && delta.context !== 'vessels.self') {
 		//console.log('Ignore '+delta.context+', not:'+window.ownVessel);
 		//console.log('Ignore '+delta.context);
 		return;


### PR DESCRIPTION
Fixed test of _delta.context_ value in  _onmessage(delta)_ as it was trying to match the result of 'vessels.' + window.ownvessel but window.ownVessel value already contained the text 'vessels.' already so the test was failing.

