### PR TITLE
chore: build from root to public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/public
+/node_modules

--- a/package.json
+++ b/package.json
@@ -7,18 +7,13 @@
     ],
     "repository": "https://github.com/SignalK/freeboard-sk",
     "scripts": {
-        "format": "prettier-standard 'src/**/*.js'",
-        "test": "mocha"
+        "prepare": "cd source && npx ng build --prod"
     },
     "author": "robert@42.co.nz",
     "contributors": [
-        { "name": "panaaj@hotmail.com" }
+        {
+            "name": "panaaj@hotmail.com"
+        }
     ],
-    "license": "Apache-v2",
-    "dependencies": {
-    },
-    "devDependencies": {
-    "mocha": "^5.0.5",
-    "prettier-standard": "^8.0.0"
-    }
+    "license": "Apache-v2"
 }

--- a/source/angular.json
+++ b/source/angular.json
@@ -13,7 +13,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/freeboard",
+            "outputPath": "../public",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",


### PR DESCRIPTION
These changes allow publishing from the project's root
directory with `npm publish`, which will trigger the `prepare`
script that will run the Angular build with /public as the target
directory.