### PR TITLE
[WIP]: Navigate To... waypoints and routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG: Freeboard-SK
 
+### v1.1.0
+
+- Display Navigation data from `navigation.courseGreatCircle.nextPoint` / `navigation.courseRhumbline.nextPoint`
+
+
+**Breaking Changes:**
+
 
 
 ### v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@signalk/freeboard-sk",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Openlayers chartplotter implementation for Signal K",
     "keywords": [
         "signalk-webapp"

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -48,10 +48,23 @@ mat-nav-list {
 
 .alarmPanel {
     position: absolute;
-    z-index: 4901;
+    z-index: 4902;
     top: 20px;
     left: 33%;
     right: 33%;
+}
+
+.navdataPanel {
+    position: absolute;
+    z-index: 4901;
+    bottom: 30px;
+    left: 0;
+    right: 0;
+    max-height: 100px;
+    text-align: center;
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
 }
 
 .control {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -71,12 +71,18 @@
     <!-- /MENU BAR-->
 
     <!--context menus-->
-    <mat-menu #settingsmenu="matMenu">     
+    <mat-menu #settingsmenu="matMenu">   
         <a mat-menu-item *ngIf="app.config.vesselTrail && app.data.trail.length!=0" 
             (click)="clearTrail()">
             <mat-icon>clear_all</mat-icon>
             <span>Clear Trail</span>			
-        </a>     
+        </a>
+        <button mat-menu-item 
+            (click)="clearNavData()">
+            <mat-icon>clear_all</mat-icon>
+            <span>Clear Navigation Data</span>			
+        </button>   
+        <mat-divider></mat-divider>        
         <a mat-menu-item (click)="toggleAisTargets()">
             <mat-icon>{{app.config.aisTargets ? 'visibility_off' : 'visibility'}}</mat-icon>
             <span>{{app.config.aisTargets ? 'Hide' : 'Show'}} AIS Targets</span>			
@@ -693,6 +699,35 @@
                         [muted]="a.value.muted || a.value.acknowledged"
                     ></audio>
                 </div>
+            </div>
+
+            <!-- *** Nav data panel ***-->
+            <div class="navdataPanel">
+                <ap-dial-text *ngIf="display.navData.vmg"
+                    [title]="'VMG'"
+                    [value]="display.navData.vmg.toFixed(1)"
+                    [units]="(app.config.units.speed=='kn') ? 'knots' : 'm/sec'">
+                </ap-dial-text>
+                <ap-dial-text *ngIf="display.navData.bearing.value"
+                    [title]="'BRG'"
+                    [value]="display.navData.bearing.value.toFixed(1)"
+                    [units]="(display.navData.bearing.type=='M') ? 'deg (M)' : 'deg (T)'">
+                </ap-dial-text>     
+                <ap-dial-text *ngIf="display.navData.dtg"
+                    [title]="'DTG'"
+                    [value]="display.navData.dtg.toFixed(1)"
+                    [units]="(app.config.units.distance=='m') ? 'km' : 'NM'">
+                </ap-dial-text>                               
+                <ap-dial-text *ngIf="display.navData.ttg"
+                    [title]="'TTG'"
+                    [value]="display.navData.ttg.toFixed(1)"
+                    [units]="'mins'">
+                </ap-dial-text>    
+                <ap-dial-text *ngIf="display.navData.xte"
+                    [title]="'XTE'"
+                    [value]="display.navData.xte.toFixed(3)"
+                    [units]="(app.config.units.distance=='m') ? 'km' : 'NM'">
+                </ap-dial-text>                              
             </div>
 		
 		</mat-sidenav-container>

--- a/src/app/lib/ui/dial-text.css
+++ b/src/app/lib/ui/dial-text.css
@@ -1,0 +1,24 @@
+.dial-text {
+    background-color: transparent;
+    width: 100px;
+    max-height: 100px;
+    font-family: roboto;
+    border: transparent 1px solid;
+}
+
+.dial-text-title {
+    font-size: 12pt;
+    font-weight: 500;
+    background-color: whitesmoke;
+}
+
+.dial-text-value {
+    font-size: 22pt;
+    font-weight: 500;
+    background-color: whitesmoke;
+}
+
+.dial-text-units {
+    font-size: 10pt;
+    background-color: whitesmoke;
+}

--- a/src/app/lib/ui/dial-text.ts
+++ b/src/app/lib/ui/dial-text.ts
@@ -1,0 +1,32 @@
+/** Text Dial Component **
+************************/
+
+import {Component, OnInit, Input} from '@angular/core';
+
+/*********** Text Dial ***************
+title: "<string>" title text,
+value: "<string>" display value,
+units: "<string>" dsisplay units,
+***********************************/
+@Component({
+	selector: 'ap-dial-text',
+	template: `
+            <div class="dial-text">
+                <div class="dial-text-title">{{title}}</div>
+                <div class="dial-text-value">{{value}}</div>
+                <div class="dial-text-units">{{units}}</div>
+            </div>	
+			`,
+    styleUrls: ['./dial-text.css']
+})
+export class TextDialComponent implements OnInit {
+    @Input() title: string;
+    @Input() value: string;
+    @Input() units: string;
+
+    constructor() {}
+	
+	//** lifecycle: events **
+    ngOnInit() { }
+
+}

--- a/src/app/lib/ui/ui.module.ts
+++ b/src/app/lib/ui/ui.module.ts
@@ -13,6 +13,7 @@ import { MatDialogModule, MatIconModule, MatButtonModule, MatTooltipModule,
 import { MsgBox, AlertDialog, ConfirmDialog, AboutDialog } from './dialogs';
 import { FileInputComponent } from './file-input.component';
 import { PopoverComponent } from './popover';
+import { TextDialComponent } from './dial-text';
 import { ResourceDialog } from './resource-dialogs';
 import { PlaybackDialog } from './playback-dialog';
 
@@ -28,13 +29,13 @@ import { AisTargetsComponent } from '../components/feature-ais.component';
       ],    
     declarations: [
         MsgBox, AlertDialog, ConfirmDialog, AboutDialog,
-        FileInputComponent,
+        FileInputComponent, TextDialComponent,
         PopoverComponent, ResourceDialog, PlaybackDialog,
         GeometryCircleComponent, AisTargetsComponent
     ],
     exports: [
         MsgBox, AlertDialog, ConfirmDialog, AboutDialog,
-        FileInputComponent,
+        FileInputComponent, TextDialComponent,
         PopoverComponent, ResourceDialog, PlaybackDialog,
         GeometryCircleComponent, AisTargetsComponent
     ],


### PR DESCRIPTION
Add functionality to send requests to Signal K server to enable:

- `Navigate to` Waypoint
- `Activate` Route

Determine what information needs to be sent to the Signal K server to set a route as the `activeRoute` or a waypoint as the `nextPoint` which will then trigger the transmission of the relevant `course` data.

![image](https://user-images.githubusercontent.com/38519157/47061175-ee5db700-d217-11e8-85d0-69c0f9e92852.png)

![image](https://user-images.githubusercontent.com/38519157/47061059-7f805e00-d217-11e8-94d4-618c9cd10ea0.png)
