### PR TITLE
Fix: app list url for non-node servers to include api version number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG: Freeboard-SK
 
+### v1.0.1
 
+- Fix: Url used to retrieve app list from non-node servers to include api version number.
 
 ### v1.0.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@signalk/freeboard-sk",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Openlayers chartplotter implementation for Signal K",
     "keywords": [
         "signalk-webapp"

--- a/src/app/pages/settings/settings-dialog.ts
+++ b/src/app/pages/settings/settings-dialog.ts
@@ -41,8 +41,10 @@ export class SettingsDialog implements OnInit {
     
     ngOnInit() { 
         let appListUrl= null;
+        let nodeUri= '/webapps';
+        let javaUri= `/signalk/v${this.signalk.version}/apps/list`;
         if(this.app.data.server && this.app.data.server.id ) {
-            appListUrl= (this.app.data.server.id=='signalk-server-node') ? '/webapps' : '/signalk/apps/list';
+            appListUrl= (this.app.data.server.id=='signalk-server-node') ? nodeUri : javaUri;
             this.signalk.get(appListUrl).subscribe( 
                 (a: Array<any>)=> {
                     this.appList= a.map( i=> { 


### PR DESCRIPTION
Update the URL used to retrieve the list of applications from the Signal K server for non Node server types to include the api version number:
`/signalk/v1/apps/list`