### PR TITLE
fix: The displayed circle that indicates anchor.maxRadius now has correct diameter

### DIFF
--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -430,7 +430,7 @@
     <aol-layer-vector [zIndex]="49" *ngIf="!app.config.anchor.raised">
         <aol-source-vector>
             <aol-feature>
-                <aol-geometry-circle [radius]="app.config.anchor.radius">  
+                <aol-geometry-circle [radius]="app.config.anchor.radius * 1.852">  
                     <aol-coordinate 
                         [x]="app.config.anchor.position[0]" 
                         [y]="app.config.anchor.position[1]" 


### PR DESCRIPTION
The displayed circle that indicates anchor.maxRadius now has correct diameter. Before setting a radius of e.g. 1852m (1nm) resulted in a displayed circle with a radius of about 1000m. It seems that aol-geometry-circle internally assumes that the radius is given in nautical miles, although the internal units of sk are SI-units (radius [m]). For the fix the argument is scaled by a factor of 1.852.