### PR TITLE
Add names to the route points when imported from GPX

### DIFF
--- a/src/app/modules/gpxload/gpxload.facade.ts
+++ b/src/app/modules/gpxload/gpxload.facade.ts
@@ -1,12 +1,12 @@
 /** Settings abstraction Facade
  * ************************************/
-import { Injectable } from '@angular/core';
-import { Subject, Observable } from 'rxjs';
+import {Injectable} from '@angular/core';
+import {Observable, Subject} from 'rxjs';
 
-import { AppInfo } from 'src/app/app.info';
-import { SignalKClient } from 'signalk-client-angular';
-import { SKResources } from '../skresources/';
-import { GPX, GPXRoute, GPXWaypoint, GPXTrack, GPXTrackSegment } from './gpx';
+import {AppInfo} from 'src/app/app.info';
+import {SignalKClient} from 'signalk-client-angular';
+import {SKResources} from '../skresources/';
+import {GPX, GPXRoute, GPXTrack, GPXTrackSegment, GPXWaypoint} from './gpx';
 
 @Injectable({ providedIn: 'root' })
 export class GPXLoadFacade  {
@@ -16,7 +16,7 @@ export class GPXLoadFacade  {
     private subCount:number=0;
 
     private uploadSource: Subject<number>;
-    public uploaded$: Observable<any>;   
+    public uploaded$: Observable<any>;
     private gpx:GPX
 
    // *******************************************************    
@@ -109,7 +109,12 @@ export class GPXLoadFacade  {
         if(r.cmt) { rte.feature.properties['cmt']=r.cmt }
         if(r.src) { rte.feature.properties['src']=r.src }
         if(r.number) { rte.feature.properties['number']=r.number }
-        if(r.type) { rte.feature.properties['type']=r.type }  
+        if(r.type) { rte.feature.properties['type']=r.type }
+
+        // Add list ow waypoints names
+        rte.feature.properties['wptNames'] = r.rtept.map(pt => {
+            return pt.name
+        })
 
         this.subCount++;
         this.signalk.api.put(`/resources/routes/${skObj[0]}`, skObj[1])

--- a/src/app/modules/skresources/resource-dialogs.ts
+++ b/src/app/modules/skresources/resource-dialogs.ts
@@ -515,6 +515,12 @@ export class AircraftPropertiesModal implements OnInit {
                                 </mat-icon>
                             </div>
                             <div style="flex: 1 1 auto;">
+                                <div *ngIf="wptNames" style="display:flex;">
+                                    <div class="key-label">Name:</div>
+                                    <div style="flex: 1 1 auto;"
+                                         [innerText]="wptNames[i]">
+                                    </div>
+                                </div>   
                                 <div style="display:flex;">
                                     <div class="key-label">Lat:</div>
                                     <div style="flex: 1 1 auto;"
@@ -567,6 +573,7 @@ export class AircraftPropertiesModal implements OnInit {
 export class ActiveResourcePropertiesModal implements OnInit {
 
     public points: Array<[number,number]>= [];
+    public wptNames: Array<[string]>= [];
     public selIndex: number=- 1;
     public orderChanged: boolean= false;
 
@@ -580,6 +587,8 @@ export class ActiveResourcePropertiesModal implements OnInit {
         if(this.data.resource[1].feature && this.data.resource[1].feature.geometry.coordinates) {
             if(this.data.type=='route'){
                 this.points= this.data.resource[1].feature.geometry.coordinates;
+                this.wptNames = this.data.resource[1].feature.properties.wptNames;
+
                 this.data.title= (this.data.resource[1].name) ? `
                     ${this.data.resource[1].name} Points` : 'Route Points'; 
                 if(this.data.resource[0]==this.app.data.activeRoute) {
@@ -618,6 +627,8 @@ export class ActiveResourcePropertiesModal implements OnInit {
     drop(e:CdkDragDrop<any>) {
         if(this.data.type=='route') {
             moveItemInArray(this.points, e.previousIndex, e.currentIndex);
+            if(this.wptNames)
+                moveItemInArray(this.wptNames, e.previousIndex, e.currentIndex);
             this.orderChanged= true;
         }
     }
@@ -630,6 +641,8 @@ export class ActiveResourcePropertiesModal implements OnInit {
             ).subscribe( r=> {
                 if(r && this.data.skres) { 
                     this.data.skres.updateRouteCoords(this.data.resource[0], this.points);
+                    if(this.wptNames)
+                        this.data.skres.updateRouteWptNames(this.data.resource[0], this.wptNames);
                 }
             })
         }

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -662,6 +662,14 @@ export class SKResources {
         this.updateRoute(id, rte);
     }
 
+    updateRouteWptNames(id:string, wptNames:Array<[string]>) {
+        let t= this.app.data.routes.filter( i=>{ if(i[0]==id) return true });
+        if(t.length==0) { return }
+        let rte=t[0][1];
+        rte['feature']['properties']['wptNames']= wptNames;
+        this.updateRoute(id, rte);
+    }
+
     // ** return array of route coordinates **
     getActiveRouteCoords(routeId?:string) {
         if(!routeId) { routeId= this.app.data.activeRoute }


### PR DESCRIPTION
This PR is based on this discussion https://github.com/SignalK/signalk/discussions/22 
Please let me know if my thinking is aligned with your suggestion. 

 I tested it on my setup and It seems to handle both cases:

- Hand drawn routes, with no names  present
- Routes imported from GPX, then points have names. 

Not sure if i covered all route manipulation routines though. 
