### PR TITLE
MOB button

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -17,7 +17,7 @@ mat-nav-list {
     height: 100vh;
     background-color: black;
     color: white;  
-    overflow: hidden;  
+    overflow: hidden;
 }
 
 .view {
@@ -180,6 +180,60 @@ mat-nav-list {
 .instrumentPanelToggle {
     display: block;
 } 
+
+/** MOB Emergency Button Styling **/
+.mob-emergency-button {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    z-index: 5000;
+}
+
+.mob-button {
+    font-weight: bold !important;
+    border: 3px solid #fff !important;
+    box-shadow: 0 0 15px rgba(230, 0, 0, 0.7) !important; 
+    animation: mob-pulse 2s infinite !important;
+}
+
+.mob-button:hover {
+    box-shadow: 0 0 25px rgba(230, 0, 0, 1) !important;
+    transform: scale(1.1) !important;
+    transition: all 0.2s ease !important;
+    animation: none !important;
+}
+
+@keyframes mob-pulse {
+    0% {
+        box-shadow: 0 0 15px rgba(230, 0, 0, 0.7);
+    }
+    50% {
+        box-shadow: 0 0 25px rgba(230, 0, 0, 0.9);
+    }
+    100% {
+        box-shadow: 0 0 15px rgba(230, 0, 0, 0.7);
+    }
+}
+
+/* Responsive positioning for smaller screens */
+@media only screen and (max-width: 650px) { 
+    .mob-emergency-button {
+        bottom: 15px;
+        right: 15px;
+    }
+}
+
+@media only screen and (max-width: 400px) { 
+    .mob-emergency-button {
+        bottom: 10px;
+        right: 10px;
+    }
+    
+    .mob-button {
+        width: 48px !important;
+        height: 48px !important;
+    }
+}
 
 @media only screen and (max-width: 650px) {  
     .bottomSheet {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -743,6 +743,7 @@
           <!-- /right button bar -->
 
           <!-- MOB Emergency Button -->
+          @if(!isInteracting) {
           <div class="mob-emergency-button">
             <button
               class="button-warn mob-button"
@@ -754,6 +755,7 @@
               <mat-icon class="ob" svgIcon="alarm-mob"></mat-icon>
             </button>
           </div>
+          }
           }
           <!--map panel-->
           <div

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -741,6 +741,19 @@
           </div>
           }
           <!-- /right button bar -->
+
+          <!-- MOB Emergency Button -->
+          <div class="mob-emergency-button">
+            <button
+              class="button-warn mob-button"
+              mat-fab
+              (click)="raiseMOBAlarm()"
+              matTooltip="MAN OVERBOARD! Emergency Alarm"
+              matTooltipPosition="above"
+            >
+              <mat-icon class="ob" svgIcon="alarm-mob"></mat-icon>
+            </button>
+          </div>
           }
           <!--map panel-->
           <div

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -338,32 +338,12 @@ export class AppComponent {
     
     const position = this.app.data.vessels.self.position;
     if (position) {
-      this.createMOBWaypoint(position)
-          .then((waypointId) => {
-            if (waypointId) {
-              // Navigate to the new MOB waypoint
-              this.course.navigateToWaypoint(waypointId);
-            }
+      this.course.setDestination({
+        latitude: position[1],
+        longitude: position[0]
       });
-    }
-  }
-
-  private async createMOBWaypoint(position: any): Promise<string | null> {
-    try {
-      const now = new Date();
-      const timestamp = now.toISOString().replace(/[:.]/g, '-').slice(0, -5);
-      const mobWaypointName = `MOB ${timestamp}`;
-      
-      const wpt = this.skres.buildWaypoint(position)[1];
-      wpt.name = mobWaypointName;
-      wpt.description = 'Person Overboard emergency waypoint';
-      wpt.type = 'pob';
-
-      const result = await this.skres.postToServer('waypoints', wpt);
-      return result.id;
-    } catch (error) {
-      console.error('Failed to create MOB waypoint:', error);
-      return null;
+    } else {
+      this.app.showMessage('MOB Alarm Raised! (No vessel position available for navigation)', false, 5000);
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -335,16 +335,6 @@ export class AppComponent {
 
   public raiseMOBAlarm() {
     this.notiMgr.raiseServerAlarm('mob', 'Person Overboard!');
-    
-    const position = this.app.data.vessels.self.position;
-    if (position) {
-      this.course.setDestination({
-        latitude: position[1],
-        longitude: position[0]
-      });
-    } else {
-      this.app.showMessage('MOB Alarm Raised! (No vessel position available for navigation)', false, 5000);
-    }
   }
 
   protected toggleConstrainMapZoom() {

--- a/src/app/modules/alarms/notification-manager.ts
+++ b/src/app/modules/alarms/notification-manager.ts
@@ -14,6 +14,7 @@ import { AlertData } from './components/alert.component';
 import { getAlertIcon } from '../icons';
 import { SignalKClient } from 'signalk-client-angular';
 import { AlertPropertiesModal } from './components/alert-properties-modal';
+import { CourseService } from '../course/course.service';
 
 type AlertItems = Array<[string, AlertData]>;
 
@@ -32,7 +33,8 @@ export class NotificationManager {
     private app: AppFacade,
     private worker: SKWorkerService,
     private signalk: SignalKClient,
-    private bottomSheet: MatBottomSheet
+    private bottomSheet: MatBottomSheet,
+    private course: CourseService
   ) {
     this.alertMap = new Map();
 
@@ -166,6 +168,12 @@ export class NotificationManager {
       }
       this.alertMap.set(alert.path, alert);
       this.emitSignals();
+    }
+
+    if (alert.type == 'mob') {
+      if (alert.properties.position) {
+        this.course.setDestination(alert.properties.position);
+      }
     }
   }
 

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -465,6 +465,16 @@
               <b>Drop Waypoint:</b>
               Place new waypoint at vessel location.
             </li>
+
+            <li class="nobullet">
+              <i class="material-icons" style="color: red">warning</i>
+              <b>MOB (Man Overboard) Emergency:</b>
+              Instantly raise a MOB (Man Overboard) emergency alarm. This 
+              sends an immediate emergency notification to all connected 
+              devices and activates alarm protocols. Additionally, it 
+              automatically creates a MOB waypoint at the vessel's current 
+              position and sets navigation to this waypoint for quick return.
+            </li>
           </ul>
 
           <hr />
@@ -1593,6 +1603,23 @@
 
           <br />
           <h5>To RAISE an alarm:</h5>
+
+          <b>Option 1: Emergency MOB Button (Recommended for MOB)</b>
+          <ul>
+            <li>
+              For <b>MOB (Man Overboard)</b> emergencies, use the dedicated red 
+              <i class="material-icons" style="color: red">warning</i> 
+              MOB button located in the bottom-right corner for instant alarm activation.
+              This button will:
+              <ul>
+                <li>Immediately raise a MOB emergency alarm</li>
+                <li>Create a timestamped MOB waypoint at the vessel's current position</li>
+                <li>Automatically set navigation to the MOB waypoint for quick return</li>
+              </ul>
+            </li>
+          </ul>
+
+          <b>Option 2: Alarms Menu</b>
           <ul>
             <li>
               Click the

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -472,8 +472,8 @@
               Instantly raise a MOB (Man Overboard) emergency alarm. This 
               sends an immediate emergency notification to all connected 
               devices and activates alarm protocols. Additionally, it 
-              automatically creates a MOB waypoint at the vessel's current 
-              position and sets navigation to this waypoint for quick return.
+              automatically sets navigation to the MOB alarm location for 
+              quick return.
             </li>
           </ul>
 
@@ -1613,8 +1613,7 @@
               This button will:
               <ul>
                 <li>Immediately raise a MOB emergency alarm</li>
-                <li>Create a timestamped MOB waypoint at the vessel's current position</li>
-                <li>Automatically set navigation to the MOB waypoint for quick return</li>
+                <li>Automatically set navigation to the MOB alarm location for quick return</li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
This PR adds a prominent MOB button in the bottom-right corner of Freeboard (see screenshot below). It raises a MOB alarm, ~creates a waypoint~ and navigates to it.

When implementing this, I was a bit unsure whether to use MOB or POB as abbreviation. I'd favor POB, but all of the sources except the waypoint type seem to use MOB. I'm happy to align with whatever.

This is my first contribution to the project. I hope you are able to take in this feature. Let me know whether there are any amendments to the PR necessary.

~~Note that this PR also contains two unrelated fixes:~~
- ~~The dev server config in the Readme was outdated~~
- ~~When compiling, I got a severe type error related to click events. The fix was rather easy: using more specific types. But I'm surprised to find type errors on master, so probably something with my setup is off?~~

<img width="1868" height="913" alt="bild" src="https://github.com/user-attachments/assets/ec5e30d8-0f63-43e5-8556-c140ae7a6c95" />

/cc @panaaj Tagging you as you seem to drive a lot of Freeboard's development