### PR TITLE
fix: Set minHeight by vh instead of vw

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -915,7 +915,7 @@ export class AppComponent {
         data: {},
         maxWidth: '90vw',
         minWidth: '90vw',
-        minHeight: '80vw'
+        minHeight: '80vh'
       })
       .afterClosed()
       .subscribe(() => {


### PR DESCRIPTION
The recently pushed version 2.16.1 introduces tabs in the settings page and sets css minHeight to 80vw. This binds the height of the settings dialog to the viewport width and leads to problems on landscape screens.