### PR TITLE
feature: config the opacity of online chart layers

### DIFF
--- a/src/app/modules/map/ol/lib/resources/layer-charts.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-charts.component.ts
@@ -106,6 +106,7 @@ export class FreeboardChartLayerComponent
     url: string,
     minZoom: number,
     maxZoom: number,
+    opacity: number,
     zIndex: number
   ): WebGLTileLayer {
     const tiles = new pmtiles.PMTiles(url);
@@ -137,6 +138,7 @@ export class FreeboardChartLayerComponent
         minZoom: minZoom
       }),
       style: {},
+      opacity: opacity,
       zIndex: zIndex
     });
   }
@@ -146,6 +148,7 @@ export class FreeboardChartLayerComponent
     url: string,
     minZoom: number,
     maxZoom: number,
+    opacity: number,
     zIndex: number
   ): TileLayer<XYZ> {
     const tiles = new pmtiles.PMTiles(url);
@@ -181,6 +184,7 @@ export class FreeboardChartLayerComponent
         maxZoom: maxZoom,
         minZoom: minZoom
       }),
+      opacity: opacity,
       zIndex: zIndex
     });
   }
@@ -216,6 +220,7 @@ export class FreeboardChartLayerComponent
               ? charts[i][1].minZoom - 0.1
               : charts[i][1].minZoom;
           const maxZ = charts[i][1].maxZoom;
+	  const opacity = charts[i][1].opacity;
 
           if (charts[i][1].type.toLowerCase() === 'mapstylejson') {
             const lg = new LayerGroup({
@@ -306,6 +311,7 @@ export class FreeboardChartLayerComponent
                   charts[i][1].url,
                   charts[i][1].minZoom,
                   charts[i][1].maxZoom,
+		  charts[i][1].opacity,
                   this.zIndex + parseInt(i)
                 );
               } else {
@@ -322,7 +328,8 @@ export class FreeboardChartLayerComponent
                 preload: 0,
                 zIndex: this.zIndex + parseInt(i),
                 minZoom: minZ,
-                maxZoom: maxZ
+                maxZoom: maxZ,
+		opacity: opacity
               });
             }
           }

--- a/src/app/modules/skresources/resource-classes.ts
+++ b/src/app/modules/skresources/resource-classes.ts
@@ -127,6 +127,7 @@ export class SKChart {
   format: string;
   minZoom = 0;
   maxZoom = 24;
+  opacity = 1.0;
   type: string;
   url: string;
   source: string;
@@ -143,6 +144,10 @@ export class SKChart {
       typeof chart?.minzoom !== 'undefined' ? chart.minzoom : this.minZoom;
     this.maxZoom =
       typeof chart?.maxzoom !== 'undefined' ? chart.maxzoom : this.maxZoom;
+    this.opacity =
+      typeof chart?.opacity !== 'undefined' && !isNaN(chart?.opacity)
+        ? chart.opacity / 100 
+	: this.opacity;
     this.type = chart?.type ? chart.type : undefined;
     this.url = chart?.url ? chart.url : undefined;
     this.scale =

--- a/src/app/types/resources/signalk.ts
+++ b/src/app/types/resources/signalk.ts
@@ -62,6 +62,7 @@ export interface ChartResource {
   format?: string;
   minzoom?: number;
   maxzoom?: number;
+  opacity?: number;
   type?: string;
   scale?: number;
   url?: string;


### PR DESCRIPTION
Combined with:
https://github.com/SignalK/charts-plugin/pull/39

This will allow you to configure the opacity of a chart when configuring it in the SignalK charts-plugin. This is useful for certain types of layers, such as NOAA weather layers.