### PR TITLE
fix: Transform projection of range-cicles from default ol projection to actual map projection

### DIFF
--- a/src/app/modules/map/ol/lib/navigation/layer-range-circles.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-range-circles.component.ts
@@ -16,7 +16,8 @@ import { Feature } from 'ol';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Style, Stroke, Fill, Text } from 'ol/style';
-import { Circle, Point } from 'ol/geom';
+import { Point } from 'ol/geom';
+import { circular } from 'ol/geom/Polygon.js';
 import { fromLonLat } from 'ol/proj';
 import { MapComponent } from '../map.component';
 import { Extent, Coordinate } from '../models';
@@ -150,12 +151,10 @@ export class RangeCirclesComponent implements OnInit, OnDestroy, OnChanges {
       const st = this.buildCircleStyle();
       for (let i = 1; i <= this.maxCircles; ++i) {
         const d = range * i;
-        const f = new Feature({
-          geometry: new Circle(
-            fromLonLat(this.position),
-            mapifyRadius(d, this.position)
-          )
-        });
+        const geodesicCircle = circular( this.position, d, 1024 );
+        geodesicCircle.transform('EPSG:4326', 'EPSG:3857');  // Transform from default projection (EPSG:4326) to map projection (EPSG:3857)
+        const f = new Feature({ geometry: geodesicCircle });
+
         f.setStyle(st);
         fa.push(f);
         // point for text display


### PR DESCRIPTION
Transform projection of range-cicles from default ol projection (EPSG:4326) to actual map projection (EPSG:3857) to assure correct dimensions on map.