### PR TITLE
add: TileJSON metadata enrichment, fix tests, and enable CI test runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,9 +17,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
-      - name: npm ci
+      - name: npm install
         run: |
-          npm ci
+          npm install
 
       - name: Install Chromium
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,29 +1,37 @@
-on: push
-name: Build Application
+on: [push, pull_request]
+name: Build and Test
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache node modules
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Node ${{ matrix.node-version }}
+      - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: npm install
+          cache: npm
+
+      - name: npm ci
         run: |
-          npm i
+          npm ci
+
+      - name: Install Chromium
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
+
+      - name: Run tests
+        env:
+          CHROME_BIN: /usr/bin/chromium
+        run: |
+          npx ng test --watch=false --browsers=ChromeHeadless
+
       - name: npm run build
         run: |
           npm run build:all

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 name: Build and Test
 jobs:
   build:
@@ -15,7 +18,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
 
       - name: npm install
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,14 +23,12 @@ jobs:
         run: |
           npm install
 
-      - name: Install Chromium
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
 
       - name: Run tests
         env:
-          CHROME_BIN: /usr/bin/chromium
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: |
           npx ng test --watch=false --browsers=ChromeHeadless
 

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -140,6 +140,9 @@ export class MapComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (!this.map) {
+      return;
+    }
     this.map.un('singleclick', this.emitSingleClickEvent);
     this.map.un('dblclick', this.emitDblClickEvent);
     this.map.un('click', this.emitClickEvent);

--- a/src/app/modules/map/ol/lib/view.directive.ts
+++ b/src/app/modules/map/ol/lib/view.directive.ts
@@ -140,6 +140,9 @@ export class ViewDirective
   }
 
   ngOnDestroy() {
+    if (!this.view) {
+      return;
+    }
     this.view.un('change:center', this.emitCenterChange);
     this.view.un('change:resolution', this.emitZoomChange);
     this.view.un('change:rotation', this.emitRotationChange);

--- a/src/app/modules/skresources/resources.service.spec.ts
+++ b/src/app/modules/skresources/resources.service.spec.ts
@@ -1,0 +1,179 @@
+import { signal } from '@angular/core';
+import { SKResourceService } from './resources.service';
+import { ChartResource } from 'src/app/types';
+
+const createService = (
+  listResponse: Record<string, ChartResource>,
+  singleResponse?: ChartResource
+) => {
+  const signalk = {
+    api: {
+      get: (_version: number, path: string) => ({
+        subscribe: (next: (res: any) => void) => {
+          if (path.includes('/resources/charts/')) {
+            if (singleResponse) {
+              next(singleResponse)
+              return
+            }
+            const id = path.split('/').pop() || ''
+            next(listResponse[id])
+            return
+          }
+          next(listResponse)
+        }
+      })
+    }
+  };
+
+  const worker = {
+    resource$: () => ({
+      subscribe: () => undefined
+    })
+  };
+
+  const dialog = {};
+
+  const app = {
+    hostDef: {
+      url: 'http://localhost:3000',
+      name: 'localhost'
+    },
+    config: {
+      selections: {}
+    },
+    debug: () => undefined,
+    parseHttpErrorResponse: () => undefined,
+    sIsFetching: signal(false),
+    uiConfig: () => ({
+      mapConstrainZoom: false
+    })
+  };
+
+  return new SKResourceService(
+    dialog as any,
+    signalk as any,
+    worker as any,
+    app as any
+  );
+};
+
+describe('SKResourceService TileJSON enrichment', () => {
+  const originalFetch = (globalThis as any).fetch;
+  const originalAbortController = (globalThis as any).AbortController;
+
+  beforeEach(() => {
+    if (!(globalThis as any).AbortController) {
+      (globalThis as any).AbortController = class {
+        signal = {};
+        abort() {
+          return undefined;
+        }
+      };
+    }
+  });
+
+  afterEach(() => {
+    (globalThis as any).fetch = originalFetch;
+    (globalThis as any).AbortController = originalAbortController;
+  });
+
+  it('enriches tilejson charts with missing metadata', async () => {
+    const tilejson = {
+      bounds: [8, 53, 8.2, 53.3],
+      minzoom: 6,
+      maxzoom: 12,
+      format: 'pbf'
+    };
+
+    (globalThis as any).fetch = jasmine
+      .createSpy('fetch')
+      .and.callFake(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(tilejson)
+        })
+      );
+
+    const service = createService({
+      nautical_pm: {
+        name: 'Nautical',
+        type: 'tileJSON',
+        url: 'http://tiles.example/data/nautical_pm.json'
+      }
+    });
+
+    const list = await service.listFromServer<any>('charts');
+    const chart = list[0][1];
+
+    expect(chart.minZoom).toBe(6);
+    expect(chart.maxZoom).toBe(12);
+    expect(chart.bounds).toEqual([8, 53, 8.2, 53.3]);
+    expect(chart.format).toBe('pbf');
+  });
+
+  it('does not fetch tilejson when metadata already present', async () => {
+    const fetchSpy = jasmine.createSpy('fetch');
+    (globalThis as any).fetch = fetchSpy;
+
+    const service = createService({
+      sample_pm: {
+        name: 'Sample Raster',
+        type: 'tileJSON',
+        url: 'http://tiles.example/data/sample_pm.json',
+        bounds: [1, 2, 3, 4],
+        minzoom: 0,
+        maxzoom: 9,
+        format: 'webp'
+      }
+    });
+
+    const list = await service.listFromServer<any>('charts');
+    const chart = list[0][1];
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(chart.minZoom).toBe(0);
+    expect(chart.maxZoom).toBe(9);
+    expect(chart.bounds).toEqual([1, 2, 3, 4]);
+    expect(chart.format).toBe('webp');
+  });
+
+  it('enriches single chart fetch for info dialog', async () => {
+    const tilejson = {
+      bounds: [10, 20, 30, 40],
+      minzoom: 3,
+      maxzoom: 14,
+      format: 'pbf'
+    };
+
+    (globalThis as any).fetch = jasmine
+      .createSpy('fetch')
+      .and.callFake(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(tilejson)
+        })
+      );
+
+    const service = createService(
+      {
+        sample: {
+          name: 'Sample',
+          type: 'tileJSON',
+          url: 'http://tiles.example/data/sample.json'
+        }
+      },
+      {
+        name: 'Sample',
+        type: 'tileJSON',
+        url: 'http://tiles.example/data/sample.json'
+      }
+    );
+
+    const chart = await service.fromServer('charts', 'sample');
+
+    expect(chart.minZoom).toBe(3);
+    expect(chart.maxZoom).toBe(14);
+    expect(chart.bounds).toEqual([10, 20, 30, 40]);
+    expect(chart.format).toBe('pbf');
+  });
+});

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -114,6 +114,80 @@ export class SKResourceService {
     }
     return this.app.config.selections[collection].includes(id);
   }
+
+  private buildChartUrl(chart: ChartResource): string | undefined {
+    if (!chart?.url) {
+      return undefined;
+    }
+
+    if (chart.url.startsWith('/') || !chart.url.startsWith('http')) {
+      return this.app.hostDef.url + chart.url;
+    }
+
+    return chart.url;
+  }
+
+  private async fetchTileJson(url: string, timeoutMs = 3000): Promise<any> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      return await response.json();
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async enrichChartFromTileJson(
+    chart: ChartResource
+  ): Promise<ChartResource> {
+    if (!chart?.type || chart.type.toLowerCase() !== 'tilejson') {
+      return chart;
+    }
+
+    const fetchUrl = this.buildChartUrl(chart);
+    if (!fetchUrl) {
+      return chart;
+    }
+
+    const needsMeta =
+      typeof chart.minzoom === 'undefined' ||
+      typeof chart.maxzoom === 'undefined' ||
+      !Array.isArray(chart.bounds) ||
+      typeof chart.format === 'undefined';
+
+    if (!needsMeta) {
+      return chart;
+    }
+
+    try {
+      const tilejson = await this.fetchTileJson(fetchUrl);
+      return {
+        ...chart,
+        bounds: Array.isArray(chart.bounds) ? chart.bounds : tilejson.bounds,
+        minzoom:
+          typeof chart.minzoom !== 'undefined'
+            ? chart.minzoom
+            : tilejson.minzoom,
+        maxzoom:
+          typeof chart.maxzoom !== 'undefined'
+            ? chart.maxzoom
+            : tilejson.maxzoom,
+        format: typeof chart.format !== 'undefined' ? chart.format : tilejson.format
+      };
+    } catch (_err) {
+      return chart;
+    }
+  }
   /**
    * @description Add resource ids to selection list
    * @param collection
@@ -284,15 +358,44 @@ export class SKResourceService {
       );
       skf?.subscribe(
         (res: Routes | Waypoints | Regions | Notes | Charts | Tracks) => {
-          const list: any = [];
-          Object.keys(res).forEach((id: string) => {
-            list.push([
-              id,
-              this.transform(collection, res[id], id),
-              !this.selectionIsFiltered(collection)
-                ? true
-                : this.selectionHas(collection, id)
-            ]);
+          const ids = Object.keys(res);
+
+          if (collection === 'charts') {
+            (async () => {
+              try {
+                const list = (await Promise.all(
+                  ids.map(async (id: string) => {
+                    const enriched = await this.enrichChartFromTileJson(
+                      res[id] as ChartResource
+                    );
+                    return [
+                      id,
+                      this.transform(collection, enriched, id),
+                      !this.selectionIsFiltered(collection)
+                        ? true
+                        : this.selectionHas(collection, id)
+                    ] as T;
+                  })
+                )) as T[];
+                resolve(list);
+              } catch (err) {
+                reject(err as HttpErrorResponse);
+              }
+            })();
+            return;
+          }
+
+          const list: T[] = [];
+          ids.forEach((id: string) => {
+            list.push(
+              [
+                id,
+                this.transform(collection, res[id], id),
+                !this.selectionIsFiltered(collection)
+                  ? true
+                  : this.selectionHas(collection, id)
+              ] as T
+            );
           });
           resolve(list);
         },
@@ -319,7 +422,22 @@ export class SKResourceService {
               | RegionResource
               | NoteResource
               | ChartResource
-          ) => resolve(this.transform(collection, res, id)),
+          ) => {
+            if (collection === 'charts') {
+              (async () => {
+                try {
+                  const enriched = await this.enrichChartFromTileJson(
+                    res as ChartResource
+                  );
+                  resolve(this.transform(collection, enriched, id));
+                } catch (err) {
+                  reject(err as HttpErrorResponse);
+                }
+              })();
+              return;
+            }
+            resolve(this.transform(collection, res, id));
+          },
           (err: HttpErrorResponse) => reject(err)
         );
     });

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,1 @@
+// Required for tsconfig.spec.json; runtime polyfills are configured in angular.json.

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,11 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);


### PR DESCRIPTION
TileJSON charts now pull missing metadata [minzoom] [maxzoom] [format] so map zoom/bounds and the info dialog show correct values.

In addition I wanted to add tests for this and found that the test framework was not working correctly and niot hooked up to the CI.
I fixed this. 

I thought about adding the lockfile in order to be able to use npm ci (and than one could cache it in CI). I could add it if you'd like, but I didn't want to add another thing on top in this PR. I can send a PR afterwards with it or add it here - whatever you prefer.

Note: CI fails because it of errors fixed in this PR: https://github.com/SignalK/freeboard-sk/pull/329
A CI can be seen here:  See: https://github.com/herostrat/freeboard-sk/pull/1

A visual before and after image:
<img width="1537" height="761" alt="image" src="https://github.com/user-attachments/assets/2abb3873-3887-49a9-bada-7e2376ab329a" />

