### PR TITLE
add: over-zoom tiles setting and tests

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -891,6 +891,7 @@
               [vesselTrail]="app.selfTrail()"
               [activeRoute]="app.data.activeRoute"
               [dblClickZoom]="app.config.map.doubleClickZoom"
+              [overZoomTiles]="app.config.map.overZoomTiles"
               [measureMode]="mapInteract.isMeasuring()"
               [drawMode]="mapInteract.isDrawing()"
               (drawEnded)="handleDrawEnded($event)"

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -97,6 +97,9 @@ export function cleanConfig(
   if (typeof settings.map.doubleClickZoom === 'undefined') {
     settings.map.doubleClickZoom = (settings as any).mapDoubleClick ?? false;
   }
+  if (typeof settings.map.overZoomTiles === 'undefined') {
+    settings.map.overZoomTiles = true;
+  }
 
   if (!settings.units.positionFormat) {
     settings.units.positionFormat =
@@ -400,6 +403,7 @@ export function defaultConfig(): IAppConfig {
       animate: false,
       labelsMinZoom: 8,
       doubleClickZoom: false, // true=zoom
+      overZoomTiles: true, // keep tiles visible beyond chart max zoom
       centerOffset: 0,
       s57Options: {
         graphicsStyle: 'Paper',

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -134,22 +134,50 @@
       <fb-mapstylejson-chart [zIndex]="10 + idx" [chart]="c">
       </fb-mapstylejson-chart>
     } @else if (c[1].type?.toLowerCase() === 'tilejson') {
-      <fb-tilejson-chart [zIndex]="10 + idx" [chart]="c"> </fb-tilejson-chart>
+      <fb-tilejson-chart
+        [zIndex]="10 + idx"
+        [chart]="c"
+        [overZoomTiles]="overZoomTiles"
+        [mapMaxZoom]="app.MAP_ZOOM_EXTENT.max"
+      >
+      </fb-tilejson-chart>
     } @else if (c[1].type?.toLowerCase() === 'wms') {
-      <fb-wms-chart [zIndex]="10 + idx" [chart]="c"> </fb-wms-chart>
+      <fb-wms-chart
+        [zIndex]="10 + idx"
+        [chart]="c"
+        [overZoomTiles]="overZoomTiles"
+        [mapMaxZoom]="app.MAP_ZOOM_EXTENT.max"
+      >
+      </fb-wms-chart>
     } @else if (c[1].type?.toLowerCase() === 'wmts') {
-      <fb-wmts-chart [zIndex]="10 + idx" [chart]="c"> </fb-wmts-chart>
+      <fb-wmts-chart
+        [zIndex]="10 + idx"
+        [chart]="c"
+        [overZoomTiles]="overZoomTiles"
+        [mapMaxZoom]="app.MAP_ZOOM_EXTENT.max"
+      >
+      </fb-wmts-chart>
     } @else if (
       c[1].type?.toLowerCase() === 'tilelayer' &&
       (c[1].format?.toLowerCase() === 'pbf' ||
         c[1].format?.toLowerCase() === 'mvt')
     ) {
-      <fb-tilelayer-vector [zIndex]="10 + idx" [chart]="c">
+      <fb-tilelayer-vector
+        [zIndex]="10 + idx"
+        [chart]="c"
+        [overZoomTiles]="overZoomTiles"
+        [mapMaxZoom]="app.MAP_ZOOM_EXTENT.max"
+      >
       </fb-tilelayer-vector>
     } @else if (
       c[0] === 'openstreetmap' || c[1].type?.toLowerCase() === 'tilelayer'
     ) {
-      <fb-tilelayer-raster [zIndex]="10 + idx" [chart]="c">
+      <fb-tilelayer-raster
+        [zIndex]="10 + idx"
+        [chart]="c"
+        [overZoomTiles]="overZoomTiles"
+        [mapMaxZoom]="app.MAP_ZOOM_EXTENT.max"
+      >
       </fb-tilelayer-raster>
     }
   }

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -164,6 +164,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   @Input() activeRoute: string;
   @Input() vesselTrail: Array<Position> = [];
   @Input() dblClickZoom = false;
+  @Input() overZoomTiles = true;
   @Output() drawEnded: EventEmitter<DrawFeatureInfo> = new EventEmitter();
   @Output() activate: EventEmitter<string> = new EventEmitter();
   @Output() deactivate: EventEmitter<string> = new EventEmitter();

--- a/src/app/modules/map/ol/lib/charts/zoom-utils.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/zoom-utils.spec.ts
@@ -1,0 +1,20 @@
+import { resolveLayerMaxZoom } from './zoom-utils';
+
+describe('resolveLayerMaxZoom', () => {
+  it('returns chart max when over-zoom disabled', () => {
+    expect(resolveLayerMaxZoom(12, 20, false)).toBe(12);
+  });
+
+  it('returns chart max when map max is not a number', () => {
+    expect(resolveLayerMaxZoom(12, undefined, true)).toBe(12);
+  });
+
+  it('uses map max when chart max is undefined and over-zoom enabled', () => {
+    expect(resolveLayerMaxZoom(undefined, 20, true)).toBe(20);
+  });
+
+  it('uses the larger of chart and map max when over-zoom enabled', () => {
+    expect(resolveLayerMaxZoom(12, 20, true)).toBe(20);
+    expect(resolveLayerMaxZoom(24, 20, true)).toBe(24);
+  });
+});

--- a/src/app/modules/map/ol/lib/charts/zoom-utils.ts
+++ b/src/app/modules/map/ol/lib/charts/zoom-utils.ts
@@ -1,0 +1,10 @@
+export function resolveLayerMaxZoom(
+  chartMax?: number,
+  mapMax?: number,
+  overZoomTiles = false
+): number | undefined {
+  if (overZoomTiles && typeof mapMax === 'number') {
+    return typeof chartMax === 'number' ? Math.max(chartMax, mapMax) : mapMax;
+  }
+  return chartMax;
+}

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -382,6 +382,16 @@
                   </div>
                   <div class="setting-card-row-item">
                     <mat-checkbox
+                      [(ngModel)]="facade.settings.map.overZoomTiles"
+                      (change)="persistModel()"
+                      matTooltip="Keep tiles visible when zooming past chart max"
+                      label="after"
+                    >
+                      Keep tiles on max zoom
+                    </mat-checkbox>
+                  </div>
+                  <div class="setting-card-row-item">
+                    <mat-checkbox
                       [(ngModel)]="facade.settings.map.lockMoveMap"
                       (change)="persistModel()"
                       matTooltip="Do not exit follow vessel when map is panned."

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -102,6 +102,7 @@ export interface IAppConfig {
     animate: boolean;
     labelsMinZoom: number;
     doubleClickZoom: boolean; // true=zoom
+    overZoomTiles: boolean; // keep tiles visible beyond chart max zoom
     centerOffset: number; // vessel offset south of center (%)
     s57Options: {
       graphicsStyle: 'Simplified' | 'Paper';


### PR DESCRIPTION
Adds map setting to keep tiles visible when zooming past chart max which is set to default on.
It applies over-zoom behavior across tile-based chart layers. Important: wo don't query for the more zoomlevel higher than the server advertises 

Settings page:
<img width="868" height="473" alt="image" src="https://github.com/user-attachments/assets/ad174672-56a1-40ee-b4e8-cdb2dfc89ee7" />

Map zoom levels:
<img width="715" height="787" alt="Screenshot_20260214_114825" src="https://github.com/user-attachments/assets/48c683a3-736f-4446-b52f-92ccae3f2436" />

Active (notice the map in the background is visible, although max zoom is 9 and we currently are zoom level 12)
<img width="715" height="787" alt="active" src="https://github.com/user-attachments/assets/9dd67cac-e9f6-4da5-af66-7385bf1162ae" />

Inactive (same area):
<img width="715" height="787" alt="not_active" src="https://github.com/user-attachments/assets/a3b77b24-6617-423a-a371-cc49f84c0829" />

