### PR TITLE
add: opacity for chart layers

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -311,6 +311,9 @@ export function cleanConfig(
   if (typeof settings.selections.chartOrder === 'undefined') {
     settings.selections.chartOrder = [];
   }
+  if (typeof settings.selections.chartOpacity === 'undefined') {
+    settings.selections.chartOpacity = {};
+  }
   if (typeof settings.selections.tracks === 'undefined') {
     settings.selections.tracks = [];
   }
@@ -488,6 +491,7 @@ export function defaultConfig(): IAppConfig {
       tracks: null,
       charts: ['openstreetmap', 'openseamap'],
       chartOrder: ['openstreetmap', 'openseamap'], // chart layer ordering
+      chartOpacity: {},
       aisTargets: null,
       aisTargetTypes: [],
       aisFilterByShipType: false,

--- a/src/app/modules/skresources/components/charts/chart-opacity-dialog.spec.ts
+++ b/src/app/modules/skresources/components/charts/chart-opacity-dialog.spec.ts
@@ -1,0 +1,148 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import {
+  ChartOpacityDialog,
+  ChartOpacityDialogData
+} from './chart-opacity-dialog';
+
+describe('ChartOpacityDialog', () => {
+  let component: ChartOpacityDialog;
+  let fixture: ComponentFixture<ChartOpacityDialog>;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<ChartOpacityDialog>>;
+  const getOpacity = () => (component as any).opacityPercent();
+
+  const createComponent = (opacityPercent: number) => {
+    const data: ChartOpacityDialogData = {
+      name: 'Test Chart',
+      opacityPercent: opacityPercent
+    };
+
+    dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    TestBed.configureTestingModule({
+      imports: [ChartOpacityDialog],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: data }
+      ]
+    });
+
+    fixture = TestBed.createComponent(ChartOpacityDialog);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  describe('initialization', () => {
+    it('should set initial opacity from data', () => {
+      createComponent(75);
+      expect(getOpacity()).toBe(75);
+    });
+
+    it('should default to 100 when opacityPercent is undefined', () => {
+      const data: ChartOpacityDialogData = {
+        name: 'Test Chart',
+        opacityPercent: undefined as any
+      };
+
+      dialogRef = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+      TestBed.configureTestingModule({
+        imports: [ChartOpacityDialog],
+        providers: [
+          { provide: MatDialogRef, useValue: dialogRef },
+          { provide: MAT_DIALOG_DATA, useValue: data }
+        ]
+      });
+
+      fixture = TestBed.createComponent(ChartOpacityDialog);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+
+      expect(getOpacity()).toBe(100);
+    });
+
+    it('should set opacity to 0 when data is 0', () => {
+      createComponent(0);
+      expect(getOpacity()).toBe(0);
+    });
+
+    it('should set opacity to 100 when data is 100', () => {
+      createComponent(100);
+      expect(getOpacity()).toBe(100);
+    });
+  });
+
+  describe('setOpacity', () => {
+    beforeEach(() => {
+      createComponent(50);
+    });
+
+    it('should update opacity signal', () => {
+      component['setOpacity'](75);
+      expect(getOpacity()).toBe(75);
+    });
+
+    it('should clamp value to maximum 100', () => {
+      component['setOpacity'](150);
+      expect(getOpacity()).toBe(100);
+    });
+
+    it('should clamp value to minimum 0', () => {
+      component['setOpacity'](-25);
+      expect(getOpacity()).toBe(0);
+    });
+
+    it('should round decimal values', () => {
+      component['setOpacity'](67.8);
+      expect(getOpacity()).toBe(68);
+    });
+
+    it('should default to 100 when value is undefined', () => {
+      component['setOpacity'](undefined as any);
+      expect(getOpacity()).toBe(100);
+    });
+
+    it('should call onOpacityChange callback when provided', () => {
+      const callback = jasmine.createSpy('onOpacityChange');
+      component.data.onOpacityChange = callback;
+      component['setOpacity'](75);
+      expect(callback).toHaveBeenCalledWith(75);
+    });
+
+    it('should not fail when onOpacityChange is undefined', () => {
+      component.data.onOpacityChange = undefined;
+      expect(() => component['setOpacity'](75)).not.toThrow();
+    });
+  });
+
+  describe('handleClose', () => {
+    beforeEach(() => {
+      createComponent(75);
+    });
+
+    it('should close dialog with save=true and current opacity on Apply', () => {
+      component['handleClose'](true);
+      expect(dialogRef.close).toHaveBeenCalledWith({
+        save: true,
+        opacityPercent: 75
+      });
+    });
+
+    it('should close dialog with save=false on Cancel', () => {
+      component['handleClose'](false);
+      expect(dialogRef.close).toHaveBeenCalledWith({
+        save: false,
+        opacityPercent: 75
+      });
+    });
+
+    it('should include updated opacity value after changes', () => {
+      component['setOpacity'](33);
+      component['handleClose'](true);
+      expect(dialogRef.close).toHaveBeenCalledWith({
+        save: true,
+        opacityPercent: 33
+      });
+    });
+  });
+});

--- a/src/app/modules/skresources/components/charts/chart-opacity-dialog.ts
+++ b/src/app/modules/skresources/components/charts/chart-opacity-dialog.ts
@@ -1,0 +1,95 @@
+import { Component, Inject, signal } from '@angular/core';
+import {
+  MatDialogModule,
+  MatDialogRef,
+  MAT_DIALOG_DATA
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatToolbarModule } from '@angular/material/toolbar';
+
+export interface ChartOpacityDialogData {
+  name: string;
+  opacityPercent: number;
+  onOpacityChange?: (opacityPercent: number) => void;
+}
+
+export interface ChartOpacityDialogResult {
+  save: boolean;
+  opacityPercent: number;
+}
+
+@Component({
+  selector: 'ap-chart-opacity',
+  imports: [
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSliderModule,
+    MatToolbarModule
+  ],
+  template: `
+    <div class="_ap-chart-opacity">
+      <mat-toolbar style="background-color: transparent">
+        <span><mat-icon>opacity</mat-icon></span>
+        <span style="flex: 1 1 auto; text-align: center">Chart Opacity</span>
+        <span style="text-align: right">
+          <button mat-icon-button (click)="handleClose(false)">
+            <mat-icon>close</mat-icon>
+          </button>
+        </span>
+      </mat-toolbar>
+      <mat-dialog-content style="min-width: 280px">
+        <div style="display: flex; align-items: center; margin-bottom: 8px">
+          <div style="flex: 1 1 auto">{{ data.name }}</div>
+          <div style="min-width: 48px; text-align: right">
+            {{ opacityPercent() }}%
+          </div>
+        </div>
+        <mat-slider min="0" max="100" step="1">
+          <input
+            matSliderThumb
+            [value]="opacityPercent()"
+            (valueChange)="setOpacity($event.value ?? $event)"
+          />
+        </mat-slider>
+      </mat-dialog-content>
+      <mat-dialog-actions align="end">
+        <button mat-button (click)="handleClose(false)">Cancel</button>
+        <button mat-flat-button (click)="handleClose(true)">Apply</button>
+      </mat-dialog-actions>
+    </div>
+  `,
+  standalone: true
+})
+export class ChartOpacityDialog {
+  protected opacityPercent = signal<number>(100);
+
+  constructor(
+    public dialogRef: MatDialogRef<ChartOpacityDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: ChartOpacityDialogData
+  ) {
+    this.opacityPercent.set(
+      typeof data.opacityPercent === 'number' ? data.opacityPercent : 100
+    );
+  }
+
+  protected setOpacity(value: number) {
+    const v = typeof value === 'number' ? value : 100;
+    const clamped = Math.min(100, Math.max(0, Math.round(v)));
+    this.opacityPercent.set(clamped);
+    // Live preview: notify parent component of opacity change
+    if (this.data.onOpacityChange) {
+      this.data.onOpacityChange(clamped);
+    }
+  }
+
+  protected handleClose(save: boolean) {
+    const result: ChartOpacityDialogResult = {
+      save: save,
+      opacityPercent: this.opacityPercent()
+    };
+    this.dialogRef.close(result);
+  }
+}

--- a/src/app/modules/skresources/components/charts/chartlist.html
+++ b/src/app/modules/skresources/components/charts/chartlist.html
@@ -191,6 +191,16 @@
                 <mat-icon>info_outline</mat-icon>
               </button>
             </div>
+            <div style="width: 100%; text-align: right">
+              <button
+                mat-icon-button
+                (click)="openOpacityDialog(r)"
+                matTooltip="Set Opacity"
+                matTooltipPosition="above"
+              >
+                <mat-icon>opacity</mat-icon>
+              </button>
+            </div>
             @if(r[1].proxy) {
             <div style="width: 100%; text-align: right">
               <button

--- a/src/app/modules/skresources/components/charts/chartlist.opacity.spec.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.opacity.spec.ts
@@ -1,0 +1,118 @@
+import { ChartListComponent } from './chartlist';
+import { SKChart } from '../../resource-classes';
+
+describe('ChartListComponent - Opacity Functions', () => {
+  let component: ChartListComponent;
+  let updateChartOpacityCacheSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    component = Object.create(ChartListComponent.prototype) as ChartListComponent;
+    updateChartOpacityCacheSpy = jasmine.createSpy('updateChartOpacityCache');
+    (component as any).skres = {
+      updateChartOpacityCache: updateChartOpacityCacheSpy
+    } as any;
+    (component as any).doFilter = () => {};
+    (component as any).fullList = [];
+  });
+
+  describe('opacityToPercent', () => {
+    it('should convert 0 to 0%', () => {
+      expect(component['opacityToPercent'](0)).toBe(0);
+    });
+
+    it('should convert 0.5 to 50%', () => {
+      expect(component['opacityToPercent'](0.5)).toBe(50);
+    });
+
+    it('should convert 1 to 100%', () => {
+      expect(component['opacityToPercent'](1)).toBe(100);
+    });
+
+    it('should default to 100% when undefined', () => {
+      expect(component['opacityToPercent'](undefined)).toBe(100);
+    });
+
+    it('should round decimal results', () => {
+      expect(component['opacityToPercent'](0.678)).toBe(68);
+    });
+
+    it('should clamp values above 1 to 100%', () => {
+      expect(component['opacityToPercent'](1.5)).toBe(100);
+    });
+
+    it('should clamp negative values to 0%', () => {
+      expect(component['opacityToPercent'](-0.5)).toBe(0);
+    });
+  });
+
+  describe('clampPercent', () => {
+    it('should return value within range unchanged', () => {
+      expect(component['clampPercent'](50)).toBe(50);
+      expect(component['clampPercent'](0)).toBe(0);
+      expect(component['clampPercent'](100)).toBe(100);
+    });
+
+    it('should clamp value above 100 to 100', () => {
+      expect(component['clampPercent'](150)).toBe(100);
+      expect(component['clampPercent'](101)).toBe(100);
+    });
+
+    it('should clamp value below 0 to 0', () => {
+      expect(component['clampPercent'](-50)).toBe(0);
+      expect(component['clampPercent'](-1)).toBe(0);
+    });
+
+    it('should round decimal values', () => {
+      expect(component['clampPercent'](45.6)).toBe(46);
+      expect(component['clampPercent'](45.4)).toBe(45);
+    });
+
+    it('should default to 100 when undefined', () => {
+      expect(component['clampPercent'](undefined)).toBe(100);
+    });
+  });
+
+  describe('updateOpacityLocal', () => {
+    beforeEach(() => {
+      const chart1 = new SKChart({
+        name: 'Chart 1',
+        defaultOpacity: 1
+      });
+      const chart2 = new SKChart({
+        name: 'Chart 2',
+        defaultOpacity: 0.8
+      });
+      component['fullList'] = [
+        ['chart-1', chart1, false],
+        ['chart-2', chart2, false]
+      ];
+    });
+
+    it('should update opacity for specified chart', () => {
+      component['updateOpacityLocal']('chart-1', 0.5);
+      const chart = component['fullList'].find((c) => c[0] === 'chart-1');
+      expect(chart?.[1].defaultOpacity).toBe(0.5);
+    });
+
+    it('should not modify other charts', () => {
+      component['updateOpacityLocal']('chart-1', 0.5);
+      const chart = component['fullList'].find((c) => c[0] === 'chart-2');
+      expect(chart?.[1].defaultOpacity).toBe(0.8);
+    });
+
+    it('should update resource cache', () => {
+      component['updateOpacityLocal']('chart-1', 0.3);
+      expect(updateChartOpacityCacheSpy).toHaveBeenCalledWith(
+        'chart-1',
+        0.3
+      );
+    });
+
+    it('should set opacity to 0', () => {
+      component['updateOpacityLocal']('chart-1', 0);
+      const chart = component['fullList'].find((c) => c[0] === 'chart-1');
+      expect(chart?.[1].defaultOpacity).toBe(0);
+    });
+  });
+
+});

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -189,6 +189,7 @@ export interface IAppConfig {
     tracks: string[] | null;
     charts: string[];
     chartOrder: string[]; // chart layer ordering
+    chartOpacity: { [id: string]: number };
     aisTargets: string[];
     aisTargetTypes: number[];
     aisFilterByShipType: boolean;


### PR DESCRIPTION
This PR add opacity for chart layers and adds tests for it, see:
[Screencast_20260214_125129.webm](https://github.com/user-attachments/assets/4324bb84-09b6-42f4-9afb-1bb5e4a1ad8b)
