### PR TITLE
fix: catching wms capability freezes browser

### DIFF
--- a/src/app/modules/skresources/components/charts/capabilities.worker.ts
+++ b/src/app/modules/skresources/components/charts/capabilities.worker.ts
@@ -1,0 +1,58 @@
+import { WMSCapabilities, WMTSCapabilities } from 'ol/format';
+import { getWMTSLayers, parseWMSCapabilities } from './wmslib';
+import type { LayerNode } from './wmslib';
+
+type WorkerMessage = {
+  type: 'wms' | 'wmts';
+  xml: string;
+  url: string;
+  options?: {
+    maxNodes?: number;
+    maxDepth?: number;
+    maxLayers?: number;
+  };
+};
+
+type WorkerResult = {
+  layers: LayerNode[] | Array<{ id: string | number; name: string; description: string }>;
+};
+
+const buildWmsLayers = (xml: string, options?: WorkerMessage['options']): LayerNode[] => {
+  const capabilities = new WMSCapabilities().read(xml);
+  const layers: LayerNode[] = [];
+  parseWMSCapabilities(capabilities, layers, {
+    maxNodes: options?.maxNodes,
+    maxDepth: options?.maxDepth
+  });
+  return layers;
+};
+
+const buildWmtsLayers = (
+  xml: string,
+  url: string,
+  options?: WorkerMessage['options']
+): Array<{ id: string | number; name: string; description: string }> => {
+  const capabilities = new WMTSCapabilities().read(xml);
+  return getWMTSLayers(capabilities, url, 'chart-provider', options?.maxLayers)
+    .map((c: any) => ({
+      id: c.layers?.[0] ?? Date.now(),
+      name: c.name,
+      description: c.description
+    }))
+    .sort((a: any, b: any) => (a.name < b.name ? -1 : 1));
+};
+
+self.onmessage = (event: MessageEvent<WorkerMessage>) => {
+  try {
+    const { type, xml, url, options } = event.data;
+    let result: WorkerResult;
+    if (type === 'wms') {
+      result = { layers: buildWmsLayers(xml, options) };
+    } else {
+      result = { layers: buildWmtsLayers(xml, url, options) };
+    }
+    self.postMessage(result);
+  } catch (err) {
+    self.postMessage(null);
+  }
+};

--- a/src/app/modules/skresources/components/charts/wmslib.spec.ts
+++ b/src/app/modules/skresources/components/charts/wmslib.spec.ts
@@ -1,0 +1,128 @@
+import {
+  getWMTSLayers,
+  parseWMSCapabilities,
+  WmsParseOptions
+} from './wmslib';
+import type { LayerNode } from './wmslib';
+
+describe('wmslib', () => {
+  const makeWmsLayer = (
+    name: string,
+    children: any[] = [],
+    withTime = false
+  ) => {
+    const layer: any = {
+      Name: name,
+      Title: `${name}-title`,
+      Abstract: `${name}-desc`
+    };
+    if (withTime) {
+      layer.Dimension = [
+        {
+          name: 'time',
+          units: 'ISO8601',
+          default: '2024-01-01T00:00:00Z',
+          values: '2024-01-01T00:00:00Z/2024-01-02T00:00:00Z/PT1H'
+        }
+      ];
+    }
+    if (children.length) {
+      layer.Layer = children;
+    }
+    return layer;
+  };
+
+  const wrapCapabilities = (layer: any | any[]) => ({
+    Capability: {
+      Layer: layer
+    }
+  });
+
+  describe('parseWMSCapabilities', () => {
+    it('should parse a single layer', () => {
+      const data: LayerNode[] = [];
+      const capabilities = wrapCapabilities(makeWmsLayer('root'));
+      parseWMSCapabilities(capabilities, data);
+      expect(data.length).toBe(1);
+      expect(data[0].name).toBe('root');
+      expect(data[0].title).toBe('root-title');
+    });
+
+    it('should parse an array of layers', () => {
+      const data: LayerNode[] = [];
+      const capabilities = wrapCapabilities([
+        makeWmsLayer('layer-a'),
+        makeWmsLayer('layer-b')
+      ]);
+      parseWMSCapabilities(capabilities, data);
+      expect(data.length).toBe(2);
+      expect(data[0].name).toBe('layer-a');
+      expect(data[1].name).toBe('layer-b');
+    });
+
+    it('should assign parent and children for nested layers', () => {
+      const data: LayerNode[] = [];
+      const child = makeWmsLayer('child');
+      const root = makeWmsLayer('root', [child]);
+      const capabilities = wrapCapabilities(root);
+      parseWMSCapabilities(capabilities, data);
+      expect(data.length).toBe(1);
+      expect(data[0].children?.length).toBe(1);
+      expect(data[0].children?.[0].name).toBe('child');
+      expect(data[0].children?.[0].parent).toBe(data[0]);
+    });
+
+    it('should include time dimension when present', () => {
+      const data: LayerNode[] = [];
+      const root = makeWmsLayer('root', [], true);
+      const capabilities = wrapCapabilities(root);
+      parseWMSCapabilities(capabilities, data);
+      expect(data[0].time).toBeDefined();
+      expect(data[0].time?.current).toBe('2024-01-01T00:00:00Z');
+    });
+
+    it('should respect maxDepth limit', () => {
+      const data: LayerNode[] = [];
+      const deep = makeWmsLayer('root', [
+        makeWmsLayer('l1', [makeWmsLayer('l2', [makeWmsLayer('l3')])])
+      ]);
+      const capabilities = wrapCapabilities(deep);
+      const options: WmsParseOptions = { maxDepth: 1 };
+      parseWMSCapabilities(capabilities, data, options);
+      expect(data.length).toBe(1);
+      expect(data[0].children?.length).toBe(1);
+      expect(data[0].children?.[0].children?.length ?? 0).toBe(0);
+    });
+
+    it('should respect maxNodes limit', () => {
+      const data: LayerNode[] = [];
+      const capabilities = wrapCapabilities([
+        makeWmsLayer('a'),
+        makeWmsLayer('b'),
+        makeWmsLayer('c')
+      ]);
+      const options: WmsParseOptions = { maxNodes: 1 };
+      parseWMSCapabilities(capabilities, data, options);
+      expect(data.length).toBe(1);
+      expect(data[0].name).toBe('a');
+    });
+  });
+
+  describe('getWMTSLayers', () => {
+    it('should respect maxLayers limit', () => {
+      const capabilities: any = {
+        Contents: {
+          Layer: [
+            { Identifier: 'l1', Title: 'Layer 1', Abstract: 'a', Format: [] },
+            { Identifier: 'l2', Title: 'Layer 2', Abstract: 'b', Format: [] },
+            { Identifier: 'l3', Title: 'Layer 3', Abstract: 'c', Format: [] }
+          ]
+        }
+      };
+      const layers = getWMTSLayers(capabilities, 'http://example', 'chart-provider', 2);
+      expect(layers.length).toBe(2);
+      expect(layers[0].name).toBe('Layer 1');
+      expect(layers[1].name).toBe('Layer 2');
+    });
+  });
+});


### PR DESCRIPTION
When opening Chart Properties (clicking on the i in the chart layer for the default maps e.g. open sea map)  for some WMS/WMTS charts froze the UI. The dialog synchronously fetched and parsed large Capabilities XML on the main thread, with no timeout, and unbounded recursive parsing.

In my fix I changed the load layer to a Lazy‑load Capabilities and also add a fetch timeout/abort handling.
Because the parsing is recursive I implemented a node count/depth and WMTS layer count.

Lastly I added tests for parser recursion/limits.