### PR TITLE
S-57 renderer: bug fixes, new CS procedures, feature inspect, and layer toggle

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -78,8 +78,12 @@ export function cleanConfig(
       shallowDepth: (settings as any).selections.s57Options.shallowDepth ?? 2,
       safetyDepth: (settings as any).selections.s57Options.safetyDepth ?? 3,
       deepDepth: (settings as any).selections.s57Options.deepDepth ?? 6,
-      colorTable: 0
+      colorTable: 0,
+      otherLayers: ['SOUNDG', 'OBSTRN', 'UWTROC', 'WRECKS', 'DEPCNT']
     };
+  }
+  if (typeof settings.map.s57Options.otherLayers === 'undefined') {
+    settings.map.s57Options.otherLayers = ['SOUNDG', 'OBSTRN', 'UWTROC', 'WRECKS', 'DEPCNT'];
   }
   if (typeof settings.map.labelsMinZoom === 'undefined') {
     settings.map.labelsMinZoom =
@@ -406,7 +410,8 @@ export function defaultConfig(): IAppConfig {
         shallowDepth: 2,
         safetyDepth: 3,
         deepDepth: 6,
-        colorTable: 0
+        colorTable: 0,
+        otherLayers: ['SOUNDG', 'OBSTRN', 'UWTROC', 'WRECKS', 'DEPCNT']
       },
       popoverMulti: false // close popovers using cose button
     },

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -351,7 +351,7 @@ export class AppFacade extends InfoService {
   private parseLoadedConfig() {
     cleanConfig(this.config, this.hostDef.params);
     this.doPostConfigLoad();
-    this.s57.init(this.config.map.s57Options);
+    this.s57.init({ ...this.config.map.s57Options, depthUnit: this.config.units.depth });
   }
 
   /** Initialise and raise "settings$.load" event */

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -613,6 +613,14 @@
         >
         </aircraft-popover>
       }
+      @if (overlay().type === 's57') {
+        <s57-popover
+          [canClose]="true"
+          [properties]="overlay().s57Properties"
+          (closed)="popoverClosed()"
+        >
+        </s57-popover>
+      }
       @if (overlay().type === 'alarm') {
         <alarm-popover
           [canClose]="app.config.map.popoverMulti"

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -31,8 +31,10 @@ import {
   AlarmPopoverComponent,
   ResourcePopoverComponent,
   ResourceSetPopoverComponent,
-  VesselPopoverComponent
+  VesselPopoverComponent,
+  S57PopoverComponent
 } from './popovers';
+import { S57_CLICKABLE_LAYERS } from './popovers/s57-popover.component';
 import { FreeboardOpenlayersModule } from 'src/app/modules/map/ol';
 import { CoordsPipe } from 'src/app/lib/pipes';
 
@@ -147,7 +149,8 @@ enum INTERACTION_MODE {
     AlarmPopoverComponent,
     ResourcePopoverComponent,
     ResourceSetPopoverComponent,
-    VesselPopoverComponent
+    VesselPopoverComponent,
+    S57PopoverComponent
   ],
   templateUrl: './fb-map.component.html',
   styleUrls: ['./fb-map.component.css']
@@ -944,9 +947,23 @@ export class FBMapComponent implements OnInit, OnDestroy {
     const fa = []; // features that can be the target of modify interaction
     let maskPopover = false; // suppress popover display
 
+    // S-57 vector tile feature detection
+    let s57Feature = null;
+
     // process list of features at click location
     e.features.forEach((feature: Feature) => {
+      // Check for S-57 vector tile features (no string ID, have 'layer' property)
       const id = feature.getId();
+      if (!id && feature.getProperties) {
+        const props = feature.getProperties();
+        if (props['layer'] && S57_CLICKABLE_LAYERS.has(props['layer'])) {
+          if (!s57Feature) {
+            s57Feature = feature;
+          }
+        }
+        return;
+      }
+
       let addToFeatureList = false;
       let aton: SKAtoN;
       let sar: SKSaR;
@@ -1082,6 +1099,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
     } else if (featureList.size > 1) {
       // show list of features
       this.formatPopover('list.', e.lonlat, featureList);
+    } else if (s57Feature && featureList.size === 0) {
+      // S-57 vector tile feature
+      this.formatPopover('s57.feature', e.lonlat, null, s57Feature);
     }
   }
 
@@ -1097,7 +1117,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
   protected formatPopover(
     id: string,
     coord: Position,
-    featureList?: Map<string, any>
+    featureList?: Map<string, any>,
+    s57Feature?: any
   ) {
     if (!id) {
       this.overlay.update((current) => {
@@ -1292,6 +1313,16 @@ export class FBMapComponent implements OnInit, OnDestroy {
           (poData.resource as GeoJsonFeature)?.properties?.name ??
           'Resource Set';
         poData.show = poData.resource ? true : false;
+        break;
+      case 's57':
+        if (s57Feature) {
+          const props = s57Feature.getProperties ? s57Feature.getProperties() : {};
+          poData.type = 's57';
+          poData.id = 's57';
+          poData.title = props['OBJNAM'] || props['layer'] || 'S-57 Feature';
+          poData.s57Properties = props;
+          poData.show = true;
+        }
         break;
       default:
         return;

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -40,6 +40,8 @@ export interface IPopover {
   meteo?: SKMeteo;
   aircraft?: SKAircraft;
   alarm?: AlertData;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  s57Properties?: { [key: string]: any };
   readOnly: boolean;
 }
 

--- a/src/app/modules/map/ol/lib/charts/s57.service.ts
+++ b/src/app/modules/map/ol/lib/charts/s57.service.ts
@@ -232,7 +232,7 @@ export class S57Service {
     const ir = a.name.localeCompare(b.name, 'en', { sensitivity: 'base' });
     if (ir !== 0) return ir;
     const c1 = Object.keys(a.attributes).length;
-    const c2 = Object.keys(a.attributes).length;
+    const c2 = Object.keys(b.attributes).length;
     if (c1 !== c2) return c2 - c1;
     return a.id - b.id;
   }

--- a/src/app/modules/map/ol/lib/charts/s57.service.ts
+++ b/src/app/modules/map/ol/lib/charts/s57.service.ts
@@ -38,6 +38,8 @@ export interface Options {
   boundaries: string;
   colors: number;
   colorTable: number;
+  otherLayers: string[];
+  depthUnit: 'm' | 'ft';
 }
 
 export const DefaultOptions: Options = {
@@ -47,7 +49,9 @@ export const DefaultOptions: Options = {
   graphicsStyle: 'Paper', //Simplified or Paper
   boundaries: 'Plain', // Plain or Symbolized
   colors: 4, // 2 or 4
-  colorTable: 0 //color scheme
+  colorTable: 0, //color scheme
+  otherLayers: ['SOUNDG', 'OBSTRN', 'UWTROC', 'WRECKS', 'DEPCNT'],
+  depthUnit: 'm'
 };
 
 interface ColorTable {

--- a/src/app/modules/map/ol/lib/charts/s57Style.ts
+++ b/src/app/modules/map/ol/lib/charts/s57Style.ts
@@ -10,6 +10,7 @@ const LOOKUPINDEXKEY = '$lupIndex';
 export class S57Style {
   private s57Service: S57Service;
   private selectedSafeContour = 1000;
+  private currentResolution = 0;
   private instructionMatch = new RegExp('([A-Z][A-Z])\\((.*)\\)');
 
   constructor(s57Service: S57Service) {
@@ -736,21 +737,31 @@ export class S57Style {
       return retval;
     }
 
-    const isNegative = depth < 0;
-    const absDepth = Math.abs(depth);
-    const wholePart = Math.floor(absDepth);
-    const decimalPart = Math.round((absDepth - wholePart) * 10);
-
-    // Write synthetic properties directly (RenderFeature has no .set())
-    featureProperties['_SOUNDG_WHOLE'] =
-      (isNegative ? '-' : '') + wholePart.toString();
-
-    retval.push('TX(_SOUNDG_WHOLE,1,1,2)');
-
-    if (decimalPart > 0) {
-      featureProperties['_SOUNDG_FRAC'] = decimalPart.toString();
-      retval.push('TX(_SOUNDG_FRAC,1,3,2)');
+    // Convert to user's preferred depth unit
+    if (this.s57Service.options.depthUnit === 'ft') {
+      depth = depth * 3.28084;
     }
+
+    // Format: whole numbers for feet; meters show tenths only when zoomed in
+    const sign = depth < 0 ? '-' : '';
+    const absDepth = Math.abs(depth);
+    let str: string;
+    if (this.s57Service.options.depthUnit === 'ft') {
+      str = sign + Math.round(absDepth).toString();
+    } else {
+      // Show tenths when zoomed in (resolution < 5 ≈ zoom 15+), whole numbers when zoomed out
+      const showTenths = this.currentResolution < 5;
+      if (showTenths) {
+        const rounded = Math.round(absDepth * 10) / 10;
+        str = sign + (rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toFixed(1));
+      } else {
+        str = sign + Math.round(absDepth).toString();
+      }
+    }
+
+    // Write synthetic property directly (RenderFeature has no .set())
+    featureProperties['_SOUNDG_WHOLE'] = str;
+    retval.push('TX(_SOUNDG_WHOLE,1,2,2)');
 
     return retval;
   }
@@ -1121,7 +1132,12 @@ export class S57Style {
   };
 
   public getStyle = (feature: Feature, resolution: number): Style[] => {
-    const lupIndex = feature[LOOKUPINDEXKEY];
+    this.currentResolution = resolution;
+    let lupIndex = feature[LOOKUPINDEXKEY];
+    if (lupIndex === undefined || lupIndex === null) {
+      lupIndex = this.s57Service.selectLookup(feature);
+      feature[LOOKUPINDEXKEY] = lupIndex;
+    }
     if (lupIndex >= 0) {
       const lup = this.s57Service.getLookup(lupIndex);
       // simple feature filter
@@ -1129,8 +1145,7 @@ export class S57Style {
         lup.displayCategory === DisplayCategory.DISPLAYBASE ||
         lup.displayCategory === DisplayCategory.STANDARD ||
         lup.displayCategory === DisplayCategory.MARINERS_STANDARD ||
-        lup.name === 'DEPCNT' ||
-        lup.name === 'SOUNDG'
+        this.s57Service.options.otherLayers.includes(lup.name)
       ) {
         return this.getStylesFromRules(lup, feature);
       }

--- a/src/app/modules/map/ol/lib/charts/s57Style.ts
+++ b/src/app/modules/map/ol/lib/charts/s57Style.ts
@@ -152,6 +152,9 @@ export class S57Style {
       case 'DASH':
         lineDash = [4, 4];
         break;
+      case 'DOTT':
+        lineDash = [2, 4];
+        break;
       case 'SOLD':
         lineDash = null;
         break;
@@ -718,6 +721,204 @@ export class S57Style {
     return retval;
   }
 
+  private GetCSSOUNDG02(feature: Feature): string[] {
+    const retval: string[] = [];
+    const featureProperties = feature.getProperties();
+
+    let depth = NaN;
+    if (featureProperties['DEPTH'] !== undefined) {
+      depth = parseFloat(featureProperties['DEPTH']);
+    } else if (featureProperties['VALSOU'] !== undefined) {
+      depth = parseFloat(featureProperties['VALSOU']);
+    }
+
+    if (isNaN(depth)) {
+      return retval;
+    }
+
+    const isNegative = depth < 0;
+    const absDepth = Math.abs(depth);
+    const wholePart = Math.floor(absDepth);
+    const decimalPart = Math.round((absDepth - wholePart) * 10);
+
+    // Write synthetic properties directly (RenderFeature has no .set())
+    featureProperties['_SOUNDG_WHOLE'] =
+      (isNegative ? '-' : '') + wholePart.toString();
+
+    retval.push('TX(_SOUNDG_WHOLE,1,1,2)');
+
+    if (decimalPart > 0) {
+      featureProperties['_SOUNDG_FRAC'] = decimalPart.toString();
+      retval.push('TX(_SOUNDG_FRAC,1,3,2)');
+    }
+
+    return retval;
+  }
+
+  //https://github.com/OpenCPN/OpenCPN/blob/master/libs/s52plib/src/s52cnsy.cpp
+  private GetCSOBSTRN04(feature: Feature): string[] {
+    const retval: string[] = [];
+    const props = feature.getProperties();
+    const geomType = feature.getGeometry().getType();
+    const layer = props['layer'];
+
+    const valsou =
+      props['VALSOU'] !== undefined ? parseFloat(props['VALSOU']) : NaN;
+    const watlev = props['WATLEV'] ? parseInt(props['WATLEV']) : 0;
+
+    if (geomType === 'Point') {
+      if (!isNaN(valsou)) {
+        if (valsou <= 0) {
+          retval.push(
+            layer === 'UWTROC' ? 'SY(UWTROC04)' : 'SY(OBSTRN11)'
+          );
+        } else if (valsou <= this.s57Service.options.safetyDepth) {
+          retval.push('SY(DANGER51)');
+        } else {
+          retval.push(
+            layer === 'UWTROC' ? 'SY(UWTROC03)' : 'SY(OBSTRN01)'
+          );
+        }
+      } else {
+        if (watlev === 1 || watlev === 2) {
+          retval.push(
+            layer === 'UWTROC' ? 'SY(UWTROC04)' : 'SY(OBSTRN11)'
+          );
+        } else if (watlev === 4 || watlev === 5) {
+          retval.push(
+            layer === 'UWTROC' ? 'SY(UWTROC03)' : 'SY(OBSTRN03)'
+          );
+        } else {
+          retval.push(
+            layer === 'UWTROC' ? 'SY(UWTROC03)' : 'SY(OBSTRN01)'
+          );
+        }
+      }
+    } else if (geomType === 'LineString') {
+      if (!isNaN(valsou) && valsou <= this.s57Service.options.safetyDepth) {
+        retval.push('LS(DOTT,2,CHBLK)');
+      } else {
+        retval.push('LS(DASH,2,CHBLK)');
+      }
+    } else {
+      // Polygon/Area
+      if (watlev === 1 || watlev === 2) {
+        retval.push('AC(CHBRN)');
+        retval.push('LS(SOLD,2,CSTLN)');
+      } else if (watlev === 4) {
+        retval.push('AC(DEPIT)');
+        retval.push('LS(DASH,2,CSTLN)');
+      } else {
+        retval.push('AC(DEPVS)');
+        retval.push('LS(DOTT,2,CHBLK)');
+      }
+    }
+
+    return retval;
+  }
+
+  //https://github.com/OpenCPN/OpenCPN/blob/master/libs/s52plib/src/s52cnsy.cpp
+  private GetCSWRECKS02(feature: Feature): string[] {
+    const retval: string[] = [];
+    const props = feature.getProperties();
+    const geomType = feature.getGeometry().getType();
+
+    const valsou =
+      props['VALSOU'] !== undefined ? parseFloat(props['VALSOU']) : NaN;
+    const watlev = props['WATLEV'] ? parseInt(props['WATLEV']) : 0;
+    const catwrk = props['CATWRK'] ? parseInt(props['CATWRK']) : 0;
+
+    if (geomType === 'Point') {
+      if (!isNaN(valsou)) {
+        if (valsou <= 0) {
+          retval.push('SY(WRECKS01)');
+        } else if (valsou <= this.s57Service.options.safetyDepth) {
+          retval.push('SY(DANGER51)');
+        } else {
+          retval.push('SY(WRECKS05)');
+        }
+      } else {
+        if (catwrk === 1) {
+          retval.push('SY(WRECKS05)');
+        } else if (catwrk === 2) {
+          retval.push('SY(WRECKS01)');
+        } else if (watlev === 1 || watlev === 2 || watlev === 3) {
+          retval.push('SY(WRECKS01)');
+        } else if (watlev === 4 || watlev === 5) {
+          retval.push('SY(WRECKS05)');
+        } else {
+          retval.push('SY(WRECKS01)');
+        }
+      }
+    } else {
+      // Polygon/Area
+      if (watlev === 1 || watlev === 2) {
+        retval.push('AC(CHBRN)');
+        retval.push('LS(SOLD,2,CSTLN)');
+      } else if (watlev === 4) {
+        retval.push('AC(DEPIT)');
+        retval.push('LS(DASH,2,CSTLN)');
+      } else {
+        retval.push('AC(DEPVS)');
+        retval.push('LS(DOTT,2,CSTLN)');
+      }
+    }
+
+    return retval;
+  }
+
+  private GetCSRESTRN01(feature: Feature): string[] {
+    const retval: string[] = [];
+    const props = feature.getProperties();
+
+    if (!props['RESTRN']) {
+      return retval;
+    }
+
+    const restrns = props['RESTRN']
+      .toString()
+      .split(',')
+      .map((v) => parseInt(v));
+
+    if (restrns.includes(1) || restrns.includes(2)) {
+      retval.push('SY(ACHRES51)');
+    }
+    if (restrns.includes(3) || restrns.includes(4)) {
+      retval.push('SY(FSHRES51)');
+    }
+    if (restrns.includes(5) || restrns.includes(6)) {
+      retval.push('SY(FSHRES71)');
+    }
+    if (restrns.includes(7) || restrns.includes(8) || restrns.includes(14)) {
+      retval.push('SY(ENTRES51)');
+    }
+    if (restrns.includes(9) || restrns.includes(10)) {
+      retval.push('SY(DRGARE51)');
+    }
+    if (restrns.includes(11) || restrns.includes(12)) {
+      retval.push('SY(DIVPRO51)');
+    }
+    if (restrns.includes(13)) {
+      retval.push('SY(ENTRES61)');
+    }
+    if (restrns.includes(27)) {
+      retval.push('SY(ENTRES71)');
+    }
+
+    if (retval.length === 0) {
+      retval.push('SY(ENTRES61)');
+    }
+
+    return retval;
+  }
+
+  private GetCSRESARE02(feature: Feature): string[] {
+    const retval: string[] = [];
+    retval.push('LS(DASH,2,CHMGD)');
+    retval.push(...this.GetCSRESTRN01(feature));
+    return retval;
+  }
+
   private evalCS(feature: Feature, instruction: string): string[] {
     let retval: string[] = [];
     const instrParts = this.instructionMatch.exec(instruction);
@@ -741,6 +942,22 @@ export class S57Style {
           break;
         case 'QUAPOS01':
           retval = this.GetCSQUAPOS01(feature);
+          break;
+        case 'SOUNDG02':
+          retval = this.GetCSSOUNDG02(feature);
+          break;
+        case 'OBSTRN04':
+          retval = this.GetCSOBSTRN04(feature);
+          break;
+        case 'WRECKS02':
+          retval = this.GetCSWRECKS02(feature);
+          break;
+        case 'RESTRN01':
+          retval = this.GetCSRESTRN01(feature);
+          break;
+        case 'RESARE01':
+        case 'RESARE02':
+          retval = this.GetCSRESARE02(feature);
           break;
         default:
           console.debug('Unsupported CS:' + instruction);
@@ -768,7 +985,10 @@ export class S57Style {
         if (instrParts && instrParts.length > 1) {
           let style: Style = null;
           const cacheKey = instrParts[1] + '_' + instrParts[2];
-          style = this.s57Service.getStyle(cacheKey);
+          const isText = instrParts[1] === 'TX' || instrParts[1] === 'TE';
+          if (!isText) {
+            style = this.s57Service.getStyle(cacheKey);
+          }
           if (!style) {
             switch (instrParts[1]) {
               case 'SY':
@@ -790,7 +1010,9 @@ export class S57Style {
                 //debugger
                 console.debug('Unsupported instruction:' + instruction);
             }
-            this.s57Service.setStyle(cacheKey, style);
+            if (!isText) {
+              this.s57Service.setStyle(cacheKey, style);
+            }
           }
 
           if (style) {
@@ -828,6 +1050,8 @@ export class S57Style {
         return 5;
       case 'BUAARE':
         return 6;
+      case 'SOUNDG':
+        return 7;
       default:
         return 99;
     }
@@ -861,10 +1085,13 @@ export class S57Style {
   public renderOrder = (feature1: Feature, feature2: Feature): number => {
     const l1 = this.layerOrder(feature1);
     const l2 = this.layerOrder(feature2);
+    // TODO: updateSafeContour has side effects inside a sort comparator,
+    // making selectedSafeContour depend on sort traversal order.
+    // Proper fix: compute safe contour in a pre-render pass over all features.
     const o1 = this.updateSafeContour(feature1);
     const o2 = this.updateSafeContour(feature2);
     let lupIndex1 = feature1[LOOKUPINDEXKEY];
-    let lupIndex2 = feature1[LOOKUPINDEXKEY];
+    let lupIndex2 = feature2[LOOKUPINDEXKEY];
     if (!lupIndex1) {
       lupIndex1 = this.s57Service.selectLookup(feature1);
       feature1[LOOKUPINDEXKEY] = lupIndex1;
@@ -880,7 +1107,7 @@ export class S57Style {
 
     if (lupIndex1 >= 0 && lupIndex2 >= 0) {
       const c1 = this.s57Service.getLookup(lupIndex1).displayPriority;
-      const c2 = this.s57Service.getLookup(lupIndex1).displayPriority;
+      const c2 = this.s57Service.getLookup(lupIndex2).displayPriority;
       if (c1 !== c2) {
         return c1 - c2;
       }
@@ -902,7 +1129,8 @@ export class S57Style {
         lup.displayCategory === DisplayCategory.DISPLAYBASE ||
         lup.displayCategory === DisplayCategory.STANDARD ||
         lup.displayCategory === DisplayCategory.MARINERS_STANDARD ||
-        lup.name === 'DEPCNT'
+        lup.name === 'DEPCNT' ||
+        lup.name === 'SOUNDG'
       ) {
         return this.getStylesFromRules(lup, feature);
       }

--- a/src/app/modules/map/popovers/index.ts
+++ b/src/app/modules/map/popovers/index.ts
@@ -7,3 +7,4 @@ export * from './chartlist-popover.component';
 export * from './aircraft-popover.component';
 export * from './alarm-popover.component';
 export * from './aton-popover.component';
+export * from './s57-popover.component';

--- a/src/app/modules/map/popovers/s57-popover.component.ts
+++ b/src/app/modules/map/popovers/s57-popover.component.ts
@@ -1,0 +1,369 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ChangeDetectionStrategy,
+  inject
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { PopoverComponent } from './popover.component';
+import { AppFacade } from 'src/app/app.facade';
+
+// S-57 object class readable names
+const S57_NAMES: { [key: string]: string } = {
+  SOUNDG: 'Sounding',
+  DEPCNT: 'Depth Contour',
+  OBSTRN: 'Obstruction',
+  UWTROC: 'Underwater Rock',
+  WRECKS: 'Wreck',
+  LIGHTS: 'Light',
+  BOYLAT: 'Lateral Buoy',
+  BOYCAR: 'Cardinal Buoy',
+  BOYISD: 'Isolated Danger Buoy',
+  BOYSAW: 'Safe Water Buoy',
+  BOYSPP: 'Special Purpose Buoy',
+  BCNLAT: 'Lateral Beacon',
+  BCNCAR: 'Cardinal Beacon',
+  BCNISD: 'Isolated Danger Beacon',
+  BCNSAW: 'Safe Water Beacon',
+  BCNSPP: 'Special Purpose Beacon',
+  LNDMRK: 'Landmark',
+  SLCONS: 'Shoreline Construction',
+  RESARE: 'Restricted Area',
+  ACHARE: 'Anchorage Area',
+  CBLSUB: 'Submarine Cable',
+  PIPSOL: 'Submarine Pipeline',
+  BERTHS: 'Berth',
+  MORFAC: 'Mooring Facility',
+  DISMAR: 'Distance Mark',
+  CURENT: 'Current',
+  TOPMAR: 'Top Mark',
+  RTPBCN: 'Radar Transponder Beacon',
+  RDOSTA: 'Radio Station',
+  RADSTA: 'Radar Station',
+  FOGSIG: 'Fog Signal',
+  PILBOP: 'Pilot Boarding Place',
+  CGUSTA: 'Coast Guard Station',
+  RSCSTA: 'Rescue Station',
+  SISTAT: 'Signal Station',
+  SISTAW: 'Signal Station Warning',
+  HRBFAC: 'Harbour Facility',
+  SMCFAC: 'Small Craft Facility',
+  CRANES: 'Crane',
+  GATCON: 'Gate',
+  BRIDGE: 'Bridge',
+  CONVYR: 'Conveyor',
+  PIPOHD: 'Overhead Pipeline',
+  CBLOHD: 'Overhead Cable',
+  OFSPLF: 'Offshore Platform',
+  LITFLT: 'Light Float',
+  LITVES: 'Light Vessel',
+  FSHFAC: 'Fishing Facility'
+};
+
+// S-57 layers that are clickable discrete objects (not area fills)
+export const S57_CLICKABLE_LAYERS = new Set([
+  // Navaids
+  'LIGHTS', 'BOYLAT', 'BOYCAR', 'BOYISD', 'BOYSAW', 'BOYSPP',
+  'BCNLAT', 'BCNCAR', 'BCNISD', 'BCNSAW', 'BCNSPP', 'TOPMAR',
+  'RTPBCN', 'RDOSTA', 'RADSTA', 'FOGSIG', 'LITFLT', 'LITVES',
+  // Hazards
+  'OBSTRN', 'UWTROC', 'WRECKS',
+  // 'SOUNDG', // too dense — depth values already shown as labels on chart
+  // Landmarks & structures
+  'LNDMRK', 'SLCONS', 'BRIDGE', 'OFSPLF', 'PILBOP',
+  'CRANES', 'GATCON', 'MORFAC', 'BERTHS', 'HRBFAC', 'SMCFAC',
+  // Cables & pipes
+  'CBLSUB', 'CBLOHD', 'PIPSOL', 'PIPOHD',
+  // Services
+  'CGUSTA', 'RSCSTA', 'SISTAT', 'SISTAW',
+  // Other discrete
+  'DISMAR', 'CURENT', 'FSHFAC', 'CONVYR',
+  // Restricted areas (line/point features)
+  'RESARE', 'ACHARE'
+]);
+
+// S-57 attribute value decodings
+const COLOUR_CODES: { [key: string]: string } = {
+  '1': 'White', '2': 'Black', '3': 'Red', '4': 'Green',
+  '5': 'Blue', '6': 'Yellow', '7': 'Grey', '8': 'Brown',
+  '9': 'Amber', '10': 'Violet', '11': 'Orange', '12': 'Magenta',
+  '13': 'Pink'
+};
+
+const WATLEV_CODES: { [key: string]: string } = {
+  '1': 'Partly submerged', '2': 'Always dry', '3': 'Always under water',
+  '4': 'Covers and uncovers', '5': 'Awash', '6': 'Subject to flooding',
+  '7': 'Floating'
+};
+
+const CATOBS_CODES: { [key: string]: string } = {
+  '1': 'Snag/stump', '2': 'Wellhead', '3': 'Diffuser',
+  '4': 'Crib', '5': 'Fish haven', '6': 'Foul area',
+  '7': 'Foul ground', '8': 'Ice boom', '9': 'Ground tackle',
+  '10': 'Boom'
+};
+
+const CATWRK_CODES: { [key: string]: string } = {
+  '1': 'Non-dangerous', '2': 'Dangerous', '3': 'Distributed remains',
+  '4': 'Mast showing', '5': 'Hull showing'
+};
+
+const BOYSHP_CODES: { [key: string]: string } = {
+  '1': 'Conical (nun)', '2': 'Can (cylindrical)', '3': 'Spherical',
+  '4': 'Pillar', '5': 'Spar', '6': 'Barrel', '7': 'Super-buoy',
+  '8': 'Ice buoy'
+};
+
+const BCNSHP_CODES: { [key: string]: string } = {
+  '1': 'Stake/pole', '2': 'Withy', '3': 'Tower', '4': 'Lattice',
+  '5': 'Pile', '6': 'Cairn', '7': 'Buoyant'
+};
+
+const CATLAM_CODES: { [key: string]: string } = {
+  '1': 'Port', '2': 'Starboard', '3': 'Preferred channel starboard',
+  '4': 'Preferred channel port'
+};
+
+const CATLIT_CODES: { [key: string]: string } = {
+  '1': 'Directional', '4': 'Leading', '5': 'Aero',
+  '6': 'Air obstruction', '7': 'Fog detector', '8': 'Flood',
+  '9': 'Strip', '10': 'Subsidiary', '11': 'Spotlight',
+  '12': 'Front', '13': 'Rear', '14': 'Lower', '15': 'Upper'
+};
+
+const LITCHR_CODES: { [key: string]: string } = {
+  '1': 'Fixed', '2': 'Flashing', '3': 'Long flashing',
+  '4': 'Quick flashing', '5': 'Very quick flashing',
+  '6': 'Ultra quick flashing', '7': 'Isophase', '8': 'Occulting',
+  '9': 'Interrupted quick', '10': 'Interrupted very quick',
+  '11': 'Morse code', '12': 'Fixed/flashing',
+  '25': 'Quick + long flash', '26': 'VQ + long flash',
+  '27': 'UQ + long flash', '28': 'Alternating',
+  '29': 'Fixed & alternating flashing'
+};
+
+const CONDTN_CODES: { [key: string]: string } = {
+  '1': 'Under construction', '2': 'Ruined', '3': 'Under reclamation',
+  '5': 'Planned'
+};
+
+const STATUS_CODES: { [key: string]: string } = {
+  '1': 'Permanent', '2': 'Occasional', '3': 'Recommended',
+  '4': 'Not in use', '5': 'Intermittent', '6': 'Reserved',
+  '7': 'Temporary', '8': 'Private', '9': 'Mandatory',
+  '11': 'Extinguished', '12': 'Illuminated', '13': 'Historic',
+  '14': 'Public', '15': 'Synchronized', '16': 'Watched',
+  '17': 'Un-watched', '18': 'Doubtful'
+};
+
+const RESTRN_CODES: { [key: string]: string } = {
+  '1': 'Anchoring prohibited', '2': 'Anchoring restricted',
+  '3': 'Fishing prohibited', '4': 'Fishing restricted',
+  '5': 'Trawling prohibited', '6': 'Trawling restricted',
+  '7': 'Entry prohibited', '8': 'Entry restricted',
+  '9': 'Dredging prohibited', '10': 'Dredging restricted',
+  '11': 'Diving prohibited', '12': 'Diving restricted',
+  '13': 'No wake', '14': 'Area to be avoided',
+  '27': 'Speed restricted'
+};
+
+const COLPAT_CODES: { [key: string]: string } = {
+  '1': 'Horizontal stripes', '2': 'Vertical stripes',
+  '3': 'Diagonal stripes', '4': 'Squared',
+  '5': 'Border stripes', '6': 'Single colour'
+};
+
+const TOPSHP_CODES: { [key: string]: string } = {
+  '1': 'Cone, point up', '2': 'Cone, point down',
+  '3': 'Sphere', '4': 'Two spheres', '5': 'Cylinder',
+  '6': 'Board', '7': 'X-shape', '8': 'Upright cross',
+  '9': 'Cube, point up', '10': 'Two cones point to point',
+  '11': 'Two cones base to base', '12': 'Rhombus',
+  '13': 'Two cones point up', '14': 'Two cones point down',
+  '33': 'Flag'
+};
+
+const CATCAM_CODES: { [key: string]: string } = {
+  '1': 'North', '2': 'East', '3': 'South', '4': 'West'
+};
+
+const CATSPM_CODES: { [key: string]: string } = {
+  '1': 'Firing danger area', '2': 'Target', '3': 'Marker ship',
+  '4': 'Degaussing range', '5': 'Barge', '6': 'Cable',
+  '7': 'Spoil ground', '8': 'Outfall', '9': 'ODAS',
+  '10': 'Recording', '11': 'Seaplane anchorage', '12': 'Recreation zone',
+  '13': 'Private', '14': 'Mooring', '15': 'LANBY',
+  '16': 'Leading', '17': 'Measured distance', '18': 'Notice',
+  '19': 'TSS', '20': 'No anchoring', '21': 'No berthing',
+  '22': 'No overtaking', '23': 'No two-way traffic',
+  '24': 'Reduced wake', '25': 'Speed limit',
+  '26': 'Stop', '27': 'Warning', '28': 'Sound ship siren',
+  '39': 'Environmental', '45': 'AIS', '51': 'No entry'
+};
+
+// Map attribute codes to their decode tables
+const DECODE_TABLES: { [key: string]: { [key: string]: string } } = {
+  COLOUR: COLOUR_CODES,
+  WATLEV: WATLEV_CODES,
+  CATOBS: CATOBS_CODES,
+  CATWRK: CATWRK_CODES,
+  BOYSHP: BOYSHP_CODES,
+  BCNSHP: BCNSHP_CODES,
+  CATLAM: CATLAM_CODES,
+  CATLIT: CATLIT_CODES,
+  LITCHR: LITCHR_CODES,
+  CONDTN: CONDTN_CODES,
+  STATUS: STATUS_CODES,
+  RESTRN: RESTRN_CODES,
+  COLPAT: COLPAT_CODES,
+  TOPSHP: TOPSHP_CODES,
+  CATCAM: CATCAM_CODES,
+  CATSPM: CATSPM_CODES
+};
+
+// Properties to show and their display order/labels
+const PROP_DISPLAY: { key: string; label: string }[] = [
+  { key: 'OBJNAM', label: 'Name' },
+  { key: 'NOBJNM', label: 'Local Name' },
+  { key: 'INFORM', label: 'Information' },
+  { key: 'NINFOM', label: 'Note' },
+  // Depth/sounding
+  { key: 'DEPTH', label: 'Depth' },
+  { key: 'VALSOU', label: 'Depth' },
+  { key: 'DRVAL1', label: 'Min Depth' },
+  { key: 'DRVAL2', label: 'Max Depth' },
+  { key: 'VALDCO', label: 'Contour Depth' },
+  // Hazard details
+  { key: 'CATWRK', label: 'Type' },
+  { key: 'CATOBS', label: 'Type' },
+  { key: 'WATLEV', label: 'Water Level' },
+  // Navaid details
+  { key: 'CATLAM', label: 'Lateral' },
+  { key: 'CATCAM', label: 'Cardinal' },
+  { key: 'CATSPM', label: 'Purpose' },
+  { key: 'BOYSHP', label: 'Shape' },
+  { key: 'BCNSHP', label: 'Shape' },
+  { key: 'TOPSHP', label: 'Top Mark' },
+  { key: 'COLOUR', label: 'Colour' },
+  { key: 'COLPAT', label: 'Pattern' },
+  // Light details
+  { key: 'LITCHR', label: 'Character' },
+  { key: 'CATLIT', label: 'Category' },
+  { key: 'SIGPER', label: 'Period' },
+  { key: 'VALNMR', label: 'Range' },
+  { key: 'HEIGHT', label: 'Height' },
+  // Restrictions
+  { key: 'RESTRN', label: 'Restriction' },
+  // Physical
+  { key: 'CONDTN', label: 'Condition' },
+  { key: 'STATUS', label: 'Status' },
+  { key: 'CONRAD', label: 'Radar Conspicuous' },
+  { key: 'CONVIS', label: 'Visually Conspicuous' },
+  { key: 'VERLEN', label: 'Vertical Clearance' },
+  { key: 'HORLEN', label: 'Length' },
+  { key: 'HORWID', label: 'Width' }
+];
+
+function decodeValue(key: string, val: unknown): string {
+  const s = String(val);
+  const table = DECODE_TABLES[key];
+  if (!table) {
+    return s;
+  }
+  // Handle comma-separated multi-values (e.g. COLOUR "1,3")
+  const parts = s.split(',');
+  const decoded = parts.map((p) => table[p.trim()] || p.trim());
+  return decoded.join(', ');
+}
+
+const DEPTH_KEYS = new Set(['DEPTH', 'VALSOU', 'DRVAL1', 'DRVAL2', 'VALDCO']);
+const HEIGHT_KEYS = new Set(['HEIGHT', 'VERLEN', 'HORLEN', 'HORWID']);
+
+@Component({
+  selector: 's57-popover',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    PopoverComponent
+  ],
+  template: `
+    <ap-popover [title]="_title" [canClose]="canClose" (closed)="handleClose()">
+      @for (prop of displayProps; track prop.key) {
+        <div style="display:flex; padding: 2px 0;">
+          <div style="font-weight:bold; min-width: 100px;">{{ prop.label }}:</div>
+          <div style="flex: 1 1 auto; text-align: right;">{{ prop.value }}</div>
+        </div>
+      }
+      @if (displayProps.length === 0) {
+        <div style="color: #888;">No details available</div>
+      }
+    </ap-popover>
+  `
+})
+export class S57PopoverComponent {
+  @Input() title: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  @Input() properties: { [key: string]: any };
+  @Input() canClose: boolean;
+  @Output() closed: EventEmitter<void> = new EventEmitter();
+
+  private app = inject(AppFacade);
+  _title: string;
+  displayProps: { key: string; label: string; value: string }[] = [];
+
+  private formatValue(key: string, val: unknown): string {
+    if (DEPTH_KEYS.has(key)) {
+      const n = parseFloat(String(val));
+      if (isNaN(n)) return String(val);
+      return this.app.formatValueForDisplay(n, 'm', true);
+    }
+    if (HEIGHT_KEYS.has(key)) {
+      const n = parseFloat(String(val));
+      if (isNaN(n)) return String(val);
+      return this.app.formatValueForDisplay(n, 'm', true);
+    }
+    if (key === 'SIGPER') {
+      const n = parseFloat(String(val));
+      return isNaN(n) ? String(val) : n + 's';
+    }
+    if (key === 'VALNMR') {
+      const n = parseFloat(String(val));
+      return isNaN(n) ? String(val) : n + ' NM';
+    }
+    if (key === 'CONRAD' || key === 'CONVIS') {
+      return val === 1 || val === '1' ? 'Yes' : 'No';
+    }
+    return decodeValue(key, val);
+  }
+
+  ngOnChanges() {
+    if (!this.properties) {
+      return;
+    }
+    const layer = this.properties['layer'] || '';
+    this._title = this.title || S57_NAMES[layer] || layer || 'Chart Feature';
+
+    this.displayProps = [];
+    for (const prop of PROP_DISPLAY) {
+      const val = this.properties[prop.key];
+      if (val === undefined || val === null || val === '') {
+        continue;
+      }
+      this.displayProps.push({
+        key: prop.key,
+        label: prop.label,
+        value: this.formatValue(prop.key, val)
+      });
+    }
+  }
+
+  handleClose() {
+    this.closed.emit();
+  }
+}

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -262,7 +262,7 @@
                             <mat-select
                               [disabled]="facade.settings.units.useServerPrefs"
                               [(ngModel)]="facade.settings.units.depth"
-                              (selectionChange)="raiseChange();persistModel()"
+                              (selectionChange)="raiseChange();persistModel();doS57()"
                             >
                               @for(i of options.availableUnits.depth; track
                               i[0]) {
@@ -550,6 +550,22 @@
                       <mat-error> Please enter a positive number </mat-error>
                       }
                       <span matSuffix>m</span>
+                    </mat-form-field>
+                  </div>
+                </div>
+                <div class="setting-card-row" style="padding-bottom: 10px">
+                  <div class="setting-card-row-item" style="width: 100%">
+                    <mat-form-field style="width: 100%">
+                      <mat-label>Additional Layers</mat-label>
+                      <mat-select
+                        [(ngModel)]="facade.settings.map.s57Options.otherLayers"
+                        (selectionChange)="doS57()"
+                        multiple
+                      >
+                        @for(layer of options.map.s57.otherLayers; track layer.value) {
+                        <mat-option [value]="layer.value">{{layer.label}}</mat-option>
+                        }
+                      </mat-select>
                     </mat-form-field>
                   </div>
                 </div>

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -433,6 +433,7 @@
                 </div>
               </mat-card-content>
             </mat-card>
+            @if (hasS57Charts()) {
             <div class="setting-group-title">VECTOR CHARTS</div>
             <mat-card>
               <mat-card-content>
@@ -571,6 +572,7 @@
                 </div>
               </mat-card-content>
             </mat-card>
+            }
           </div>
         </div>
       </div>

--- a/src/app/modules/settings/components/settings-dialog.ts
+++ b/src/app/modules/settings/components/settings-dialog.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ElementRef, signal, effect } from '@angular/core';
+import { Component, OnInit, ElementRef, signal, effect, computed } from '@angular/core';
 
 import { FormsModule, NgModel } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -25,6 +25,7 @@ import { defaultConfig } from 'src/app/app.config';
 import { SettingsOptions } from '../settings.facade';
 import { S57Service } from '../../map/ol';
 import { AppFacade } from 'src/app/app.facade';
+import { SKResourceService } from '../../skresources';
 import { Convert } from 'src/app/lib/convert';
 
 interface PreferredPathsResult {
@@ -77,6 +78,10 @@ export class SettingsDialog implements OnInit {
 
   protected unitsChangedSignal = signal<number>(0);
 
+  protected hasS57Charts = computed(() =>
+    this.skres.charts().some((c) => c[1].type?.toLowerCase() === 's-57')
+  );
+
   private saveOnClose = false;
 
   constructor(
@@ -85,7 +90,8 @@ export class SettingsDialog implements OnInit {
     protected dialogRef: MatDialogRef<SettingsDialog>,
     protected wakeLock: WakeLockService,
     private s57: S57Service,
-    protected app: AppFacade
+    protected app: AppFacade,
+    private skres: SKResourceService
   ) {
     this.options = new SettingsOptions();
 

--- a/src/app/modules/settings/components/settings-dialog.ts
+++ b/src/app/modules/settings/components/settings-dialog.ts
@@ -150,7 +150,7 @@ export class SettingsDialog implements OnInit {
     } else {
       this.persistModel();
     }
-    this.s57.SetOptions(this.facade.settings.map.s57Options);
+    this.s57.SetOptions({ ...this.facade.settings.map.s57Options, depthUnit: this.facade.settings.units.depth });
   }
 
   /**

--- a/src/app/modules/settings/settings.facade.ts
+++ b/src/app/modules/settings/settings.facade.ts
@@ -104,7 +104,22 @@ export class SettingsOptions {
         [2, 'Day White Background']
         /*[3, 'Dusk'],
         [4, 'Night']*/
-      ])
+      ]),
+      otherLayers: [
+        { value: 'SOUNDG', label: 'Depth Soundings' },
+        { value: 'DEPCNT', label: 'Depth Contours' },
+        { value: 'OBSTRN', label: 'Obstructions' },
+        { value: 'UWTROC', label: 'Underwater Rocks' },
+        { value: 'WRECKS', label: 'Wrecks' },
+        { value: 'CBLSUB', label: 'Submarine Cables' },
+        { value: 'PIPSOL', label: 'Submarine Pipelines' },
+        { value: 'BERTHS', label: 'Berths' },
+        { value: 'MORFAC', label: 'Mooring Facilities' },
+        { value: 'LNDMRK', label: 'Landmarks' },
+        { value: 'DISMAR', label: 'Distance Marks' },
+        { value: 'CURENT', label: 'Currents' },
+        { value: 'MAGVAR', label: 'Magnetic Variation' }
+      ]
     }
   };
 

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -113,6 +113,7 @@ export interface IAppConfig {
       safetyDepth: number;
       deepDepth: number;
       colorTable: number;
+      otherLayers: string[];
     };
     popoverMulti: boolean; // close popovers using cose button
   };


### PR DESCRIPTION
- Fix bugs in the S-57 rendering pipeline: compareLookup() wrong variable, renderOrder() referencing feature1 instead of feature2 (twice), TX/TE style cache bleeding across features, and documented updateSafeContour side effect in sort comparator
- Implement 6 missing CS procedures: SOUNDG02 (depth soundings), OBSTRN04 (obstructions/underwater rocks), WRECKS02 (wrecks), RESTRN01 (restriction symbols), RESARE01/02 (restricted areas). SOUNDG02, OBSTRN04, and WRECKS02 are safety-critical
<img width="1462" height="919" alt="image" src="https://github.com/user-attachments/assets/db9367c6-8e4a-453d-b973-0acdeb5dde12" />


- Add click-to-inspect for S-57 features: clicking buoys, beacons, lights, wrecks, obstructions, etc. shows a popover with decoded S-57 attributes (e.g., COLOUR: 4 → Green, CATWRK: 2 → Dangerous)
<img width="711" height="682" alt="image" src="https://github.com/user-attachments/assets/059b6a6a-dc0b-45d6-b93f-5dae24b698ee" />
- Add Additional Layers toggle in settings: users can enable/disable OTHER display category features (soundings, obstructions, wrecks, cables, landmarks, etc.) via a multi-select dropdown
<img width="1178" height="683" alt="image" src="https://github.com/user-attachments/assets/0f4df62f-c287-420f-bb38-e98c77e31cc4" />
- Depth unit support: sounding labels on the chart and feature inspect popovers respect the user's depth unit preference (meters/feet), with zoom-dependent rounding for meters (tenths at zoom 15+, whole numbers below)
- Hide VECTOR CHARTS settings when no S-57 charts are loaded 
- Add DOTT line style support for obstruction rendering