### PR TITLE
Improve startup performance: eliminate duplicate API calls

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -273,16 +273,6 @@ export class AppComponent {
     // set self to active vessel
     this.app.data.vessels.active = this.app.data.vessels.self;
 
-    // CONFIG$ - handle app.config$ event
-    this.obsList.push(
-      this.app.config$.subscribe((value: string) => {
-        // config has been loaded and cleaned (ready)
-        if (value === 'ready') {
-          this.fetchResources(true);
-        }
-      })
-    );
-
     // handle skAuthChange signal
     effect(() => {
       this.app.debug('** skAuthChange Event:', this.app.skAuthChange());

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -77,6 +77,7 @@ export type SKSelection = SKResourceType | 'aisTargets' | 'infolayers';
 @Injectable({ providedIn: 'root' })
 export class SKResourceService {
   private reOpen: { key?: string; value?: string; readOnly?: boolean };
+  private inflight = new Map<string, Promise<any[]>>();
 
   constructor(
     private dialog: MatDialog,
@@ -277,7 +278,13 @@ export class SKResourceService {
       query = '';
     }
 
-    return new Promise((resolve, reject) => {
+    const key = `${collection}${query}`;
+    const existing = this.inflight.get(key);
+    if (existing) {
+      return existing as Promise<T[]>;
+    }
+
+    const promise = new Promise<T[]>((resolve, reject) => {
       const skf = this.signalk.api.get(
         this.app.skApiVersion,
         `/resources/${collection}${query}`
@@ -298,7 +305,12 @@ export class SKResourceService {
         },
         (err: HttpErrorResponse) => reject(err)
       );
-    });
+    }).finally(() => {
+      this.inflight.delete(key);
+    }) as Promise<T[]>;
+
+    this.inflight.set(key, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Remove the redundant `fetchResources(true)` call from the `config$.ready` subscription — resources are already fetched in `queryAfterConnect()` after the server connection is established
- Add in-flight request deduplication to `listFromServer()` so concurrent calls for the same resource collection return the existing promise instead of firing parallel HTTP requests

Closes #340

## Test plan

- [ ] Verify resources (routes, waypoints, charts, notes, regions, tracks) are still loaded correctly after startup
- [ ] Check browser DevTools Network tab: each `/v2/api/resources/*` endpoint should be called only once during startup, not twice
- [ ] Verify that importing GPX/GeoJSON still triggers a resource refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)