### PR TITLE
Improve startup performance: defer S57 chart symbols loading

### DIFF
--- a/src/app/modules/map/ol/lib/charts/s57.service.ts
+++ b/src/app/modules/map/ol/lib/charts/s57.service.ts
@@ -110,6 +110,8 @@ export class S57Service {
 
   private attMatch = new RegExp('([A-Za-z0-9]{6})([0-9,\\?]*)');
 
+  private loaded = false;
+
   private http = inject(HttpClient);
 
   constructor() {}
@@ -117,6 +119,14 @@ export class S57Service {
   public init(options: Options = DefaultOptions) {
     this.options = Object.assign({}, options);
     this.selectedColorTable = this.options.colorTable;
+  }
+
+  /** Load chart symbols and images. Called lazily on first use. */
+  public ensureLoaded() {
+    if (this.loaded) {
+      return;
+    }
+    this.loaded = true;
 
     this.http
       .get('assets/s57/chartsymbols.xml', { responseType: 'text' })

--- a/src/app/modules/map/ol/lib/charts/vectorLayerStyleFactory.ts
+++ b/src/app/modules/map/ol/lib/charts/vectorLayerStyleFactory.ts
@@ -73,6 +73,7 @@ export class VectorLayerStyleFactory {
 
   public CreateVectorLayerStyler(chart: SKChart): VectorLayerStyler {
     if (chart.type === 'S-57' || chart.type === 's-57') {
+      this.s57service.ensureLoaded();
       return new S57LayerStyler(this.s57service);
     }
   }


### PR DESCRIPTION
## Summary

- `S57Service.init()` no longer fetches `chartsymbols.xml` (2.2 MB) and `rastersymbols-day.png` (250 KB) at startup — it only stores the options
- New `ensureLoaded()` method performs the actual fetch, called lazily from `VectorLayerStyleFactory` when an S57 chart layer is first created
- Users without S57 vector charts save ~2.5 MB of transfer and XML parsing time on every page load

Closes #342

## Test plan

- [ ] Startup without S57 charts: verify `chartsymbols.xml` and `rastersymbols-day.png` are NOT fetched (check Network tab)
- [ ] With S57 charts configured: verify chart symbols load correctly when the S57 layer is displayed
- [ ] Change S57 options in settings: verify `SetOptions()` still works and triggers a refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)