### PR TITLE
fix: stop sending null for optional note properties

### DIFF
--- a/src/app/modules/skresources/resource-classes.ts
+++ b/src/app/modules/skresources/resource-classes.ts
@@ -79,12 +79,12 @@ export class SKNote {
   constructor(note?: NoteResource) {
     this.name = note?.name ?? '';
     this.description = note?.description ?? '';
-    this.position = note?.position ?? null;
-    this.href = note?.href ?? null;
+    this.position = note?.position;
+    this.href = note?.href;
     this.mimeType = note?.mimeType ?? '';
     this.url = note?.url ?? '';
     // ca reports
-    this.group = note?.group ?? null;
+    this.group = note?.group;
     this.authors =
       note?.authors && Array.isArray(note?.authors) ? note.authors : [];
     this.properties =


### PR DESCRIPTION
## Summary

- SKNote constructor defaulted `href`, `position`, and `group` to `null` when not provided
- `JSON.stringify` includes `null` values in the payload, which fails validation on Signal K server v2.24.0 where TypeBox/AJV rejects `null` for string-typed optional fields
- Leaving them `undefined` instead causes `JSON.stringify` to omit them entirely, which the server's `Type.Partial()` schema accepts

Fixes note creation via Freeboard on Signal K server >= v2.24.0.