### PR TITLE
feat(charts): add In view filter to chart list

### DIFF
--- a/src/app/modules/map/ol/lib/charts/chart-utils.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils.spec.ts
@@ -1,5 +1,9 @@
 import { expect, describe, it } from 'vitest';
-import { extentFromBounds, resolveLayerMaxZoom } from './chart-utils';
+import {
+  extentFromBounds,
+  isChartInView,
+  resolveLayerMaxZoom
+} from './chart-utils';
 
 describe('resolveLayerMaxZoom', () => {
   it('returns chart max when over-zoom disabled', () => {
@@ -31,5 +35,49 @@ describe('extentFromBounds', () => {
 
   it('returns undefined for invalid bounds values', () => {
     expect(extentFromBounds([90, 90, 90, 300])).toBe(undefined);
+  });
+
+  it('returns a transformed extent for valid mid-range bounds', () => {
+    const extent = extentFromBounds([-10, -10, 10, 10]);
+    expect(extent).toBeDefined();
+    expect(extent).toHaveLength(4);
+    expect(extent?.every((n) => Number.isFinite(n))).toBe(true);
+  });
+
+  it('rejects bounds that touch the +/-180 / +/-90 edges', () => {
+    expect(extentFromBounds([-180, 0, 10, 10])).toBe(undefined);
+    expect(extentFromBounds([-10, -90, 10, 10])).toBe(undefined);
+    expect(extentFromBounds([-10, -10, 180, 10])).toBe(undefined);
+    expect(extentFromBounds([-10, -10, 10, 90])).toBe(undefined);
+  });
+
+  it('accepts bounds just inside the edges', () => {
+    expect(extentFromBounds([-179.99, -89.99, 179.99, 89.99])).toBeDefined();
+  });
+});
+
+describe('isChartInView', () => {
+  const extent = [10, 40, 20, 50];
+
+  it('keeps a chart whose bounds overlap the extent', () => {
+    expect(isChartInView([15, 45, 30, 60], extent)).toBe(true);
+  });
+
+  it('keeps a chart fully contained within the extent', () => {
+    expect(isChartInView([12, 42, 18, 48], extent)).toBe(true);
+  });
+
+  it('drops a chart whose bounds are disjoint from the extent', () => {
+    expect(isChartInView([30, 45, 40, 60], extent)).toBe(false);
+  });
+
+  it('keeps a chart that only touches the extent edge', () => {
+    expect(isChartInView([20, 40, 30, 50], extent)).toBe(true);
+  });
+
+  it('keeps charts with missing or malformed bounds (treated as global)', () => {
+    expect(isChartInView(undefined, extent)).toBe(true);
+    expect(isChartInView([10, 40, 20], extent)).toBe(true);
+    expect(isChartInView([], extent)).toBe(true);
   });
 });

--- a/src/app/modules/map/ol/lib/charts/chart-utils.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils.spec.ts
@@ -80,4 +80,38 @@ describe('isChartInView', () => {
     expect(isChartInView([10, 40, 20], extent)).toBe(true);
     expect(isChartInView([], extent)).toBe(true);
   });
+
+  describe('antimeridian-crossing view', () => {
+    // View straddling the dateline reported by OpenLayers as maxLon > 180.
+    const eastWrapped = [170, 40, 190, 60];
+    // Equivalent view reported with minLon < -180.
+    const westWrapped = [-190, 40, -170, 60];
+
+    it('keeps a chart just west of the dateline (maxLon > 180 view)', () => {
+      expect(isChartInView([172, 42, 178, 58], eastWrapped)).toBe(true);
+    });
+
+    it('keeps a chart just east of the dateline (maxLon > 180 view)', () => {
+      expect(isChartInView([-178, 42, -172, 58], eastWrapped)).toBe(true);
+    });
+
+    it('keeps a chart east of the dateline (minLon < -180 view)', () => {
+      expect(isChartInView([-178, 42, -172, 58], westWrapped)).toBe(true);
+    });
+
+    it('drops a chart outside a dateline-crossing view', () => {
+      expect(isChartInView([100, 42, 120, 58], eastWrapped)).toBe(false);
+    });
+
+    it('drops a chart within the view longitude but outside its latitude', () => {
+      expect(isChartInView([172, 0, 178, 20], eastWrapped)).toBe(false);
+    });
+
+    it('keeps every chart when the view spans the whole globe', () => {
+      const worldView = [-200, 40, 200, 60];
+      expect(isChartInView([-178, 42, -172, 58], worldView)).toBe(true);
+      expect(isChartInView([0, 42, 10, 58], worldView)).toBe(true);
+      expect(isChartInView([172, 42, 178, 58], worldView)).toBe(true);
+    });
+  });
 });

--- a/src/app/modules/map/ol/lib/charts/chart-utils.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils.ts
@@ -1,4 +1,4 @@
-import { Extent } from 'ol/extent';
+import { Extent, intersects } from 'ol/extent';
 import { transformExtent } from 'ol/proj';
 
 export function resolveLayerMaxZoom(
@@ -27,4 +27,32 @@ export function extentFromBounds(bounds?: number[]): Extent | undefined {
     return undefined;
   }
   return transformExtent(bounds, 'EPSG:4326', 'EPSG:3857');
+}
+
+/**
+ * Determines whether a chart should remain visible when the chart list is
+ * filtered to the current map view.
+ *
+ * Charts without valid bounds metadata are treated as global (not tied to a
+ * region) and are always kept. Both `bounds` and `extent` are EPSG:4326
+ * [minLon, minLat, maxLon, maxLat], so they are compared directly without
+ * re-projection.
+ *
+ * Limitation: this is a plain min/max overlap test and does not account for a
+ * viewport that crosses the antimeridian (+/-180 longitude); near the dateline a
+ * chart may be wrongly included or excluded.
+ *
+ * Example:
+ *   bounds=[10, 40, 20, 50], extent=[15, 45, 30, 60] -> true  (overlap)
+ *   bounds=[10, 40, 20, 50], extent=[30, 45, 40, 60] -> false (disjoint)
+ *   bounds=undefined,        extent=[...]            -> true  (global chart)
+ */
+export function isChartInView(
+  bounds: number[] | undefined,
+  extent: Extent
+): boolean {
+  if (!Array.isArray(bounds) || bounds.length !== 4) {
+    return true;
+  }
+  return intersects(bounds, extent);
 }

--- a/src/app/modules/map/ol/lib/charts/chart-utils.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils.ts
@@ -38,14 +38,17 @@ export function extentFromBounds(bounds?: number[]): Extent | undefined {
  * [minLon, minLat, maxLon, maxLat], so they are compared directly without
  * re-projection.
  *
- * Limitation: this is a plain min/max overlap test and does not account for a
- * viewport that crosses the antimeridian (+/-180 longitude); near the dateline a
- * chart may be wrongly included or excluded.
+ * A viewport that crosses the antimeridian (+/-180 longitude) is reported by
+ * OpenLayers with a longitude range that runs past the dateline (e.g. a view
+ * straddling +/-180 arrives as minLon=170, maxLon=190). Chart bounds are always
+ * normalised to [-180, 180], so such a view is split into its two normalised
+ * longitude ranges and the chart is kept if it overlaps either.
  *
  * Example:
- *   bounds=[10, 40, 20, 50], extent=[15, 45, 30, 60] -> true  (overlap)
- *   bounds=[10, 40, 20, 50], extent=[30, 45, 40, 60] -> false (disjoint)
- *   bounds=undefined,        extent=[...]            -> true  (global chart)
+ *   bounds=[10, 40, 20, 50],   extent=[15, 45, 30, 60]  -> true  (overlap)
+ *   bounds=[10, 40, 20, 50],   extent=[30, 45, 40, 60]  -> false (disjoint)
+ *   bounds=[-178, 40, -170, 50], extent=[170, 40, 190, 60] -> true (dateline)
+ *   bounds=undefined,          extent=[...]             -> true  (global chart)
  */
 export function isChartInView(
   bounds: number[] | undefined,
@@ -54,5 +57,44 @@ export function isChartInView(
   if (!Array.isArray(bounds) || bounds.length !== 4) {
     return true;
   }
+  const [minLon, , maxLon] = extent;
+  if (maxLon > 180 || minLon < -180) {
+    return splitExtentAtAntimeridian(extent).some((range) =>
+      intersects(bounds, range)
+    );
+  }
   return intersects(bounds, extent);
+}
+
+/**
+ * Split a map extent that crosses the antimeridian into normalised longitude
+ * ranges within [-180, 180].
+ *
+ * OpenLayers reports a dateline-crossing viewport with a longitude that runs
+ * past the antimeridian; the wrapped portion has to be brought back into range
+ * before it can be compared with chart bounds, which are always normalised.
+ *
+ * Input:  [170, 40, 190, 60]
+ * Output: [[170, 40, 180, 60], [-180, 40, -170, 60]]
+ */
+function splitExtentAtAntimeridian(extent: Extent): Extent[] {
+  const [minLon, minLat, maxLon, maxLat] = extent;
+  // A span of a full turn or more means the whole world is longitudinally
+  // visible, so there is nothing to exclude on longitude.
+  if (maxLon - minLon >= 360) {
+    return [[-180, minLat, 180, maxLat]];
+  }
+  // Normalise both edges to [-180, 180). Input:  190 -> Output: -170
+  const wrap = (lon: number) => ((((lon + 180) % 360) + 360) % 360) - 180;
+  const west = wrap(minLon);
+  const east = wrap(maxLon);
+  // When the view genuinely crosses the dateline the normalised west edge sits
+  // east of the normalised east edge; emit the two pieces either side of it.
+  if (west > east) {
+    return [
+      [west, minLat, 180, maxLat],
+      [-180, minLat, east, maxLat]
+    ];
+  }
+  return [[west, minLat, east, maxLat]];
 }

--- a/src/app/modules/skresources/components/charts/chartlist.html
+++ b/src/app/modules/skresources/components/charts/chartlist.html
@@ -92,20 +92,29 @@
         matTooltip="Display Chart Boundaries"
         matTooltipPosition="above"
       >
-        Boundaries
+        Bounds
+      </mat-slide-toggle>
+      <mat-slide-toggle
+        style="margin-left: 12px"
+        [hideIcon]="true"
+        [checked]="inViewOnly"
+        (change)="toggleInViewOnly($event.checked)"
+        matTooltip="Show only charts whose bounds intersect the current map view"
+        matTooltipPosition="above"
+      >
+        In Bounds
       </mat-slide-toggle>
       <button
-        mat-button
+        mat-icon-button
         (click)="showChartLayers(true)"
         matTooltip="Re-order Charts"
         matTooltipPosition="above"
       >
         <mat-icon>import_export</mat-icon>
-        Re-order
       </button>
 
       <button
-        mat-button
+        mat-icon-button
         matTooltip="Add Chart"
         matTooltipPosition="above"
         [matMenuTriggerFor]="addchartmenu"

--- a/src/app/modules/skresources/components/charts/chartlist.html
+++ b/src/app/modules/skresources/components/charts/chartlist.html
@@ -92,20 +92,29 @@
         matTooltip="Display Chart Boundaries"
         matTooltipPosition="above"
       >
-        Boundaries
+        Bounds
+      </mat-slide-toggle>
+      <mat-slide-toggle
+        style="margin-left: 12px"
+        [hideIcon]="true"
+        [checked]="inViewOnly"
+        (change)="toggleInViewOnly($event.checked)"
+        matTooltip="Show only charts visible in the current map view"
+        matTooltipPosition="above"
+      >
+        In view
       </mat-slide-toggle>
       <button
-        mat-button
+        mat-icon-button
         (click)="showChartLayers(true)"
         matTooltip="Re-order Charts"
         matTooltipPosition="above"
       >
         <mat-icon>import_export</mat-icon>
-        Re-order
       </button>
 
       <button
-        mat-button
+        mat-icon-button
         matTooltip="Add Chart"
         matTooltipPosition="above"
         [matMenuTriggerFor]="addchartmenu"

--- a/src/app/modules/skresources/components/charts/chartlist.html
+++ b/src/app/modules/skresources/components/charts/chartlist.html
@@ -106,6 +106,7 @@
       </mat-slide-toggle>
       <button
         mat-icon-button
+        aria-label="Re-order Charts"
         (click)="showChartLayers(true)"
         matTooltip="Re-order Charts"
         matTooltipPosition="above"
@@ -115,6 +116,7 @@
 
       <button
         mat-icon-button
+        aria-label="Add Chart"
         matTooltip="Add Chart"
         matTooltipPosition="above"
         [matMenuTriggerFor]="addchartmenu"

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -37,6 +37,7 @@ import { FBMapInteractService } from 'src/app/modules/map/fbmap-interact.service
 import { SingleSelectListDialog } from 'src/app/lib/components';
 import { SKResourceGroupService } from '../groups/groups.service';
 import { SKChart } from '../../resource-classes';
+import { intersects as extentsIntersect } from 'ol/extent';
 
 @Component({
   selector: 'chart-list',
@@ -67,6 +68,7 @@ export class ChartListComponent extends ResourceListBase {
   protected override filteredList = signal<FBCharts>([]);
 
   displayChartLayers = false;
+  protected inViewOnly = false;
 
   constructor(
     protected app: AppFacade,
@@ -88,6 +90,13 @@ export class ChartListComponent extends ResourceListBase {
     effect(() => {
       if (this.worker.resourceUpdate().path.includes('resources.charts')) {
         this.initItems(true);
+      }
+    });
+    // react to map extent changes when in-view filter is active
+    effect(() => {
+      this.app.mapExtent();
+      if (this.inViewOnly) {
+        this.doFilter();
       }
     });
   }
@@ -133,6 +142,42 @@ export class ChartListComponent extends ResourceListBase {
       this.app.parseHttpErrorResponse(err);
       this.fullList = [];
     }
+  }
+
+  /**
+   * @description Toggle filtering of chart list by map viewport.
+   */
+  protected toggleInViewOnly(checked: boolean) {
+    this.inViewOnly = checked;
+    this.doFilter();
+  }
+
+  /**
+   * @description Override base filter to also apply map viewport bounds filter.
+   */
+  protected override doFilter() {
+    const text = this.filterText?.toLowerCase() ?? '';
+    const extent = this.app.mapExtent();
+    const useExtent =
+      this.inViewOnly && Array.isArray(extent) && extent.length === 4;
+    let fl: FBCharts = this.fullList.filter((item) => {
+      if (text && !item[1].name?.toLowerCase().includes(text)) {
+        return false;
+      }
+      if (useExtent) {
+        const b = item[1].bounds;
+        if (!Array.isArray(b) || b.length !== 4) {
+          // charts without bounds are treated as global and kept visible
+          return true;
+        }
+        // both bounds and mapExtent are [minLon, minLat, maxLon, maxLat]
+        return extentsIntersect(b, extent);
+      }
+      return true;
+    });
+    fl.sort((a, b) => a[1].name.localeCompare(b[1].name));
+    this.filteredList.update(() => fl.slice(0));
+    this.alignSelections();
   }
 
   /**

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -39,6 +39,7 @@ import {
 import { SKResourceGroupService } from '../groups/groups.service';
 import { SKChart } from '../../resource-classes';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { isChartInView } from 'src/app/modules/map/ol/lib/charts/chart-utils';
 
 @Component({
   selector: 'chart-list',
@@ -69,6 +70,7 @@ export class ChartListComponent extends ResourceListBase {
   protected override filteredList = signal<FBCharts>([]);
 
   displayChartLayers = false;
+  protected inViewOnly = false;
 
   protected app = inject(AppFacade);
   private worker = inject(SKWorkerService);
@@ -89,6 +91,13 @@ export class ChartListComponent extends ResourceListBase {
     effect(() => {
       if (this.worker.resourceUpdate().path.includes('resources.charts')) {
         this.initItems(true);
+      }
+    });
+    // re-apply the filter as the map view changes while the in-view filter is on
+    effect(() => {
+      this.app.mapExtent();
+      if (this.inViewOnly) {
+        this.doFilter();
       }
     });
   }
@@ -281,6 +290,34 @@ export class ChartListComponent extends ResourceListBase {
     if (this.app.data.chartBounds.show) {
       this.app.data.chartBounds.charts = this.fullList;
     }
+  }
+
+  /**
+   * @description Toggle filtering of the chart list to the current map view.
+   */
+  protected toggleInViewOnly(checked: boolean) {
+    this.inViewOnly = checked;
+    this.doFilter();
+  }
+
+  /**
+   * @description Filter and sort charts by name, additionally restricting the
+   * list to charts visible in the current map view when the in-view filter is on.
+   */
+  protected override doFilter() {
+    const text = this.filterText?.toLowerCase() ?? '';
+    const extent = this.app.mapExtent();
+    const useExtent =
+      this.inViewOnly && Array.isArray(extent) && extent.length === 4;
+    const fl = this.fullList.filter((item) => {
+      if (text && !item[1].name?.toLowerCase().includes(text)) {
+        return false;
+      }
+      return useExtent ? isChartInView(item[1].bounds, extent) : true;
+    });
+    fl.sort((a, b) => a[1].name.localeCompare(b[1].name));
+    this.filteredList.update(() => fl.slice(0));
+    this.alignSelections();
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds an **In view** slide toggle to the chart list. When enabled, only charts whose `bounds` intersect the current map viewport (`app.mapExtent`) are shown.
- The list updates reactively as the user pans/zooms the map, via a signal-driven `effect` that recomputes the filter while the toggle is on.
- Combines with the existing text filter; charts without bounds metadata are treated as global and remain visible.

## Changes
- `chart-utils.ts`: new pure `isChartInView(bounds, extent)` helper (alongside `extentFromBounds`) encapsulating the bounds/viewport intersection and the "no bounds = global" rule. Both inputs are EPSG:4326 `[minLon, minLat, maxLon, maxLat]`, compared via `intersects` from `ol/extent` with no re-projection.
- `chart-utils.spec.ts`: unit tests for `isChartInView` (overlap, containment, edge-touching, disjoint, missing/malformed bounds) plus boundary tests for `extentFromBounds`.
- `chartlist.ts`: new `inViewOnly` flag, `toggleInViewOnly()`, an overridden `doFilter()` combining the name filter with the viewport filter, and an `effect()` watching `app.mapExtent`.
- `chartlist.html`: new **In view** `mat-slide-toggle`; the existing boundary toggle relabelled **Bounds** and the Re-order / Add buttons made icon-only to fit on one row.

## Known limitation
The intersection is a plain min/max overlap test and does not handle viewports crossing the antimeridian (±180° longitude); this is documented in `isChartInView`.

## Closes
Closes #351

## Test plan
- Install several charts covering different regions (e.g. NOAA US + OSM + a European chart)
- Open chart list, confirm the **In view** toggle appears next to **Bounds**
- Toggle on, pan/zoom the map — list shrinks to charts intersecting the viewport
- Verify OSM (no bounds) stays visible regardless of viewport
- Combine with the text filter — both predicates applied
- Toggle off — full list returns


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “In view” filter to the chart list to show only charts visible in the current map extent.
  * Updated the chart-list toolbar controls to a more compact icon-based layout.

* **Bug Fixes**
  * Improved in-view filtering to update automatically as the map moves.
  * Enhanced bounds edge handling near the dateline and world limits, including correct inclusion/exclusion at exact edge values.

* **Tests**
  * Expanded coverage for chart extent visibility and edge-case scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->