### PR TITLE
fix: use assignment instead of comparison for alarm lastUpdate

### DIFF
--- a/helper/alarms/alarms.ts
+++ b/helper/alarms/alarms.ts
@@ -141,7 +141,7 @@ class AreaAlarmManager {
         notify = true;
         server.debug(`*** active -> to inactive (${id})`);
       }
-      alarm.lastUpdate == Date.now();
+      alarm.lastUpdate = Date.now();
     } else {
       if (condition === 'outside' && !alarm.active) {
         // transition to active


### PR DESCRIPTION
alarm.lastUpdate == Date.now() was a no-op comparison instead of an assignment, so entry-trigger area alarms never had their lastUpdate timestamp refreshed after creation.