### PR TITLE
fix: constrain tile layers to chart bounds to prevent 404 floods

### DIFF
--- a/src/app/modules/map/ol/lib/charts/chart-bounds.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-bounds.ts
@@ -1,0 +1,20 @@
+import { Extent } from 'ol/extent';
+import { transformExtent } from 'ol/proj';
+
+/**
+ * Convert chart bounds [minLon, minLat, maxLon, maxLat] to an EPSG:3857 extent
+ * suitable for use as a layer extent. Returns undefined if bounds are missing
+ * or cover the full world (no constraint needed).
+ */
+export function chartExtent(bounds?: number[]): Extent | undefined {
+  if (!Array.isArray(bounds) || bounds.length < 4) return undefined;
+  if (
+    bounds[0] <= -180 &&
+    bounds[1] <= -90 &&
+    bounds[2] >= 180 &&
+    bounds[3] >= 90
+  ) {
+    return undefined;
+  }
+  return transformExtent(bounds, 'EPSG:4326', 'EPSG:3857');
+}

--- a/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
@@ -13,6 +13,7 @@ import WebGLTileLayer from 'ol/layer/WebGLTile';
 import { XYZ } from 'ol/source';
 
 import { initPMTilesXYZLayer } from './pmtiles-utils';
+import { chartExtent } from './chart-bounds';
 import { osmLayer } from '../util';
 import { MapComponent } from '../map.component';
 import { resolveLayerMaxZoom } from './zoom-utils';
@@ -81,8 +82,10 @@ export class RasterChartLayerComponent implements OnDestroy {
             ? chart[1].minZoom - 0.1
             : chart[1].minZoom;
 
+        const extent = chartExtent(chart[1].bounds);
+
         if (chart[1].url.indexOf('.pmtiles') !== -1) {
-          this.layer = initPMTilesXYZLayer(chart[1], this.zIndex());
+          this.layer = initPMTilesXYZLayer(chart[1], this.zIndex(), extent);
         } else {
           this.layer = new TileLayer({
             source: new XYZ({
@@ -93,6 +96,7 @@ export class RasterChartLayerComponent implements OnDestroy {
             zIndex: this.zIndex(),
             minZoom: minZ,
             maxZoom: layerMaxZ,
+            extent,
             opacity: chart[1].defaultOpacity ?? 1
           });
         }

--- a/src/app/modules/map/ol/lib/charts/layer-tilejson-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-tilejson-chart.component.ts
@@ -15,6 +15,7 @@ import { MapComponent } from '../map.component';
 
 import { FBChart } from 'src/app/types';
 import { resolveLayerMaxZoom } from './zoom-utils';
+import { chartExtent } from './chart-bounds';
 
 // ** Freeboard TileJSON Chart **
 @Component({
@@ -79,6 +80,7 @@ export class TileJsonChartLayerComponent implements OnDestroy {
         zIndex: this.zIndex(),
         minZoom: minZ,
         maxZoom: layerMaxZ,
+        extent: chartExtent(chart[1].bounds),
         opacity: chart[1].defaultOpacity ?? 1
       });
 

--- a/src/app/modules/map/ol/lib/charts/layer-vector-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-vector-chart.component.ts
@@ -18,6 +18,7 @@ import { MapComponent } from '../map.component';
 import { FBChart } from 'src/app/types';
 import { initPMTilesVectorLayer } from './pmtiles-utils';
 import { resolveLayerMaxZoom } from './zoom-utils';
+import { chartExtent } from './chart-bounds';
 
 // ** Freeboard Vector TileLayer Chart **
 @Component({
@@ -73,8 +74,10 @@ export class VectorChartLayerComponent implements OnDestroy {
         this.overZoomTiles()
       );
 
+      const extent = chartExtent(chart[1].bounds);
+
       if (chart[1].url.indexOf('.pmtiles') !== -1) {
-        this.layer = initPMTilesVectorLayer(chart[1], this.zIndex());
+        this.layer = initPMTilesVectorLayer(chart[1], this.zIndex(), extent);
       } else {
         this.layer = new VectorTileLayer({
           source: new VectorTileSource({
@@ -91,6 +94,7 @@ export class VectorChartLayerComponent implements OnDestroy {
           zIndex: this.zIndex(),
           minZoom: minZ,
           maxZoom: layerMaxZ,
+          extent,
           opacity: chart[1].defaultOpacity ?? 1
         });
       }

--- a/src/app/modules/map/ol/lib/charts/layer-wms-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wms-chart.component.ts
@@ -17,6 +17,7 @@ import { FBChart } from 'src/app/types';
 import { Map } from 'ol';
 import { MapService } from '../map.service';
 import { resolveLayerMaxZoom } from './zoom-utils';
+import { chartExtent } from './chart-bounds';
 
 // ** Freeboard WMS Chart **
 @Component({
@@ -118,6 +119,7 @@ export class WmsChartLayerComponent implements OnDestroy {
         zIndex: this.zIndex(),
         minZoom: minZ,
         maxZoom: layerMaxZ,
+        extent: chartExtent(chart[1].bounds),
         opacity: chart[1].defaultOpacity ?? 1
       });
 

--- a/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
@@ -13,6 +13,7 @@ import TileLayer from 'ol/layer/Tile';
 import { MapComponent } from '../map.component';
 
 import { FBChart } from 'src/app/types';
+import { chartExtent } from './chart-bounds';
 import WMTS, { optionsFromCapabilities } from 'ol/source/WMTS';
 
 import WMTSCapabilities from 'ol/format/WMTSCapabilities';
@@ -94,6 +95,7 @@ export class WmtsChartLayerComponent implements OnDestroy {
         zIndex: this.zIndex(),
         minZoom: minZ,
         maxZoom: layerMaxZ,
+        extent: chartExtent(chart[1].bounds),
         opacity: chart[1].defaultOpacity ?? 1
       });
 

--- a/src/app/modules/map/ol/lib/charts/pmtiles-utils.ts
+++ b/src/app/modules/map/ol/lib/charts/pmtiles-utils.ts
@@ -7,6 +7,7 @@ import { SKChart } from 'src/app/modules/skresources';
 import VectorTileLayer from 'ol/layer/VectorTile';
 import VectorTileSource from 'ol/source/VectorTile';
 import { MVT } from 'ol/format';
+import { Extent } from 'ol/extent';
 
 // create a PMTile WebGLtile layer
 export function initPMTilesWebGLLayer(
@@ -51,7 +52,8 @@ export function initPMTilesWebGLLayer(
 // create a PMTile XYZ source TileLayer
 export function initPMTilesXYZLayer(
   chart: SKChart,
-  zIndex: number
+  zIndex: number,
+  extent?: Extent
 ): TileLayer<XYZ> {
   const tiles = new pmtiles.PMTiles(chart.url);
 
@@ -87,6 +89,7 @@ export function initPMTilesXYZLayer(
       minZoom: chart.minZoom
     }),
     zIndex: zIndex,
+    extent,
     opacity: chart.defaultOpacity ?? 1
   });
 }
@@ -94,7 +97,8 @@ export function initPMTilesXYZLayer(
 // create a PMTile Vector layer
 export function initPMTilesVectorLayer(
   chart: SKChart,
-  zIndex: number
+  zIndex: number,
+  extent?: Extent
 ): VectorTileLayer {
   const tiles = new pmtiles.PMTiles(chart.url);
 
@@ -132,6 +136,7 @@ export function initPMTilesVectorLayer(
       tileLoadFunction: loader
     }),
     zIndex: zIndex,
+    extent,
     opacity: chart.defaultOpacity ?? 1,
     minZoom: chart.minZoom,
     maxZoom: chart.maxZoom,


### PR DESCRIPTION
Uses the chart bounds metadata already provided by Signal K to set the OpenLayers layer extent on all tile layer types. This way OL simply won't request tiles outside the chart's coverage area.

Applies to: XYZ raster, TileJSON, WMS, WMTS, PMTiles (raster + vector), and MVT/PBF vector tile layers. The S-57 vector layer already did this via VectorLayerStyleFactory, so this aligns the rest.

Not tested beyond a type-check. Happy to refine.