### PR TITLE
fix(lookahead): Center map based on COG instead of north of vessel.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1323,7 +1323,7 @@ export class AppComponent {
    * Center the map relative to the vessel position
    */
   protected centerVessel() {
-    const pos = this.app.calcMapCenter(this.app.data.vessels.active.position);
+    const pos = this.app.calcMapCenter();
     this.centerAndZoom(pos);
   }
 

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -220,6 +220,9 @@ export class AppFacade extends InfoService {
   selfTrail = signal<LineString>([]); // vessel trail from indexedDB
   selfTrailFromServer = signal<LineString>([]); // vessel trail from server
   mapExtent = signal<Extent>([]); // map viewport extent
+  mapViewTopCenter = signal<Position>([0, 0]); // top-centre of viewport (rotation-aware)
+  mapViewRightCenter = signal<Position>([0, 0]); // right-centre of viewport (rotation-aware)
+  mapViewRotation = signal<number>(0); // OL view rotation in radians (CCW positive)
 
   protected signalk = inject(SignalKClient);
   private worker = inject(SKWorkerService);
@@ -696,18 +699,31 @@ export class AppFacade extends InfoService {
     if (cog === null) {
       return this.data.vessels.active.position;
     }
-    const ctrOfExtent: Position = GeoUtils.centreOfPolygon([
-      this.mapExtent().slice(0, 2) as Position,
-      [this.mapExtent()[0], this.mapExtent()[3]],
-      this.mapExtent().slice(-2) as Position,
-      [this.mapExtent()[2], this.mapExtent()[1]],
-      this.mapExtent().slice(0, 2) as Position
-    ]);
-    const offsetDistance =
-      GeoUtils.distanceTo(this.mapExtent().slice(0, 2) as Position, [
-        this.mapExtent()[0],
-        ctrOfExtent[1]
-      ]) * (this.config.map.centerOffset ?? 0.5);
+    // Compute the geodetic distance from the viewport centre to the screen
+    // edge in the exact CoG direction. This correctly handles any map rotation
+    // mode (north-up or heading-up) and any screen aspect ratio.
+    //
+    // In OL, a CW bearing β has projected-space direction (sin β, cos β).
+    // With OL view rotation rot (CCW), the screen-space components are:
+    //   sx = sin(β + rot)  (rightward)   sy = cos(β + rot)  (upward)
+    // The edge of the viewport rectangle lies at min(hw/|sx|, hh/|sy|)
+    // where hw = geodetic half-width, hh = geodetic half-height.
+    const hh = GeoUtils.distanceTo(
+      this.config.map.center as Position,
+      this.mapViewTopCenter()
+    );
+    const hw = GeoUtils.distanceTo(
+      this.config.map.center as Position,
+      this.mapViewRightCenter()
+    );
+    const rot = this.mapViewRotation();
+    const sx = Math.abs(Math.sin(cog + rot));
+    const sy = Math.abs(Math.cos(cog + rot));
+    const edgeDistance = Math.min(
+      sx > 1e-10 ? hw / sx : Infinity,
+      sy > 1e-10 ? hh / sy : Infinity
+    );
+    const offsetDistance = edgeDistance * (this.config.map.centerOffset ?? 0.5);
     return GeoUtils.destCoordinate(
       this.data.vessels.active.position,
       cog,

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -689,7 +689,13 @@ export class AppFacade extends InfoService {
   /** Calculate the position to center the map.
    * Tales into account the amount of offset to apply
    */
-  calcMapCenter(ref: Position): Position {
+  calcMapCenter(): Position {
+    const cog =
+      this.data.vessels.active.cogTrue ??
+      this.data.vessels.active.headingTrue;
+    if (cog === null) {
+      return this.data.vessels.active.position;
+    }
     const ctrOfExtent: Position = GeoUtils.centreOfPolygon([
       this.mapExtent().slice(0, 2) as Position,
       [this.mapExtent()[0], this.mapExtent()[3]],
@@ -702,14 +708,11 @@ export class AppFacade extends InfoService {
         this.mapExtent()[0],
         ctrOfExtent[1]
       ]) * (this.config.map.centerOffset ?? 0.5);
-    const pos: Position = true //this.app.config.display.mapCenterOffset ?
-      ? GeoUtils.destCoordinate(
-          this.data.vessels.active.position,
-          0,
-          offsetDistance
-        )
-      : ref;
-    return pos;
+    return GeoUtils.destCoordinate(
+      this.data.vessels.active.position,
+      cog,
+      offsetDistance
+    );
   }
 
   /**

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -1394,7 +1394,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   // center map to active vessel position
   private centerVessel() {
-    const pos = this.app.calcMapCenter(this.dfeat.active.position);
+    const pos = this.app.calcMapCenter();
     this.mapCenterPositon.update(() => pos);
   }
 

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -557,6 +557,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
     this.app.config.map.zoomLevel = e.zoom;
 
     this.app.mapExtent.update(() => e.extent);
+    this.app.mapViewTopCenter.update(() => e.topCenter as Position);
+    this.app.mapViewRightCenter.update(() => e.rightCenter as Position);
+    this.app.mapViewRotation.update(() => e.rotation);
     this.app.config.map.center = e.lonlat as Position;
 
     this.drawVesselLines();

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -30,6 +30,12 @@ export interface FBMapEvent extends MapEvent {
   zoomChanged: boolean;
   extent: Extent;
   projCode: string;
+  /** Geographic coords of the viewport's top-centre pixel (rotation-aware) */
+  topCenter: Coordinate;
+  /** Geographic coords of the viewport's right-centre pixel (rotation-aware) */
+  rightCenter: Coordinate;
+  /** OL view rotation in radians (CCW positive) at the time of the event */
+  rotation: number;
 }
 
 export interface FBClickEvent extends MapBrowserEvent<PointerEvent> {
@@ -293,7 +299,7 @@ export class MapComponent implements OnInit, OnDestroy {
     this.mapMoveEnd.emit(this.augmentMoveEvent(event));
   };
 
-  // ** add {lonlat, zoom, extent, projection code} fields to event
+  // ** add {lonlat, zoom, extent, projCode, topCenter, rightCenter, rotation} fields to event
   private augmentMoveEvent(event: MapEvent) {
     const zoom = this.map.getView().getZoom();
     return Object.assign(event, {
@@ -301,7 +307,10 @@ export class MapComponent implements OnInit, OnDestroy {
       zoom: zoom,
       zoomChanged: this.zoomAtStart !== zoom,
       extent: this.getMapExtent(),
-      projCode: this.map.getView().getProjection().getCode()
+      projCode: this.map.getView().getProjection().getCode(),
+      topCenter: this.getMapViewTopCenter(),
+      rightCenter: this.getMapViewRightCenter(),
+      rotation: this.map.getView().getRotation()
     });
   }
 
@@ -365,6 +374,46 @@ export class MapComponent implements OnInit, OnDestroy {
       v.calculateExtent(this.map.getSize()),
       mrid,
       'EPSG:4326'
+    );
+  }
+
+  /**
+   * Returns the geographic coordinates [lon, lat] of the viewport's
+   * top-centre pixel, correctly accounting for map rotation.
+   * In OL, positive rotation is CCW. The projected-space unit vector
+   * pointing "up" on screen is (-sin θ, cos θ).
+   */
+  getMapViewTopCenter(): Coordinate {
+    if (!this.map) {
+      return [0, 0];
+    }
+    const v = this.map.getView();
+    const center = v.getCenter();
+    const rot = v.getRotation();
+    const hh = (this.map.getSize()[1] / 2) * v.getResolution();
+    return toLonLat(
+      [center[0] - hh * Math.sin(rot), center[1] + hh * Math.cos(rot)],
+      v.getProjection()
+    );
+  }
+
+  /**
+   * Returns the geographic coordinates [lon, lat] of the viewport's
+   * right-centre pixel, correctly accounting for map rotation.
+   * In OL, positive rotation is CCW. The projected-space unit vector
+   * pointing "right" on screen is (cos θ, sin θ).
+   */
+  getMapViewRightCenter(): Coordinate {
+    if (!this.map) {
+      return [0, 0];
+    }
+    const v = this.map.getView();
+    const center = v.getCenter();
+    const rot = v.getRotation();
+    const hw = (this.map.getSize()[0] / 2) * v.getResolution();
+    return toLonLat(
+      [center[0] + hw * Math.cos(rot), center[1] + hw * Math.sin(rot)],
+      v.getProjection()
     );
   }
 }


### PR DESCRIPTION
Disclaimer: Maybe I missunderstood the lookahead mode introduced in #285.

Currently, the lookahead mode centers the map north of the vessel.

This patch calculates the map center based of the COG since I expected the lookahead mode to use the COG/heading or course to determine the center offset.

Addtionally, this patch uses a different calculation for the base offset distance. Instead of using the tiles' extents (which can be a lot bigger than the viewport's extents if the viewport is rotated) it uses the viewport corners to determine the extends. In head-up mode, this places the vessel nicely in the lower part of the screen. In north-up mode, the vessel moves on a rectangle with same the aspect ratio as the screen.