### PR TITLE
fix: Use correct css class for scale line

### DIFF
--- a/src/app/modules/map/mapconfig.ts
+++ b/src/app/modules/map/mapconfig.ts
@@ -6,7 +6,6 @@ export const mapControls = [
   {
     name: 'scaleline',
     options: {
-      className: 'ol-scale-line',
       bar: true,
       steps: 2,
       text: false,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -41,7 +41,7 @@ b { font-weight: 500; }
     animation-iteration-count: infinite;
 }
 
-.ol-scale-line {
+.ol-scale-bar {
     bottom: unset;
     top: 10px;
     left: 180px;


### PR DESCRIPTION
This fixes the positioning of the middle label and the second bar of the scale bar.

Removing the css class name from the options reverts it to the openlayers default.

Broken:
<img width="165" height="64" alt="Screenshot From 2026-04-11 10-40-53" src="https://github.com/user-attachments/assets/5e332580-3b8b-445e-82e3-f755b7c26e1b" />

Fixed:
<img width="165" height="64" alt="Screenshot From 2026-04-11 10-42-26" src="https://github.com/user-attachments/assets/1bd56aa5-4953-46a5-aa9c-36cd30cadbb4" />