### PR TITLE
feat: Customizable line styles

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -168,13 +168,13 @@ export function cleanConfig(
       laylines: false,
       selfLines: {
         cog: {
-          length: 10, // (minutes) length = cogLine * sog
+          lineLength: { kind: 'time', value: 10 },
           color: 'rgba(204, 12, 225, 0.7)',
           weight: 1,
           dash: 'none'
         },
         heading: {
-          length: -1, // mode for display of heading line -1 = default
+          lineLength: { kind: 'distance', value: 1 },
           color: 'rgba(221, 99, 0, 0.5)',
           weight: 4,
           dash: 'none'
@@ -220,15 +220,20 @@ export function cleanConfig(
       settings.vessels.rangeCirclesDistance = 1000;
     }
     if (typeof settings.vessels.selfLines === 'undefined') {
+      const oldCogLine = (settings as any).vessels.cogLine;
+      const oldHeadingSize = (settings as any).vessels.headingLineSize;
       settings.vessels.selfLines = {
         cog: {
-          length: (settings as any).vessels.cogLine ?? 10,
+          lineLength: { kind: 'time', value: oldCogLine ?? 10 },
           color: 'rgba(204, 12, 225, 0.7)',
           weight: 1,
           dash: 'none'
         },
         heading: {
-          length: (settings as any).vessels.headingLineSize ?? -1,
+          lineLength: {
+            kind: 'distance',
+            value: oldHeadingSize != null && oldHeadingSize > 0 ? oldHeadingSize : 1
+          },
           color: 'rgba(221, 99, 0, 0.5)',
           weight: 4,
           dash: 'none'
@@ -237,6 +242,17 @@ export function cleanConfig(
       // @todo remove (implemented) v2.22.2
       delete (settings as any).vessels.cogLine;
       delete (settings as any).vessels.headingLineSize;
+    } else if (typeof (settings.vessels.selfLines.cog as any).length !== 'undefined') {
+      // migrate from upstream v2.22 format (length:number) to lineLength:ILineLengthDef
+      const oldCog = (settings.vessels.selfLines.cog as any).length as number;
+      const oldHd = (settings.vessels.selfLines.heading as any).length as number;
+      settings.vessels.selfLines.cog.lineLength = { kind: 'time', value: oldCog ?? 10 };
+      settings.vessels.selfLines.heading.lineLength = {
+        kind: 'distance',
+        value: oldHd != null && oldHd > 0 ? oldHd : 1
+      };
+      delete (settings.vessels.selfLines.cog as any).length;
+      delete (settings.vessels.selfLines.heading as any).length;
     }
     if (typeof settings.vessels.routing === 'undefined') {
       settings.vessels.routing = {
@@ -462,13 +478,13 @@ export function defaultConfig(): IAppConfig {
       laylines: false,
       selfLines: {
         cog: {
-          length: 10, // (minutes) length = cogLine * sog
+          lineLength: { kind: 'time', value: 10 },
           color: 'rgba(204, 12, 225, 0.7)',
           weight: 1,
           dash: 'none'
         },
         heading: {
-          length: -1, // mode for display of heading line -1 = default
+          lineLength: { kind: 'distance', value: 1 },
           color: 'rgba(221, 99, 0, 0.5)',
           weight: 4,
           dash: 'none'

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -204,6 +204,16 @@ export function cleanConfig(
         defaultRoute: { color: 'green', weight: 2, dash: 'long' },
         activeSegment: { color: 'gray', weight: 1, dash: 'medium' },
         destination: { color: 'rgba(221, 149, 0, 1)', weight: 2, dash: 'none' }
+      },
+      selfTrailStyle: {
+        color: 'rgb(252, 3, 132)',
+        weight: 1,
+        dash: 'short'
+      },
+      aisTrackStyle: {
+        color: 'rgb(255, 0, 255)',
+        weight: 1,
+        dash: 'short'
       }
     };
   } else {
@@ -260,6 +270,20 @@ export function cleanConfig(
         defaultRoute: { color: 'green', weight: 2, dash: 'long' },
         activeSegment: { color: 'gray', weight: 1, dash: 'medium' },
         destination: { color: 'rgba(221, 149, 0, 1)', weight: 2, dash: 'none' }
+      };
+    }
+    if (typeof settings.vessels.selfTrailStyle === 'undefined') {
+      settings.vessels.selfTrailStyle = {
+        color: 'rgb(252, 3, 132)',
+        weight: 1,
+        dash: 'short'
+      };
+    }
+    if (typeof settings.vessels.aisTrackStyle === 'undefined') {
+      settings.vessels.aisTrackStyle = {
+        color: 'rgb(255, 0, 255)',
+        weight: 1,
+        dash: 'short'
       };
     }
   }
@@ -515,6 +539,16 @@ export function defaultConfig(): IAppConfig {
         defaultRoute: { color: 'green', weight: 2, dash: 'long' },
         activeSegment: { color: 'gray', weight: 1, dash: 'medium' },
         destination: { color: 'rgba(221, 149, 0, 1)', weight: 2, dash: 'none' }
+      },
+      selfTrailStyle: {
+        color: 'rgb(252, 3, 132)',
+        weight: 1,
+        dash: 'short'
+      },
+      aisTrackStyle: {
+        color: 'rgb(255, 0, 255)',
+        weight: 1,
+        dash: 'short'
       }
     },
     resources: {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -198,6 +198,12 @@ export function cleanConfig(
         lastHour: '5s',
         next23: '1m',
         beyond24: '5m'
+      },
+      routing: {
+        activeRoute: { color: 'blue', weight: 4, dash: 'none' },
+        defaultRoute: { color: 'green', weight: 2, dash: 'long' },
+        activeSegment: { color: 'gray', weight: 1, dash: 'medium' },
+        destination: { color: 'rgba(221, 149, 0, 1)', weight: 2, dash: 'none' }
       }
     };
   } else {
@@ -231,6 +237,14 @@ export function cleanConfig(
       // @todo remove (implemented) v2.22.2
       delete (settings as any).vessels.cogLine;
       delete (settings as any).vessels.headingLineSize;
+    }
+    if (typeof settings.vessels.routing === 'undefined') {
+      settings.vessels.routing = {
+        activeRoute: { color: 'blue', weight: 4, dash: 'none' },
+        defaultRoute: { color: 'green', weight: 2, dash: 'long' },
+        activeSegment: { color: 'gray', weight: 1, dash: 'medium' },
+        destination: { color: 'rgba(221, 149, 0, 1)', weight: 2, dash: 'none' }
+      };
     }
   }
 
@@ -479,6 +493,12 @@ export function defaultConfig(): IAppConfig {
         lastHour: '5s',
         next23: '1m',
         beyond24: '5m'
+      },
+      routing: {
+        activeRoute: { color: 'blue', weight: 4, dash: 'none' },
+        defaultRoute: { color: 'green', weight: 2, dash: 'long' },
+        activeSegment: { color: 'gray', weight: 1, dash: 'medium' },
+        destination: { color: 'rgba(221, 149, 0, 1)', weight: 2, dash: 'none' }
       }
     },
     resources: {

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -54,6 +54,7 @@ import {
   LineStyleDash,
   LineStyleDef
 } from './modules/settings/components/linestyle-select.component';
+import { lineDashFor, DASH_PATTERNS } from './modules/map/ol/lib/util';
 
 /** Parent Window message */
 interface ParentMessage {
@@ -385,24 +386,20 @@ export class AppFacade extends InfoService {
     this.doPostConfigLoad();
   }
 
-  // line dash style helpers
+  // line dash style helpers — SVG stroke-dasharray strings derived from DASH_PATTERNS
   get lineDashMap() {
-    return new Map([
-      ['none', 'none'],
-      ['short', '2 2'],
-      ['medium', '4 4'],
-      ['long', '8 4'],
-      ['alt', '8 4 2 4']
-    ]);
+    return new Map(
+      Object.entries(DASH_PATTERNS).map(([key, arr]) => [
+        key,
+        arr.length === 0 ? 'none' : arr.join(' ')
+      ])
+    );
   }
 
   // line dash style format helpers
   formatLineDashArray(value: LineStyleDash): number[] | null {
-    return value === 'none'
-      ? null
-      : Array.from(this.lineDashMap.get(value))
-          .filter((i) => i !== ' ')
-          .map((i) => Number(i));
+    const arr = lineDashFor(value);
+    return arr.length === 0 ? null : arr;
   }
 
   /** Initialise and raise "settings$.load" event */

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -397,8 +397,8 @@ export class AppFacade extends InfoService {
   }
 
   // line dash style format helpers
-  formatLineDashArray(value: LineStyleDash): number[] | null {
-    const arr = lineDashFor(value);
+  formatLineDashArray(value: LineStyleDash, weight = 1): number[] | null {
+    const arr = lineDashFor(value, weight);
     return arr.length === 0 ? null : arr;
   }
 
@@ -422,7 +422,8 @@ export class AppFacade extends InfoService {
             color: this.config.vessels.selfLines.cog.color,
             width: this.config.vessels.selfLines.cog.weight,
             lineDash: this.formatLineDashArray(
-              this.config.vessels.selfLines.cog.dash
+              this.config.vessels.selfLines.cog.dash,
+              this.config.vessels.selfLines.cog.weight
             )
           }
         },
@@ -432,7 +433,8 @@ export class AppFacade extends InfoService {
             color: this.config.vessels.selfLines.heading.color,
             width: this.config.vessels.selfLines.heading.weight,
             lineDash: this.formatLineDashArray(
-              this.config.vessels.selfLines.heading.dash
+              this.config.vessels.selfLines.heading.dash,
+              this.config.vessels.selfLines.heading.weight
             )
           }
         }

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -249,7 +249,7 @@
   <!-- Routes -->
   <fb-routes
     [routes]="skres.routes()"
-    [routeStyles]="featureStyles.route"
+    [routeStyles]="routeFeatureStyles"
     [activeRoute]="activeRoute"
     [darkMode]="app.uiConfig().invertColor"
     [labelMinZoom]="this.app.config.map.labelsMinZoom"
@@ -661,7 +661,9 @@
   @if (anchor.raised() && dfeat.navData.position) {
     @if (dfeat.navData.startPosition) {
       <fb-xte-path
-        [color]=""
+        [color]="app.config.vessels.routing.activeSegment.color"
+        [weight]="app.config.vessels.routing.activeSegment.weight"
+        [dash]="app.config.vessels.routing.activeSegment.dash"
         [startPosition]="dfeat.navData.startPosition"
         [destPosition]="dfeat.navData.position"
         [zIndex]="340"
@@ -696,7 +698,7 @@
         [vesselPosition]="dfeat.active.position"
         [showMarker]="!app.data.activeWaypoint"
         [markerName]="course.courseData().destPointName"
-        [bearingStyles]="featureStyles.destination"
+        [bearingStyles]="destinationFeatureStyles"
         [labelMinZoom]="this.app.config.map.labelsMinZoom"
         [mapZoom]="mapZoomLevel()"
         [zIndex]="335"

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -729,7 +729,7 @@
     </fb-range-circles>
   }
 
-  @if (app.config.vessels.selfLines.cog.length !== 0) {
+  @if (app.config.vessels.selfLines.cog.lineLength.value !== 0) {
     <fb-heading-line
       [coords]="vesselLines().heading"
       [lineStyle]="app.selfLines().heading"
@@ -739,10 +739,10 @@
     </fb-heading-line>
   }
 
-  @if (app.config.vessels.selfLines.cog.length !== 0) {
+  @if (app.config.vessels.selfLines.cog.lineLength.value !== 0) {
     <fb-cog-line
       [coords]="vesselLines().cog"
-      [cogTime]="app.config.vessels.selfLines.cog.length"
+      [cogTime]="app.config.vessels.selfLines.cog.lineLength.value"
       [lineStyle]="app.selfLines().cog"
       [units]="app.config.units.distance"
       [darkMode]="app.uiConfig().invertColor"

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -222,6 +222,7 @@
       [updateIds]="skstream.aisStatus().updated"
       [removeIds]="skstream.aisStatus().expired"
       [mapZoom]="mapZoomLevel()"
+      [aisTrackStyle]="aisTrackStyleConfig"
       zIndex="110"
     >
     </ais-targets-track>
@@ -781,6 +782,7 @@
       [localTrail]="app.selfTrail()"
       [serverTrail]="app.selfTrailFromServer()"
       [trailStyles]=""
+      [selfTrailStyle]="selfTrailStyleConfig"
       [zIndex]="990"
     >
     </fb-vessel-trail>

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -41,13 +41,14 @@ import { CoordsPipe } from 'src/app/lib/pipes';
 
 import { computeDestinationPoint, getGreatCircleBearing } from 'geolib';
 import { toLonLat } from 'ol/proj';
-import { Style, Stroke, Fill } from 'ol/style';
+import { Style, Stroke, Fill, Circle, Text } from 'ol/style';
 import { Collection, Feature } from 'ol';
 import { Feature as GeoJsonFeature } from 'geojson';
 
 import { Convert } from 'src/app/lib/convert';
 import { GeoUtils, Angle } from 'src/app/lib/geoutils';
 import { LineString, MultiLineString, Position } from 'src/app/types';
+import { lineDashFor } from './ol/lib/util';
 
 import { AppFacade } from 'src/app/app.facade';
 
@@ -213,6 +214,54 @@ export class FBMapComponent implements OnInit, OnDestroy {
   protected mapRotation = signal<number>(0);
 
   protected showNoteslayer = signal<boolean>(false); //control notes layer display
+
+  /** Route line styles built dynamically from config */
+  protected get routeFeatureStyles() {
+    const r = this.app.config.vessels.routing;
+    const defDash = lineDashFor(r.defaultRoute.dash, r.defaultRoute.weight);
+    return {
+      active: new Style({
+        stroke: new Stroke({
+          color: r.activeRoute.color,
+          width: r.activeRoute.weight,
+          lineDash: lineDashFor(r.activeRoute.dash, r.activeRoute.weight)
+        })
+      }),
+      default: new Style({
+        stroke: new Stroke({
+          color: r.defaultRoute.color,
+          width: r.defaultRoute.weight,
+          lineDash: defDash.length ? defDash : undefined
+        }),
+        text: new Text({ text: '', offsetY: 10 })
+      })
+    };
+  }
+
+  /** Destination bearing-line styles built dynamically from config */
+  protected get destinationFeatureStyles() {
+    const d = this.app.config.vessels.routing.destination;
+    const dash = lineDashFor(d.dash, d.weight);
+    return {
+      ...destinationStyles,
+      line: [
+        new Style({ stroke: new Stroke({ color: 'white', width: d.weight + 4 }) }),
+        new Style({
+          image: new Circle({
+            radius: 5,
+            stroke: new Stroke({ width: 2, color: 'white' }),
+            fill: new Fill({ color: d.color })
+          }),
+          stroke: new Stroke({
+            color: d.color,
+            width: d.weight,
+            lineDash: dash.length ? dash : undefined
+          }),
+          text: new Text({ text: '', offsetY: -29 })
+        })
+      ]
+    };
+  }
 
   // ** map feature styles
   protected featureStyles = {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -262,6 +262,16 @@ export class FBMapComponent implements OnInit, OnDestroy {
     };
   }
 
+  /** Self trail style — spread to create new reference so OnPush child detects changes */
+  protected get selfTrailStyleConfig() {
+    return { ...this.app.config.vessels.selfTrailStyle };
+  }
+
+  /** AIS track style — spread to create new reference so OnPush child detects changes */
+  protected get aisTrackStyleConfig() {
+    return { ...this.app.config.vessels.aisTrackStyle };
+  }
+
   // ** map feature styles
   protected featureStyles = {
     route: routeStyles,

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -47,7 +47,7 @@ import { Feature as GeoJsonFeature } from 'geojson';
 
 import { Convert } from 'src/app/lib/convert';
 import { GeoUtils, Angle } from 'src/app/lib/geoutils';
-import { LineString, MultiLineString, Position } from 'src/app/types';
+import { ILineLengthDef, LineString, MultiLineString, Position } from 'src/app/types';
 import { lineDashFor } from './ol/lib/util';
 
 import { AppFacade } from 'src/app/app.facade';
@@ -91,7 +91,6 @@ import { SKPosition } from 'src/app/types';
 import {
   FBMapEvent,
   FBPointerEvent,
-  zoomOffsetLevel,
   MapComponent
 } from './ol/lib/map.component';
 import { FeatureLike } from 'ol/Feature';
@@ -1473,12 +1472,18 @@ export class FBMapComponent implements OnInit, OnDestroy {
     this.mapCenterPositon.update(() => pos);
   }
 
+  /** Compute a line length in metres from an ILineLengthDef */
+  private lineLengthToMeters(ll: ILineLengthDef, sogMs: number): number {
+    const resolution = this.olMap?.getMap()?.getView()?.getResolution() ?? 1;
+    switch (ll.kind) {
+      case 'time':     return sogMs * ll.value * 60;
+      case 'distance': return Convert.nauticalMilesToKm(ll.value) * 1000;
+      case 'pixels':   return ll.value * resolution;
+    }
+  }
+
   /** construct vessel lines for rendering */
   protected drawVesselLines(vesselUpdate = false) {
-    const z = this.mapZoomLevel();
-    const offset = z < 29 ? zoomOffsetLevel[Math.floor(z)] : 60;
-    const wMax = 10; // max line length
-
     // update vessel trail
     if (vesselUpdate) {
       this.app.addToSelfTrail(this.dfeat.self.position);
@@ -1489,31 +1494,31 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
     // render cog, heading, twd, awa for focused vessel
     this.vesselLines.update(() => {
-      const cog = this.dfeat.active.vectors.cog ?? [];
-
       const sog = this.dfeat.active.sog || 0;
-      let hl = 0;
-      if (this.app.config.vessels.selfLines.heading.length === -1) {
-        hl = (sog > wMax ? wMax : sog) * offset;
-      } else {
-        hl =
-          Convert.nauticalMilesToKm(
-            this.app.config.vessels.selfLines.heading.length
-          ) * 1000;
-      }
+      const pos = this.dfeat.active.position;
+
+      // Heading line
+      const hl = this.lineLengthToMeters(
+        this.app.config.vessels.selfLines.heading.lineLength, sog
+      );
       const heading = [
-        this.dfeat.active.position,
-        GeoUtils.rhumbDestination(
-          this.dfeat.active.position,
-          this.dfeat.active.orientation,
-          hl
-        )
+        pos,
+        GeoUtils.rhumbDestination(pos, this.dfeat.active.orientation, hl)
       ];
 
-      return {
-        cog: cog,
-        heading: heading
-      };
+      // COG line — computed in main thread so all unit kinds work (incl. pixels)
+      const cogAngle = this.dfeat.active.cog;
+      let cog: LineString = [];
+      if (cogAngle != null && pos) {
+        const cl = this.lineLengthToMeters(
+          this.app.config.vessels.selfLines.cog.lineLength, sog
+        );
+        if (cl > 0) {
+          cog = [pos, GeoUtils.rhumbDestination(pos, cogAngle, cl)];
+        }
+      }
+
+      return { cog, heading };
     });
   }
 

--- a/src/app/modules/map/ol/lib/navigation/layer-bearing-line.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-bearing-line.component.ts
@@ -50,8 +50,7 @@ export class BearingLineComponent implements OnInit, OnDestroy, OnChanges {
   protected markerName = input<string>('');
 
   @Input() mapZoom = 10;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  @Input() bearingStyles: { [key: string]: any };
+  protected bearingStyles = input<{ [key: string]: Style | Style[] }>();
   @Input() opacity: number;
   @Input() visible: boolean;
   @Input() extent: Extent;
@@ -73,6 +72,7 @@ export class BearingLineComponent implements OnInit, OnDestroy, OnChanges {
       this.markerPosition();
       this.vesselPosition();
       this.showMarker();
+      this.bearingStyles();
       this.parseValues();
       if (this.source) {
         this.source.clear();
@@ -167,8 +167,8 @@ export class BearingLineComponent implements OnInit, OnDestroy, OnChanges {
 
   // build target style
   buildStyle(key: string): Style | Style[] {
-    if (this.bearingStyles && this.bearingStyles[key]) {
-      return this.bearingStyles[key];
+    if (this.bearingStyles() && this.bearingStyles()[key]) {
+      return this.bearingStyles()[key];
     } else {
       if (this.layerProperties && this.layerProperties.style) {
         return this.layerProperties.style;

--- a/src/app/modules/map/ol/lib/navigation/layer-xte-path.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-xte-path.component.ts
@@ -19,7 +19,7 @@ import { Style, Stroke, Fill } from 'ol/style';
 import { LineString } from 'ol/geom';
 import { MapComponent } from '../map.component';
 import { Extent, Coordinate } from '../models';
-import { fromLonLatArray, mapifyCoords } from '../util';
+import { fromLonLatArray, mapifyCoords, lineDashFor } from '../util';
 import { AsyncSubject } from 'rxjs';
 
 // ** Freeboard XTE path component **
@@ -43,6 +43,8 @@ export class XTEPathComponent implements OnInit, OnDestroy, OnChanges {
   protected startPosition = input<Coordinate>();
   protected destPosition = input<Coordinate>();
   protected color = input<string>();
+  protected weight = input<number>();
+  protected dash = input<string>();
 
   @Input() opacity: number;
   @Input() visible: boolean;
@@ -64,6 +66,8 @@ export class XTEPathComponent implements OnInit, OnDestroy, OnChanges {
       this.startPosition();
       this.destPosition();
       this.color();
+      this.weight();
+      this.dash();
       this.parseValues();
       if (this.source) {
         this.source.clear();
@@ -141,11 +145,12 @@ export class XTEPathComponent implements OnInit, OnDestroy, OnChanges {
     } else {
       // default style
       const color = this.color() ?? 'gray';
+      const ld = lineDashFor(this.dash() ?? 'medium', this.weight() ?? 1);
       cs = new Style({
         stroke: new Stroke({
-          width: 1,
+          width: this.weight() ?? 1,
           color: color,
-          lineDash: [5, 5]
+          lineDash: ld.length ? ld : [5, 5]
         }),
         fill: new Fill({
           color: 'rgba(255,0,0,.2)'

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets-track.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets-track.component.ts
@@ -9,8 +9,9 @@ import { Feature } from 'ol';
 import { Style, Stroke } from 'ol/style';
 import { MultiLineString } from 'ol/geom';
 import { MapComponent } from '../map.component';
-import { fromLonLatArray, mapifyCoords } from '../util';
+import { fromLonLatArray, mapifyCoords, lineDashFor } from '../util';
 import { AISBaseLayerComponent } from './ais-base.component';
+import { LineStyleConfig } from 'src/app/types';
 
 // ** Signal K AIS targets track  **
 @Component({
@@ -25,6 +26,7 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
   @Input() tracksMinZoom = 10;
   @Input() override mapZoom = 10;
   @Input() showTracks = true;
+  @Input() aisTrackStyle: LineStyleConfig;
 
   constructor(
     protected override mapComponent: MapComponent,
@@ -48,7 +50,7 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
       ) {
         this.reloadTracks();
       } else {
-        if (keys.includes('tracksMinZoom')) {
+        if (keys.includes('tracksMinZoom') || keys.includes('aisTrackStyle')) {
           if (typeof this.mapZoom !== 'undefined') {
             this.reloadTracks();
           }
@@ -138,10 +140,20 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
 
   // build track style
   buildStyle(id: string): Style {
-    const rgb = id.indexOf('aircraft') !== -1 ? '0, 0, 255' : '255, 0, 255';
-    let color =
-      this.mapZoom < this.tracksMinZoom ? `rgba(${rgb},0)` : `rgba(${rgb},1)`;
-    color = this.showTracks ? `rgba(${rgb},1)` : `rgba(${rgb},0)`;
+    const isAircraft = id.indexOf('aircraft') !== -1;
+    if (isAircraft) {
+      const visible = this.showTracks ? 1 : 0;
+      return new Style({
+        stroke: new Stroke({ width: 1, color: `rgba(0,0,255,${visible})`, lineDash: [2, 2] })
+      });
+    }
+    // vessel track — use configured style
+    const st = this.aisTrackStyle;
+    const color = this.showTracks
+      ? (st ? st.color : 'rgb(255, 0, 255)')
+      : 'rgba(0,0,0,0)';
+    const width = st ? st.weight : 1;
+    const lineDash = st ? lineDashFor(st.dash, st.weight) : [2, 2];
     if (this.layerProperties && this.layerProperties.style) {
       const cs = this.layerProperties.style.clone();
       const ls = cs.getStroke();
@@ -150,11 +162,7 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
       return cs;
     } else {
       return new Style({
-        stroke: new Stroke({
-          width: 1,
-          color: color,
-          lineDash: [2, 2]
-        })
+        stroke: new Stroke({ width, color, lineDash })
       });
     }
   }

--- a/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
@@ -3,7 +3,9 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
-  SimpleChanges
+  SimpleChanges,
+  effect,
+  input
 } from '@angular/core';
 import { Feature } from 'ol';
 import { Style, Stroke, Fill, Circle, RegularShape } from 'ol/style';
@@ -24,7 +26,7 @@ import { FBRoutes } from 'src/app/types';
   standalone: false
 })
 export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
-  @Input() routeStyles: { [key: string]: Style };
+  protected routeStyles = input<{ [key: string]: Style }>();
   @Input() activeRoute: string;
   @Input() routes: FBRoutes = [];
 
@@ -33,6 +35,13 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
     protected override changeDetectorRef: ChangeDetectorRef
   ) {
     super(mapComponent, changeDetectorRef);
+    effect(() => {
+      this.routeStyles();
+      if (this.source) {
+        this.source.clear();
+        this.parseFBRoutes(this.routes);
+      }
+    });
   }
 
   override ngOnInit() {
@@ -47,7 +56,7 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
       this.source.clear();
       if ('routes' in changes) {
         this.parseFBRoutes(changes['routes'].currentValue);
-      } else if ('activeRoute' in changes) {
+      } else {
         this.onActivateRoute();
       }
     }
@@ -86,7 +95,7 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
     const isActive = id === this.activeRoute;
     let ptFill: Fill;
 
-    if (typeof this.routeStyles === 'undefined') {
+    if (typeof this.routeStyles() === 'undefined') {
       if (this.layerProperties && this.layerProperties.style) {
         return this.layerProperties.style;
       } else {
@@ -103,15 +112,15 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
     }
 
     // line style
-    if (isActive && typeof this.routeStyles.active !== 'undefined') {
-      styles.push(this.routeStyles.active);
+    if (isActive && typeof this.routeStyles().active !== 'undefined') {
+      styles.push(this.routeStyles().active);
       ptFill = new Fill({
-        color: this.routeStyles.active.getStroke().getColor()
+        color: this.routeStyles().active.getStroke().getColor()
       });
     } else {
-      styles.push(this.routeStyles.default.clone());
+      styles.push(this.routeStyles().default.clone());
       ptFill = new Fill({
-        color: this.routeStyles.default.getStroke().getColor()
+        color: this.routeStyles().default.getStroke().getColor()
       });
     }
 

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -31,8 +31,9 @@ export const DASH_PATTERNS: Record<string, number[]> = {
   alt: [8, 4, 2, 4]
 };
 
-export function lineDashFor(dash: string): number[] {
-  return DASH_PATTERNS[dash] ?? [];
+export function lineDashFor(dash: string, weight = 1): number[] {
+  const pattern = DASH_PATTERNS[dash] ?? [];
+  return pattern.map(v => v * weight);
 }
 
 // Point | LineString | MultiLineString

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -22,6 +22,19 @@ export function osmSource() {
   return new OSM();
 }
 
+/** Named dash pattern → OL lineDash array (empty = solid) */
+export const DASH_PATTERNS: Record<string, number[]> = {
+  none: [],
+  short: [2, 2],
+  medium: [4, 4],
+  long: [8, 4],
+  alt: [8, 4, 2, 4]
+};
+
+export function lineDashFor(dash: string): number[] {
+  return DASH_PATTERNS[dash] ?? [];
+}
+
 // Point | LineString | MultiLineString
 export function fromLonLatArray(
   coords: Array<Array<Coordinate>> | Array<Coordinate> | Coordinate

--- a/src/app/modules/map/ol/lib/vessel/layer-vessel-trail.component.ts
+++ b/src/app/modules/map/ol/lib/vessel/layer-vessel-trail.component.ts
@@ -17,8 +17,9 @@ import { Style, Stroke } from 'ol/style';
 import { Geometry, MultiLineString, LineString } from 'ol/geom';
 import { MapComponent } from '../map.component';
 import { Extent, Coordinate } from '../models';
-import { fromLonLatArray, mapifyCoords } from '../util';
+import { fromLonLatArray, mapifyCoords, lineDashFor } from '../util';
 import { AsyncSubject } from 'rxjs';
+import { LineStyleConfig } from 'src/app/types';
 
 // ** Freeboard Vessel trail component **
 @Component({
@@ -41,6 +42,7 @@ export class VesselTrailComponent implements OnInit, OnDestroy, OnChanges {
   @Input() localTrail: Array<Coordinate>;
   @Input() serverTrail: Array<Array<Coordinate>>;
   @Input() trailStyles: { [key: string]: Style };
+  @Input() selfTrailStyle: LineStyleConfig;
   @Input() opacity: number;
   @Input() visible: boolean;
   @Input() extent: Extent;
@@ -99,9 +101,15 @@ export class VesselTrailComponent implements OnInit, OnDestroy, OnChanges {
             this.parseServerTrail();
           }
         }
-        if (key === 'trailStyles') {
+        if (key === 'trailStyles' || key === 'selfTrailStyle') {
           if (this.source) {
             this.parseTrails();
+            if (this.trailLocal) {
+              this.trailLocal.setStyle(this.buildStyle('local'));
+            }
+            if (this.trailServer) {
+              this.trailServer.setStyle(this.buildStyle('server'));
+            }
           }
         } else if (key === 'layerProperties') {
           this.layer.setProperties(properties, false);
@@ -176,9 +184,18 @@ export class VesselTrailComponent implements OnInit, OnDestroy, OnChanges {
   // build target style
   buildStyle(type = 'local'): Style {
     let cs: Style;
+    const st = this.selfTrailStyle;
     if (type === 'server') {
       if (this.trailStyles && this.trailStyles.server) {
         cs = this.trailStyles.server;
+      } else if (st) {
+        cs = new Style({
+          stroke: new Stroke({
+            color: st.color,
+            width: st.weight,
+            lineDash: lineDashFor(st.dash, st.weight)
+          })
+        });
       } else {
         cs = new Style({
           // default server
@@ -192,6 +209,14 @@ export class VesselTrailComponent implements OnInit, OnDestroy, OnChanges {
     } else {
       if (this.trailStyles && this.trailStyles.local) {
         cs = this.trailStyles.local;
+      } else if (st) {
+        cs = new Style({
+          stroke: new Stroke({
+            color: st.color,
+            width: st.weight,
+            lineDash: lineDashFor(st.dash, st.weight)
+          })
+        });
       } else {
         cs = new Style({
           // default local

--- a/src/app/modules/settings/components/linestyle-select.component.ts
+++ b/src/app/modules/settings/components/linestyle-select.component.ts
@@ -19,7 +19,7 @@ export interface LineStyleDef {
 export interface LineStyleConfig {
   color: string;
   weight: number;
-  dash: string;
+  dash: LineStyleDash;
 }
 
 export type LineStyleDash = 'none' | 'short' | 'medium' | 'long' | 'alt';

--- a/src/app/modules/settings/components/linestyle-select.component.ts
+++ b/src/app/modules/settings/components/linestyle-select.component.ts
@@ -174,7 +174,7 @@ export class LineStyleSelectComponent {
   ngOnInit() {}
 
   onSelectChange(opt: { key: string; value: any }) {
-    let d = this.app.formatLineDashArray(this._dash());
+    let d = this.app.formatLineDashArray(this._dash(), this._weight());
 
     this.selectionChange.emit({
       lineStyle: {

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -883,6 +883,45 @@
                 </div>
                 <div class="setting-card-row-item">
                   <fieldset>
+                    <legend>Trail &amp; Track Styles</legend>
+                    <div class="setting-card-row" style="padding-bottom: 10px">
+                      <div class="setting-card-row-item">
+                        <fieldset>
+                          <legend>Self Vessel Trail</legend>
+                          <div class="setting-card-row" style="padding-bottom: 10px">
+                            <div class="setting-card-row-item">
+                              <linestyle-select
+                                [color]="facade.settings.vessels.selfTrailStyle.color"
+                                [dash]="facade.settings.vessels.selfTrailStyle.dash"
+                                [weight]="facade.settings.vessels.selfTrailStyle.weight"
+                                (selectionChange)="onTrailStyle('self', $event)"
+                              ></linestyle-select>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                    <div class="setting-card-row" style="padding-bottom: 10px">
+                      <div class="setting-card-row-item">
+                        <fieldset>
+                          <legend>AIS Target Tracks</legend>
+                          <div class="setting-card-row" style="padding-bottom: 10px">
+                            <div class="setting-card-row-item">
+                              <linestyle-select
+                                [color]="facade.settings.vessels.aisTrackStyle.color"
+                                [dash]="facade.settings.vessels.aisTrackStyle.dash"
+                                [weight]="facade.settings.vessels.aisTrackStyle.weight"
+                                (selectionChange)="onTrailStyle('ais', $event)"
+                              ></linestyle-select>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+                <div class="setting-card-row-item">
+                  <fieldset>
                     <legend>Route &amp; Navigation Line Styles</legend>
                     <div class="setting-card-row" style="padding-bottom: 10px">
                       <div class="setting-card-row-item">

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -877,6 +877,79 @@
                 </div>
                 <div class="setting-card-row-item">
                   <fieldset>
+                    <legend>Route &amp; Navigation Line Styles</legend>
+                    <div class="setting-card-row" style="padding-bottom: 10px">
+                      <div class="setting-card-row-item">
+                        <fieldset>
+                          <legend>Active Route</legend>
+                          <div class="setting-card-row" style="padding-bottom: 10px">
+                            <div class="setting-card-row-item">
+                              <linestyle-select
+                                [color]="facade.settings.vessels.routing.activeRoute.color"
+                                [dash]="facade.settings.vessels.routing.activeRoute.dash"
+                                [weight]="facade.settings.vessels.routing.activeRoute.weight"
+                                (selectionChange)="onRouteStyle('activeRoute', $event)"
+                              ></linestyle-select>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                    <div class="setting-card-row" style="padding-bottom: 10px">
+                      <div class="setting-card-row-item">
+                        <fieldset>
+                          <legend>Other Routes</legend>
+                          <div class="setting-card-row" style="padding-bottom: 10px">
+                            <div class="setting-card-row-item">
+                              <linestyle-select
+                                [color]="facade.settings.vessels.routing.defaultRoute.color"
+                                [dash]="facade.settings.vessels.routing.defaultRoute.dash"
+                                [weight]="facade.settings.vessels.routing.defaultRoute.weight"
+                                (selectionChange)="onRouteStyle('defaultRoute', $event)"
+                              ></linestyle-select>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                    <div class="setting-card-row" style="padding-bottom: 10px">
+                      <div class="setting-card-row-item">
+                        <fieldset>
+                          <legend>Active Segment</legend>
+                          <div class="setting-card-row" style="padding-bottom: 10px">
+                            <div class="setting-card-row-item">
+                              <linestyle-select
+                                [color]="facade.settings.vessels.routing.activeSegment.color"
+                                [dash]="facade.settings.vessels.routing.activeSegment.dash"
+                                [weight]="facade.settings.vessels.routing.activeSegment.weight"
+                                (selectionChange)="onRouteStyle('activeSegment', $event)"
+                              ></linestyle-select>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                    <div class="setting-card-row" style="padding-bottom: 10px">
+                      <div class="setting-card-row-item">
+                        <fieldset>
+                          <legend>Destination Bearing Line</legend>
+                          <div class="setting-card-row" style="padding-bottom: 10px">
+                            <div class="setting-card-row-item">
+                              <linestyle-select
+                                [color]="facade.settings.vessels.routing.destination.color"
+                                [dash]="facade.settings.vessels.routing.destination.dash"
+                                [weight]="facade.settings.vessels.routing.destination.weight"
+                                (selectionChange)="onRouteStyle('destination', $event)"
+                              ></linestyle-select>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+                <div class="setting-card-row-item">
+                  <fieldset>
                     <legend>
                       <mat-checkbox
                         [(ngModel)]="facade.settings.vessels.rangeCircles"

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -808,18 +808,21 @@
                             style="padding-bottom: 10px"
                           >
                             <div class="setting-card-row-item">
-                              <mat-form-field>
-                                <mat-label>Heading Line Length</mat-label>
+                              <mat-form-field style="width: 110px">
+                                <mat-label>Length</mat-label>
+                                <input matInput type="number" min="0"
+                                  [(ngModel)]="facade.settings.vessels.selfLines.heading.lineLength.value"
+                                  (change)="persistModel()"
+                                >
+                              </mat-form-field>
+                              <mat-form-field style="width: 110px">
+                                <mat-label>Unit</mat-label>
                                 <mat-select
-                                  matTooltip="Length of heading line."
-                                  [(ngModel)]="facade.settings.vessels.selfLines.heading.length"
+                                  [(ngModel)]="facade.settings.vessels.selfLines.heading.lineLength.kind"
                                   (selectionChange)="persistModel()"
                                 >
-                                  @for(i of options.vessel.headingLine; track
-                                  i[0] ) {
-                                  <mat-option [value]="i[0]"
-                                    >{{i[1]}}</mat-option
-                                  >
+                                  @for(k of options.lineLengthKinds; track k[0]) {
+                                    <mat-option [value]="k[0]">{{k[1]}}</mat-option>
                                   }
                                 </mat-select>
                               </mat-form-field>
@@ -845,18 +848,21 @@
                             style="padding-bottom: 10px"
                           >
                             <div class="setting-card-row-item">
-                              <mat-form-field>
-                                <mat-label>COG Line Length</mat-label>
+                              <mat-form-field style="width: 110px">
+                                <mat-label>Length</mat-label>
+                                <input matInput type="number" min="0"
+                                  [(ngModel)]="facade.settings.vessels.selfLines.cog.lineLength.value"
+                                  (change)="persistModel()"
+                                >
+                              </mat-form-field>
+                              <mat-form-field style="width: 110px">
+                                <mat-label>Unit</mat-label>
                                 <mat-select
-                                  matTooltip="Length of COG line."
-                                  [(ngModel)]="facade.settings.vessels.selfLines.cog.length"
+                                  [(ngModel)]="facade.settings.vessels.selfLines.cog.lineLength.kind"
                                   (selectionChange)="persistModel()"
                                 >
-                                  @for(i of options.vessel.cogLine; track i[0])
-                                  {
-                                  <mat-option [value]="i[0]"
-                                    >{{i[1]}}</mat-option
-                                  >
+                                  @for(k of options.lineLengthKinds; track k[0]) {
+                                    <mat-option [value]="k[0]">{{k[1]}}</mat-option>
                                   }
                                 </mat-select>
                               </mat-form-field>

--- a/src/app/modules/settings/components/settings-dialog.ts
+++ b/src/app/modules/settings/components/settings-dialog.ts
@@ -182,6 +182,20 @@ export class SettingsDialog implements OnInit {
     }
   }
 
+  /** handle route / navigation line style change */
+  onRouteStyle(
+    target: 'activeRoute' | 'defaultRoute' | 'activeSegment' | 'destination',
+    value: { lineStyle: LineStyleDef; config: LineStyleConfig }
+  ) {
+    const st = this.facade.settings.vessels.routing?.[target];
+    if (st) {
+      st.color = value.config.color;
+      st.dash = value.config.dash;
+      st.weight = value.config.weight;
+      this.persistModel();
+    }
+  }
+
   /**
    * toggle display of favourites
    */

--- a/src/app/modules/settings/components/settings-dialog.ts
+++ b/src/app/modules/settings/components/settings-dialog.ts
@@ -196,6 +196,21 @@ export class SettingsDialog implements OnInit {
     }
   }
 
+  /** handle trail / AIS track style change */
+  onTrailStyle(
+    target: 'self' | 'ais',
+    value: { lineStyle: LineStyleDef; config: LineStyleConfig }
+  ) {
+    const key = target === 'self' ? 'selfTrailStyle' : 'aisTrackStyle';
+    const st = this.facade.settings.vessels[key];
+    if (st) {
+      st.color = value.config.color;
+      st.dash = value.config.dash;
+      st.weight = value.config.weight;
+      this.persistModel();
+    }
+  }
+
   /**
    * toggle display of favourites
    */

--- a/src/app/modules/settings/settings.facade.ts
+++ b/src/app/modules/settings/settings.facade.ts
@@ -165,32 +165,18 @@ export class SettingsOptions {
     [-1, 'On']
   ]);
 
+  lineLengthKinds: [string, string][] = [
+    ['time', 'min'],
+    ['distance', 'nm'],
+    ['pixels', 'px']
+  ];
+
   vessel = {
     selfIconScale: new Map([
       [0.75, 'S'],
       [0.9, 'M'],
       [1.15, 'L'],
       [1.4, 'XL']
-    ]),
-    headingLine: new Map([
-      [-1, 'Default'],
-      [1, '1 nmi (2km)'],
-      [2, '2 nmi (4km)'],
-      [5, '5 nmi (10km)'],
-      [10, '10 nmi (20km)'],
-      [15, '15 nmi (30km)'],
-      [20, '20 nmi (40km)'],
-      [50, '50 nmi (90km)'],
-      [100, '100 nmi (180km)']
-    ]),
-    cogLine: new Map([
-      [0, 'None'],
-      [5, '5 min'],
-      [10, '10 min'],
-      [30, '30 min'],
-      [60, '60 min'],
-      [2 * 60, '2 hrs'],
-      [24 * 60, '24 hrs']
     ]),
     aisTimeouts: new Map([
       [60000, '1 min'],

--- a/src/app/modules/skstream/skstream.worker.ts
+++ b/src/app/modules/skstream/skstream.worker.ts
@@ -110,7 +110,7 @@ const aisMgr = {
   maxTrack: 20 // max point count in track
 };
 
-let vesselPrefs = { selfLines: { cog: { length: 10 } }, aisCogLine: 10 }; // selections.vessel
+let vesselPrefs = { aisCogLine: 10 }; // selections.vessel
 
 // ** Vessel trail management **
 const trailMgr: VesselTrailConfig = {
@@ -996,13 +996,10 @@ function processVessel(d: SKVessel, v: any, isSelf = false) {
         : v.value;
   }
 
-  // ** cog vector **
+  // ** cog vector (AIS only — self is computed in main thread) **
   const cog = d.cogTrue ?? d.cogMagnetic ?? undefined;
-  if (typeof cog !== 'undefined' && d.position) {
-    const cogLen = isSelf
-      ? vesselPrefs.selfLines.cog.length
-      : vesselPrefs.aisCogLine;
-    const cvlen = (d.sog ?? 0) * (cogLen * 60);
+  if (!isSelf && typeof cog !== 'undefined' && d.position) {
+    const cvlen = (d.sog ?? 0) * (vesselPrefs.aisCogLine * 60);
     d.vectors.cog = [
       d.position,
       GeoUtils.rhumbDestination(d.position, cog, cvlen)

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -9,6 +9,11 @@ export interface ILineLengthDef {
   value: number; // px | minutes | nmi
 }
 
+import {
+  LineStyleDash,
+  LineStyleConfig
+} from '../modules/settings/components/linestyle-select.component';
+export { LineStyleDash, LineStyleConfig };
 import { FBCharts, FBRoute } from './resources/freeboard';
 import {
   SKMeteo,
@@ -177,6 +182,8 @@ export interface IAppConfig {
       activeSegment: LineStyleConfig; // current leg (XTE reference track)
       destination: LineStyleConfig;  // vessel-to-next-waypoint bearing line
     };
+    selfTrailStyle: LineStyleConfig; // style of self vessel trail line
+    aisTrackStyle: LineStyleConfig;  // style of AIS target track lines
   };
   resources: {
     // ** resource options

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -163,6 +163,12 @@ export interface IAppConfig {
       next23: string;
       beyond24: string;
     };
+    routing: {
+      activeRoute: LineStyleConfig;  // active route line
+      defaultRoute: LineStyleConfig; // inactive / other route lines
+      activeSegment: LineStyleConfig; // current leg (XTE reference track)
+      destination: LineStyleConfig;  // vessel-to-next-waypoint bearing line
+    };
   };
   resources: {
     // ** resource options

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -1,6 +1,14 @@
 // ** Resource Types **
 
 import { Position, LineString, MultiLineString } from './resources/geojson';
+export type LineLengthKind = 'pixels' | 'time' | 'distance';
+
+/** How to interpret the line length value */
+export interface ILineLengthDef {
+  kind: LineLengthKind;
+  value: number; // px | minutes | nmi
+}
+
 import { FBCharts, FBRoute } from './resources/freeboard';
 import {
   SKMeteo,
@@ -131,13 +139,13 @@ export interface IAppConfig {
     laylines: boolean;
     selfLines: {
       cog: {
-        length: number; // (minutes) length = cogLine * sog
+        lineLength: ILineLengthDef;
         color: string;
         weight: number;
         dash: LineStyleDash;
       };
       heading: {
-        length: number; // mode for display of heading line -1 = default
+        lineLength: ILineLengthDef;
         color: string;
         weight: number;
         dash: LineStyleDash;


### PR DESCRIPTION
This PR builts on top of #363 

Depending on the background map and the screen and sunlight angle, the default line style can be hard to see. This PR proposes making the line and track styles customizable.

Heading in bright red, COG line thin dotted in black
<img width="178" height="158" alt="Screenshot From 2026-04-18 14-22-50" src="https://github.com/user-attachments/assets/aec2d0c2-9968-4ebf-8e11-ffd6538c7f48" />

Track style menu:
<img width="1262" height="903" alt="Screenshot From 2026-04-18 14-20-51" src="https://github.com/user-attachments/assets/2d356cb7-f07d-4ed6-b728-45656f583972" />

Vessel line style menu
<img width="1262" height="903" alt="Screenshot From 2026-04-18 14-19-54" src="https://github.com/user-attachments/assets/2b150567-2b96-4216-992d-681d21898ff5" />

