### PR TITLE
fix: Use Rhumb Line instead of Great Circle for drawing cog and heading lines

### DIFF
--- a/src/app/lib/geoutils.ts
+++ b/src/app/lib/geoutils.ts
@@ -28,18 +28,28 @@ export class GeoUtils {
     const λ1 = origin[0] * Math.PI / 180;
     const θ = bearingRad;
 
-    let Δφ = δ * Math.cos(θ);
+    const Δφ = δ * Math.cos(θ);
     let φ2 = φ1 + Δφ;
-    if (Math.abs(φ2) > Math.PI / 2) {
-      φ2 = φ2 > 0 ? Math.PI / 2 : -Math.PI / 2;
-      Δφ = φ2 - φ1;
+    let δ_eff = δ;
+
+    // Clamp to ±89° to avoid the Mercator/pole singularity (log(tan(π/2)) → ∞).
+    // Scale the effective distance proportionally so that tan(θ)·Δψ — the rhumb
+    // bearing identity — produces the correct longitude offset and the line points
+    // in the right direction on the Mercator map.
+    const MAX_φ = 89 * Math.PI / 180;
+    if (φ2 > MAX_φ && φ1 < MAX_φ) {
+      δ_eff = δ * (MAX_φ - φ1) / Δφ;
+      φ2 = MAX_φ;
+    } else if (φ2 < -MAX_φ && φ1 > -MAX_φ) {
+      δ_eff = δ * (-MAX_φ - φ1) / Δφ;
+      φ2 = -MAX_φ;
     }
 
     const Δψ = Math.log(
       Math.tan(Math.PI / 4 + φ2 / 2) / Math.tan(Math.PI / 4 + φ1 / 2)
     );
-    const q = Math.abs(Δψ) > 1e-12 ? Δφ / Δψ : Math.cos(φ1);
-    const Δλ = (δ * Math.sin(θ)) / q;
+    const q = Math.abs(Δψ) > 1e-12 ? (φ2 - φ1) / Δψ : Math.cos(φ1);
+    const Δλ = (δ_eff * Math.sin(θ)) / q;
 
     return [(λ1 + Δλ) * 180 / Math.PI, φ2 * 180 / Math.PI];
   }

--- a/src/app/lib/geoutils.ts
+++ b/src/app/lib/geoutils.ts
@@ -15,6 +15,35 @@ import { SKPosition, Position } from '../types';
 export type Extent = [number, number, number, number]; // coords [swlon,swlat,nelon,nelat] of a bounding box
 
 export class GeoUtils {
+  private static readonly R = 6_371_000; // mean earth radius in metres
+
+  /**
+   * Rhumb-line destination: given a start [lon,lat], bearing (radians),
+   * and distance (metres), return the destination [lon,lat].
+   */
+  static rhumbDestination(origin: Position, bearingRad: number, distMeters: number): Position {
+    const R = GeoUtils.R;
+    const δ = distMeters / R;
+    const φ1 = origin[1] * Math.PI / 180;
+    const λ1 = origin[0] * Math.PI / 180;
+    const θ = bearingRad;
+
+    let Δφ = δ * Math.cos(θ);
+    let φ2 = φ1 + Δφ;
+    if (Math.abs(φ2) > Math.PI / 2) {
+      φ2 = φ2 > 0 ? Math.PI / 2 : -Math.PI / 2;
+      Δφ = φ2 - φ1;
+    }
+
+    const Δψ = Math.log(
+      Math.tan(Math.PI / 4 + φ2 / 2) / Math.tan(Math.PI / 4 + φ1 / 2)
+    );
+    const q = Math.abs(Δψ) > 1e-12 ? Δφ / Δψ : Math.cos(φ1);
+    const Δλ = (δ * Math.sin(θ)) / q;
+
+    return [(λ1 + Δλ) * 180 / Math.PI, φ2 * 180 / Math.PI];
+  }
+
   static destCoordinate(
     src: Position,
     bearing: number,

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -1427,7 +1427,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
       }
       const heading = [
         this.dfeat.active.position,
-        GeoUtils.destCoordinate(
+        GeoUtils.rhumbDestination(
           this.dfeat.active.position,
           this.dfeat.active.orientation,
           hl

--- a/src/app/modules/map/ol/lib/navigation/layer-cog-line.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-cog-line.component.ts
@@ -22,7 +22,7 @@ import { StyleLike } from 'ol/style/Style';
 import { LineString, Point } from 'ol/geom';
 import { MapComponent } from '../map.component';
 import { Extent, Coordinate } from '../models';
-import { fromLonLatArray, mapifyCoords } from '../util';
+import { fromLonLatArray } from '../util';
 import { AsyncSubject } from 'rxjs';
 import { getDistance } from 'geolib';
 import { Convert } from 'src/app/lib/convert';
@@ -145,7 +145,9 @@ export class CogLineComponent implements OnInit, OnDestroy, OnChanges {
   parseInput() {
     const fa: Feature[] = [];
     if (Array.isArray(this.coords()) && this.coords().length !== 0) {
-      this.mapifiedLine = mapifyCoords(this.coords());
+      // Coordinates arrive pre-unwrapped from rhumbDestination —
+      // no mapifyCoords needed (it would flip wide-angle lines).
+      this.mapifiedLine = this.coords().map(p => [p[0], p[1]] as Coordinate);
 
       this.labelText.update(() => {
         return `${this.formatNumber(

--- a/src/app/modules/map/ol/lib/vessel/layer-vessel.component.ts
+++ b/src/app/modules/map/ol/lib/vessel/layer-vessel.component.ts
@@ -18,7 +18,7 @@ import { Geometry, Point, LineString } from 'ol/geom';
 import { fromLonLat } from 'ol/proj';
 import { MapComponent } from '../map.component';
 import { Extent, Coordinate } from '../models';
-import { fromLonLatArray, mapifyCoords } from '../util';
+import { fromLonLatArray } from '../util';
 import { AsyncSubject } from 'rxjs';
 import { Options } from 'ol/style/Icon';
 
@@ -284,13 +284,15 @@ export class VesselComponent implements OnInit, OnDestroy, OnChanges {
     if (!coords || !Array.isArray(coords)) {
       return;
     }
+    // Coordinates arrive pre-unwrapped from rhumbDestination — fromLonLatArray
+    // handles any longitude value, so no mapifyCoords needed.
     if (!lf) {
       // create feature
-      lf = new Feature(new LineString(fromLonLatArray(mapifyCoords(coords))));
+      lf = new Feature(new LineString(fromLonLatArray(coords)));
     } else {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const g: any = lf.getGeometry();
-      g.setCoordinates(fromLonLatArray(mapifyCoords(coords)));
+      g.setCoordinates(fromLonLatArray(coords));
     }
     return lf;
   }

--- a/src/app/modules/skstream/skstream.worker.ts
+++ b/src/app/modules/skstream/skstream.worker.ts
@@ -1003,7 +1003,7 @@ function processVessel(d: SKVessel, v: any, isSelf = false) {
     const cvlen = (d.sog ?? 0) * (cogLen * 60);
     d.vectors.cog = [
       d.position,
-      GeoUtils.destCoordinate(d.position, cog, cvlen)
+      GeoUtils.rhumbDestination(d.position, cog, cvlen)
     ];
   }
 }


### PR DESCRIPTION
Currently, the endpoints for the heading and cog lines are calculated using Great Circle math. Away from the equator and for long distances, this leads to endpoints closer to the equator than they should be and significant discrepancies between the heading/cog and the drawn lines.

See the following pictures for errors in the current implementation and the proposed fix as comparison. Heading and course over ground are equal in all screenshots.

Close to poles, near Svalbard, sailing eastwards. The boat icon points eastwards, but the heading line is bent southwards.
Broken:
<img width="480" height="270" alt="Screenshot From 2026-04-16 20-52-18" src="https://github.com/user-attachments/assets/11b742cd-ffdc-4545-9444-c043dad1b72a" />
Fixed:
<img width="480" height="270" alt="Screenshot From 2026-04-16 20-54-49" src="https://github.com/user-attachments/assets/bb9da3b9-07a9-46e1-9ad6-ac388707758a" />


A long COG line deviates significantly from the real course.
Broken:
<img width="1091" height="486" alt="Screenshot From 2026-04-16 21-02-46" src="https://github.com/user-attachments/assets/550f326b-be11-4511-b2cf-74b0022d09e7" />
Fixed:
<img width="1091" height="486" alt="Screenshot From 2026-04-16 21-04-03" src="https://github.com/user-attachments/assets/5b2ed4d5-cc86-4075-bff0-c6350649c216" />

On a larger zoomlevel, also the small heading deviation is visible:
Broken:
<img width="513" height="459" alt="Screenshot From 2026-04-16 21-05-16" src="https://github.com/user-attachments/assets/1b79d19c-801c-4e37-a048-762c448b805a" />
Fixed:
<img width="513" height="459" alt="Screenshot From 2026-04-16 21-04-30" src="https://github.com/user-attachments/assets/173cbeae-8fe5-47ff-b639-413a962f86d9" />


