### PR TITLE
fix(map): draw tracks and routes crossing antimeridian without jumps

### DIFF
--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -38,7 +38,10 @@ import {
   S57_CLICKABLE_LAYERS,
   S57_NAMES
 } from './popovers';
-import { FreeboardOpenlayersModule } from 'src/app/modules/map/ol';
+import {
+  FreeboardOpenlayersModule,
+  FreeboardRouteLayerComponent
+} from 'src/app/modules/map/ol';
 import { CoordsPipe } from 'src/app/lib/pipes';
 
 import { computeDestinationPoint, getGreatCircleBearing } from 'geolib';
@@ -213,6 +216,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   @ViewChild(MatMenuTrigger, { static: true }) contextMenu: MatMenuTrigger;
   @ViewChild('olMap', { static: false }) olMap: MapComponent;
+  @ViewChild(FreeboardRouteLayerComponent)
+  routeLayer: FreeboardRouteLayerComponent;
 
   scaleUnits = input<string>('');
 
@@ -1139,8 +1144,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
     }
     let pc;
     if (fid.split('.')[0] === 'route') {
+      // c is a flat Coordinate[] from the scratch LineString (EPSG:3857)
       pc = this.transformCoordsArray(c);
       this.mapInteract.measurementCoords = pc;
+      // Re-split at antimeridian and update all source segment features so
+      // the rendered route reflects the edit after each vertex drop.
+      if (this.routeLayer) {
+        this.routeLayer.updateRouteSegments(fid.split('.')[1], pc);
+      }
     } else if (fid.split('.')[0] === 'region') {
       for (let e = 0; e < c.length; e++) {
         if (this.isCoordsArray(c[e])) {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -1039,7 +1039,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         this.mapInteract.draw.features.getArray()[0] as Feature;
       // Give OL Modify a scratch LineString with unwrapped (non-split) coords
       // so there are no phantom ±180° boundary vertices during editing.
-      const mc = mapifyCoords([...rawCoords]);
+      const mc = mapifyCoords(rawCoords);
       // Shift the scratch geometry to the world copy the user clicked in.
       // OL always returns the primary-world Feature regardless of which
       // rendered copy was hit, so we identify the correct copy explicitly.

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -46,13 +46,8 @@ import { CoordsPipe } from 'src/app/lib/pipes';
 
 import { computeDestinationPoint, getGreatCircleBearing } from 'geolib';
 import { fromLonLat, toLonLat } from 'ol/proj';
-import {
-  LineString as OlLineString
-} from 'ol/geom';
-import {
-  fromLonLatArray,
-  mapifyCoords
-} from './ol/lib/util';
+import { LineString as OlLineString } from 'ol/geom';
+import { fromLonLatArray, mapifyCoords } from './ol/lib/util';
 import { Style, Stroke, Fill } from 'ol/style';
 import { Collection, Feature } from 'ol';
 import { Feature as GeoJsonFeature } from 'geojson';
@@ -539,7 +534,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
           if (this.overlay().type === 'ais') {
             this.overlay.update((current) => {
               const newPos = this.dfeat.ais.get(current.id).position;
-              const wo = Math.round((current.position[0] - newPos[0]) / 360) * 360;
+              const wo =
+                Math.round((current.position[0] - newPos[0]) / 360) * 360;
               return Object.assign({}, current, {
                 position: wo !== 0 ? [newPos[0] + wo, newPos[1]] : newPos,
                 vessel: this.dfeat.ais.get(current.id)
@@ -1056,21 +1052,26 @@ export class FBMapComponent implements OnInit, OnDestroy {
       const clickMercX = clickMerc[0];
       const clickMercY = clickMerc[1];
       const worldWidth = 2 * 20037508.3427892;
-      let minX = mercCoords[0][0], maxX = mercCoords[0][0];
+      let minX = mercCoords[0][0],
+        maxX = mercCoords[0][0];
       for (const c of mercCoords) {
         if (c[0] < minX) minX = c[0];
         if (c[0] > maxX) maxX = c[0];
       }
       const m = Math.round(clickMercX / worldWidth);
       const n = Math.ceil((maxX - minX) / worldWidth);
-      let bestShift = 0, bestDist = Infinity;
+      let bestShift = 0,
+        bestDist = Infinity;
       for (let k = m - n - 1; k <= m + n + 1; k++) {
         const shift = k * worldWidth;
         for (const c of mercCoords) {
           const dx = c[0] + shift - clickMercX;
           const dy = c[1] - clickMercY;
           const dist = dx * dx + dy * dy; // squared Euclidean, no sqrt needed
-          if (dist < bestDist) { bestDist = dist; bestShift = shift; }
+          if (dist < bestDist) {
+            bestDist = dist;
+            bestShift = shift;
+          }
         }
       }
       if (bestShift !== 0) {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -518,8 +518,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
     ) {
       if (this.overlay().isSelf) {
         this.overlay.update((current) => {
+          const newPos = this.dfeat.self.position;
+          const wo = Math.round((current.position[0] - newPos[0]) / 360) * 360;
           return Object.assign({}, current, {
-            position: this.dfeat.self.position,
+            position: wo !== 0 ? [newPos[0] + wo, newPos[1]] : newPos,
             vessel: this.dfeat.self
           });
         });
@@ -536,26 +538,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
         } else {
           if (this.overlay().type === 'ais') {
             this.overlay.update((current) => {
+              const newPos = this.dfeat.ais.get(current.id).position;
+              const wo = Math.round((current.position[0] - newPos[0]) / 360) * 360;
               return Object.assign({}, current, {
-                position: this.dfeat.ais.get(current.id).position,
+                position: wo !== 0 ? [newPos[0] + wo, newPos[1]] : newPos,
                 vessel: this.dfeat.ais.get(current.id)
               });
             });
           }
-        }
-      }
-      if (this.app.mapExtent()[0] < 180 && this.app.mapExtent()[2] > 180) {
-        // if dateline is in view adjust overlay position to stay with vessel
-
-        if (
-          this.overlay().position[0] < 0 &&
-          this.overlay().position[0] > -180
-        ) {
-          this.overlay.update((current) => {
-            return Object.assign({}, current, {
-              position: [current.position[0] + 360, current.position[1]]
-            });
-          });
         }
       }
     }
@@ -1473,6 +1463,11 @@ export class FBMapComponent implements OnInit, OnDestroy {
     let item = null;
     const t = id.split('.');
     let aid: string;
+    // Shift stored geographic positions to the clicked world copy so the popup
+    // appears at the same world copy the user clicked, not the primary world.
+    const worldOffset = coord ? Math.floor((coord[0] + 180) / 360) * 360 : 0;
+    const wrapPos = (pos: Position): Position =>
+      worldOffset !== 0 ? [pos[0] + worldOffset, pos[1]] : pos;
 
     switch (t[0]) {
       case 's57':
@@ -1526,7 +1521,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.type = 'ais';
         poData.isSelf = true;
         poData.vessel = this.dfeat.self;
-        poData.position = this.dfeat.self.position;
+        poData.position = wrapPos(this.dfeat.self.position);
         poData.show = true;
         break;
       case 'ais-vessels':
@@ -1537,7 +1532,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.type = 'ais';
         poData.id = aid;
         poData.vessel = this.dfeat.ais.get(aid);
-        poData.position = poData.vessel.position;
+        poData.position = wrapPos(poData.vessel.position);
         poData.show = true;
         break;
       case 'atons':
@@ -1549,7 +1544,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.type = 'aton';
         poData.id = id;
         poData.aton = this.app.data.atons.get(id);
-        poData.position = poData.aton.position;
+        poData.position = wrapPos(poData.aton.position);
         poData.show = true;
         break;
       case 'sar':
@@ -1559,7 +1554,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.type = 'aton';
         poData.id = id;
         poData.aton = this.app.data.sar.get(id);
-        poData.position = poData.aton.position;
+        poData.position = wrapPos(poData.aton.position);
         poData.show = true;
         break;
       case 'meteo':
@@ -1569,7 +1564,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.type = t[0];
         poData.id = id;
         poData.aton = this.app.data.meteo.get(id);
-        poData.position = poData.aton.position;
+        poData.position = wrapPos(poData.aton.position);
         poData.show = true;
         break;
       case 'aircraft':
@@ -1579,7 +1574,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.type = t[0];
         poData.id = id;
         poData.aircraft = this.app.data.aircraft.get(id);
-        poData.position = poData.aircraft.position;
+        poData.position = wrapPos(poData.aircraft.position);
         poData.show = true;
         break;
       case 'tidal': {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -42,7 +42,14 @@ import { FreeboardOpenlayersModule } from 'src/app/modules/map/ol';
 import { CoordsPipe } from 'src/app/lib/pipes';
 
 import { computeDestinationPoint, getGreatCircleBearing } from 'geolib';
-import { toLonLat } from 'ol/proj';
+import { fromLonLat, toLonLat } from 'ol/proj';
+import {
+  LineString as OlLineString
+} from 'ol/geom';
+import {
+  fromLonLatArray,
+  mapifyCoords
+} from './ol/lib/util';
 import { Style, Stroke, Fill } from 'ol/style';
 import { Collection, Feature } from 'ol';
 import { Feature as GeoJsonFeature } from 'geojson';
@@ -321,6 +328,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
   protected course = inject(CourseService);
   protected mapInteract = inject(FBMapInteractService);
   protected mapService = inject(MapService);
+  /** Source feature whose MultiLineString geometry is updated live during route editing. */
+  private routeEditSourceFeature: Feature | null = null;
   private settings = inject(SettingsFacade);
   private bottomSheet = inject(MatBottomSheet);
   private infoPanel = inject(InfoPanelFacade);
@@ -1021,15 +1030,68 @@ export class FBMapComponent implements OnInit, OnDestroy {
     if (this.mapInteract.draw.features.getLength() === 0) {
       return;
     }
-    this.mapInteract.startModifying(this.overlay());
+    this.routeEditSourceFeature = null;
     if (this.overlay().type === 'route') {
       const rid = this.overlay().id;
-      this.mapInteract.measurementCoords = this.routeBuffers.has(rid)
+      const rawCoords = this.routeBuffers.has(rid)
         ? (this.routeBuffers
             .get(rid)!
             .points.map((p) => p.position) as LineString)
         : this.skres.fromCache('routes', rid)[1].feature.geometry.coordinates;
+      // Keep a reference to the rendered MultiLineString feature so its
+      // geometry can be updated live after each vertex drop.
+      this.routeEditSourceFeature =
+        this.mapInteract.draw.features.getArray()[0] as Feature;
+      // Give OL Modify a scratch LineString with unwrapped (non-split) coords
+      // so there are no phantom ±180° boundary vertices during editing.
+      const mc = mapifyCoords([...rawCoords]);
+      // Shift the scratch geometry to the world copy the user clicked in.
+      // OL always returns the primary-world Feature regardless of which
+      // rendered copy was hit, so we identify the correct copy explicitly.
+      //
+      // Strategy: the click's raw Mercator x encodes the world copy (thanks to
+      // the transform() fix in map.component.ts).  mapifyCoords() may produce
+      // a geometry spanning n world widths (e.g. a route crossing the
+      // antimeridian multiple times).  We search all shifts in the range
+      // [m-n-1 .. m+n+1] where m = clicked world copy and n = route width in
+      // world copies, and pick the shift that places the nearest vertex closest
+      // to the click.
+      const mercCoords = fromLonLatArray(mc) as Coordinate[];
+      const clickMerc = fromLonLat(this.overlay().position as [number, number]);
+      const clickMercX = clickMerc[0];
+      const clickMercY = clickMerc[1];
+      const worldWidth = 2 * 20037508.3427892;
+      let minX = mercCoords[0][0], maxX = mercCoords[0][0];
+      for (const c of mercCoords) {
+        if (c[0] < minX) minX = c[0];
+        if (c[0] > maxX) maxX = c[0];
+      }
+      const m = Math.round(clickMercX / worldWidth);
+      const n = Math.ceil((maxX - minX) / worldWidth);
+      let bestShift = 0, bestDist = Infinity;
+      for (let k = m - n - 1; k <= m + n + 1; k++) {
+        const shift = k * worldWidth;
+        for (const c of mercCoords) {
+          const dx = c[0] + shift - clickMercX;
+          const dy = c[1] - clickMercY;
+          const dist = dx * dx + dy * dy; // squared Euclidean, no sqrt needed
+          if (dist < bestDist) { bestDist = dist; bestShift = shift; }
+        }
+      }
+      if (bestShift !== 0) {
+        mercCoords.forEach((c) => (c[0] += bestShift));
+      }
+      const scratchGeom = new OlLineString(mercCoords);
+      const scratchFeat = new Feature({ geometry: scratchGeom });
+      scratchFeat.setId(this.routeEditSourceFeature.getId());
+      scratchFeat.set(
+        'pointMetadata',
+        this.routeEditSourceFeature.get('pointMetadata')
+      );
+      this.mapInteract.draw.features = new Collection([scratchFeat]);
+      this.mapInteract.measurementCoords = rawCoords;
     }
+    this.mapInteract.startModifying(this.overlay());
     if (featureType === 'anchor') {
       this.overlay().type = featureType;
       this.mapInteract.draw.forSave.id = featureType;

--- a/src/app/modules/map/ol/lib/charts/layer-chart-bounds.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-chart-bounds.component.ts
@@ -151,8 +151,7 @@ export class ChartBoundsLayerComponent extends FBFeatureLayerComponent {
         [bounds[2], bounds[3]],
         [bounds[0], bounds[3]],
         [bounds[0], bounds[1]]
-      ],
-      0
+      ]
     );
     return [fromLonLatArray(rect)];
   }

--- a/src/app/modules/map/ol/lib/charts/layer-chart-bounds.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-chart-bounds.component.ts
@@ -144,15 +144,13 @@ export class ChartBoundsLayerComponent extends FBFeatureLayerComponent {
         bounds[3] === 90)
     )
       return [];
-    const rect = mapifyCoords(
-      [
-        [bounds[0], bounds[1]],
-        [bounds[2], bounds[1]],
-        [bounds[2], bounds[3]],
-        [bounds[0], bounds[3]],
-        [bounds[0], bounds[1]]
-      ]
-    );
+    const rect = mapifyCoords([
+      [bounds[0], bounds[1]],
+      [bounds[2], bounds[1]],
+      [bounds[2], bounds[3]],
+      [bounds[0], bounds[3]],
+      [bounds[0], bounds[1]]
+    ]);
     return [fromLonLatArray(rect)];
   }
 }

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -21,7 +21,7 @@ import RenderEvent from 'ol/render/Event';
 import { MapService } from './map.service';
 import { MapReadyEvent } from './models';
 import { AsyncSubject } from 'rxjs';
-import { toLonLat, transformExtent } from 'ol/proj';
+import { toLonLat, transform, transformExtent } from 'ol/proj';
 import { Coordinate } from 'ol/coordinate';
 import { FeatureLike } from 'ol/Feature';
 import { Extent } from 'ol/extent';
@@ -360,7 +360,9 @@ export class MapComponent implements OnInit, OnDestroy {
   private emitRightClickEvent = (event: MouseEvent) => {
     this.ngZone.run(() => {
       event.preventDefault();
-      const c = this.map.getEventCoordinate(event);
+      // Use getEventCoordinateInternal (EPSG:3857) so the pixel lookup is
+      // correct and the lon/lat preserves the world-copy offset.
+      const c = this.map.getEventCoordinateInternal(event);
       this.mapRightClick.emit({
         features: this.map.getFeaturesAtPixel(
           this.map.getPixelFromCoordinateInternal(c),
@@ -368,7 +370,7 @@ export class MapComponent implements OnInit, OnDestroy {
             hitTolerance: this.hitTolerance
           }
         ),
-        lonlat: toLonLat(c)
+        lonlat: transform(c, 'EPSG:3857', 'EPSG:4326')
       });
     });
   };
@@ -387,7 +389,11 @@ export class MapComponent implements OnInit, OnDestroy {
       features: this.map.getFeaturesAtPixel(event.pixel, {
         hitTolerance: this.hitTolerance
       }),
-      lonlat: toLonLat(event.coordinate)
+      // Use raw transform (not toLonLat) so the longitude preserves the
+      // world-copy offset (e.g. 190° for world +1). This ensures that
+      // fromLonLat() in overlay.component.ts produces the correct Mercator
+      // position so OL places the popup in the world copy the user clicked.
+      lonlat: transform(event.coordinate, 'EPSG:3857', 'EPSG:4326')
     });
   }
 

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets-track.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets-track.component.ts
@@ -9,7 +9,7 @@ import { Feature } from 'ol';
 import { Style, Stroke } from 'ol/style';
 import { MultiLineString } from 'ol/geom';
 import { MapComponent } from '../map.component';
-import { fromLonLatArray, mapifyCoords } from '../util';
+import { fromLonLatArray, splitAtAntimeridian } from '../util';
 import { AISBaseLayerComponent } from './ais-base.component';
 import { shouldRenderTrack } from 'src/app/lib/vessel-track';
 
@@ -170,16 +170,13 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
     }
   }
 
-  // ** mapify and transform MultiLineString coordinates
+  // ** split at antimeridian and transform MultiLineString coordinates
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parseCoordinates(trk: Array<any>) {
     // ** handle dateline crossing **
-    const tc = trk.map((mls) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const lines: Array<any> = [];
-      mls.forEach((line) => lines.push(mapifyCoords(line)));
-      return lines;
-    });
+    const tc = trk.map((mls) =>
+      mls.flatMap((line) => splitAtAntimeridian(line))
+    );
     return fromLonLatArray(tc);
   }
 }

--- a/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
@@ -115,7 +115,8 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
   // Route style function
   buildStyle(feature: Feature) {
     const styles = [];
-    const isActive = (feature.getId() as string).split('.')[1] === this.activeRoute;
+    const isActive =
+      (feature.getId() as string).split('.')[1] === this.activeRoute;
     let ptFill: Fill;
 
     if (typeof this.routeStyles === 'undefined') {

--- a/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
@@ -7,12 +7,10 @@ import {
 } from '@angular/core';
 import { Feature } from 'ol';
 import { Style, Stroke, Fill, Circle, RegularShape } from 'ol/style';
-import { LineString, Point } from 'ol/geom';
-import { toLonLat } from 'ol/proj';
+import { MultiLineString, Point } from 'ol/geom';
 import { MapComponent } from '../map.component';
-import { fromLonLatArray, mapifyCoords } from '../util';
-import { getRhumbLineBearing } from 'geolib';
-import { GeolibInputCoordinates } from 'geolib/es/types';
+import { Coordinate } from '../models';
+import { fromLonLatArray, splitAtAntimeridian } from '../util';
 import { FBFeatureLayerComponent } from '../sk-feature.component';
 import { FBRoutes } from 'src/app/types';
 import { MapImageRegistry } from '../map-image-registry.service';
@@ -69,18 +67,25 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
     for (const r of routes) {
       if (r[2]) {
         // selected
-        const mc = mapifyCoords(r[1].feature.geometry.coordinates);
-        const c = fromLonLatArray(mc);
+        const rawCoords = r[1].feature.geometry.coordinates;
+        // Split at antimeridian: each segment stays within [-180, 180] so
+        // OL wrapX can clone every segment into all adjacent world copies.
+        const multiCoords = splitAtAntimeridian(rawCoords).map(
+          (seg) => fromLonLatArray(seg) as Coordinate[]
+        );
         const f = new Feature({
-          geometry: new LineString(c),
+          geometry: new MultiLineString(multiCoords),
           name: r[1].name
         });
         f.setId('route.' + r[0]);
         f.set('pointMetadata', r[1].feature.properties.coordinatesMeta ?? null);
-        // Style FUNCTION (not a static array) so the per-vertex markers, whose
-        // geometries are derived from the line in buildStyle, re-evaluate as the
-        // geometry changes during a Modify drag — otherwise they stay frozen at
-        // the original vertex positions until the edit finishes.
+        // Store waypoint Mercator coordinates separately so buildStyle can place
+        // markers on actual waypoints without having to filter out the
+        // interpolated ±180° split endpoints from the MultiLineString.
+        f.set('waypointMercCoords', fromLonLatArray(rawCoords) as Coordinate[]);
+        // Style FUNCTION (not a static array) so the per-vertex markers,
+        // whose geometries are derived from waypointMercCoords, re-evaluate
+        // as the geometry changes during a Modify drag.
         f.setStyle((feat) => this.buildStyle(feat as Feature));
         fa.push(f);
       }
@@ -89,12 +94,28 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
     this.updateLabels();
   }
 
+  /**
+   * Update the rendered LineString geometry after a vertex drag.
+   * Called from fb-map after each onModifyEnd while editing a route.
+   * @param routeId   The bare route UUID (without the 'route.' prefix)
+   * @param newCoords New waypoint coordinates in lon/lat (EPSG:4326)
+   */
+  updateRouteSegments(routeId: string, newCoords: Coordinate[]) {
+    const f = this.source.getFeatureById('route.' + routeId) as Feature;
+    if (f) {
+      const multiCoords = splitAtAntimeridian(newCoords).map(
+        (seg) => fromLonLatArray(seg) as Coordinate[]
+      );
+      (f.getGeometry() as MultiLineString).setCoordinates(multiCoords);
+      f.set('waypointMercCoords', fromLonLatArray(newCoords) as Coordinate[]);
+      f.setStyle(this.buildStyle(f));
+    }
+  }
+
   // Route style function
   buildStyle(feature: Feature) {
-    const geometry = feature.getGeometry() as LineString;
     const styles = [];
-    const id = (feature.getId() as string).split('.').slice(-1)[0];
-    const isActive = id === this.activeRoute;
+    const isActive = (feature.getId() as string).split('.')[1] === this.activeRoute;
     let ptFill: Fill;
 
     if (typeof this.routeStyles === 'undefined') {
@@ -135,15 +156,21 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
     const wptSym = this.mapImages.getExternalSymbol(ROUTE_MARKER_WAYPOINT);
     const endSym = this.mapImages.getExternalSymbol(ROUTE_MARKER_END);
 
-    // point styles
-    let idx = 0;
-    const l = geometry.getCoordinates().length;
-    geometry.forEachSegment((start, end) => {
-      // start point
+    // Waypoint Mercator coordinates are stored on the feature at creation/update
+    // time. They correspond to the actual route waypoints in the primary world
+    // ([-180°, 180°] → [-20037508, 20037508] m), so OL's wrapX mechanism
+    // correctly clones the resulting Point markers into every world copy.
+    const waypoints: Coordinate[] = feature.get('waypointMercCoords') ?? [];
+    const worldWidth = 2 * 20037508.3427892;
+
+    const l = waypoints.length;
+    for (let idx = 0; idx < l; idx++) {
+      const c = waypoints[idx];
       if (idx === 0) {
+        // start point
         styles.push(
           new Style({
-            geometry: new Point(start),
+            geometry: new Point(c),
             image:
               startSym ??
               new Circle({
@@ -156,67 +183,11 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
               })
           })
         );
-      } else {
-        if (wptSym) {
-          // Clone the cached icon so each segment can carry its own bearing
-          // rotation without mutating the shared instance.
-          const d = getRhumbLineBearing(
-            toLonLat(start) as GeolibInputCoordinates,
-            toLonLat(end) as GeolibInputCoordinates
-          );
-          const img = wptSym.clone();
-          img.setRotation((d * Math.PI) / 180);
-          img.setRotateWithView(true);
-          styles.push(
-            new Style({
-              geometry: new Point(start),
-              image: img
-            })
-          );
-        } else if (isActive) {
-          styles.push(
-            new Style({
-              geometry: new Point(start),
-              image: new Circle({
-                radius: 4,
-                stroke: new Stroke({
-                  width: 1,
-                  color: 'white'
-                }),
-                fill: ptFill
-              })
-            })
-          );
-        } else {
-          const d = getRhumbLineBearing(
-            toLonLat(start) as GeolibInputCoordinates,
-            toLonLat(end) as GeolibInputCoordinates
-          );
-          const rotation = (d * Math.PI) / 180;
-          styles.push(
-            new Style({
-              geometry: new Point(start),
-              image: new RegularShape({
-                radius: 6,
-                stroke: new Stroke({
-                  width: 1,
-                  color: 'white'
-                }),
-                fill: ptFill,
-                points: 3,
-                angle: 0,
-                rotateWithView: true,
-                rotation: rotation
-              })
-            })
-          );
-        }
-      }
-      // last point
-      if (idx === l - 2) {
+      } else if (idx === l - 1) {
+        // end point
         styles.push(
           new Style({
-            geometry: new Point(end),
+            geometry: new Point(c),
             image:
               endSym ??
               new RegularShape({
@@ -231,9 +202,61 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
               })
           })
         );
+      } else if (wptSym) {
+        // intermediate waypoint: external symbol, rotated to bearing.
+        // Use Mercator dx/dy so the arrow wraps correctly at the antimeridian.
+        const prev = waypoints[idx - 1];
+        let dx = c[0] - prev[0];
+        if (dx > worldWidth / 2) dx -= worldWidth;
+        else if (dx < -worldWidth / 2) dx += worldWidth;
+        const rotation = Math.atan2(dx, c[1] - prev[1]);
+        const img = wptSym.clone();
+        img.setRotation(rotation);
+        img.setRotateWithView(true);
+        styles.push(
+          new Style({
+            geometry: new Point(c),
+            image: img
+          })
+        );
+      } else if (isActive) {
+        // intermediate waypoint (active route)
+        styles.push(
+          new Style({
+            geometry: new Point(c),
+            image: new Circle({
+              radius: 4,
+              stroke: new Stroke({ width: 1, color: 'white' }),
+              fill: ptFill
+            })
+          })
+        );
+      } else {
+        // intermediate waypoint (inactive): arrow pointing towards next waypoint.
+        // Compute bearing in Mercator space; detect antimeridian crossings by
+        // checking if |dx| > half a world width, and wrap accordingly so the
+        // arrow points in the correct direction of travel.
+        const prev = waypoints[idx - 1];
+        let dx = c[0] - prev[0];
+        if (dx > worldWidth / 2) dx -= worldWidth;
+        else if (dx < -worldWidth / 2) dx += worldWidth;
+        const rotation = Math.atan2(dx, c[1] - prev[1]);
+        styles.push(
+          new Style({
+            geometry: new Point(c),
+            image: new RegularShape({
+              radius: 6,
+              stroke: new Stroke({ width: 1, color: 'white' }),
+              fill: ptFill,
+              points: 3,
+              angle: 0,
+              rotateWithView: true,
+              rotation: rotation
+            })
+          })
+        );
       }
-      idx++;
-    });
+    }
     return styles;
   }
 }

--- a/src/app/modules/map/ol/lib/resources/layer-tracks.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-tracks.component.ts
@@ -9,7 +9,7 @@ import { Feature } from 'ol';
 import { Style, Text, Stroke } from 'ol/style';
 import { MultiLineString } from 'ol/geom';
 import { MapComponent } from '../map.component';
-import { fromLonLatArray, mapifyCoords } from '../util';
+import { fromLonLatArray, splitAtAntimeridian } from '../util';
 import { SKTrack } from 'src/app/modules';
 import { FBFeatureLayerComponent } from '../sk-feature.component';
 import { FBTracks } from 'src/app/types';
@@ -98,11 +98,10 @@ export class TrackLayerComponent extends FBFeatureLayerComponent {
     }
   }
 
-  // ** mapify and transform MultiLineString coordinates
+  // ** split at antimeridian and transform MultiLineString coordinates
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parseCoordinates(mls: Array<any>) {
-    const lines = [];
-    mls.forEach((line) => lines.push(mapifyCoords(line)));
+    const lines = mls.flatMap((line) => splitAtAntimeridian(line));
     return fromLonLatArray(lines);
   }
 }

--- a/src/app/modules/map/ol/lib/util.spec.ts
+++ b/src/app/modules/map/ol/lib/util.spec.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { mapifyCoords, splitAtAntimeridian } from './util';
+
+// ---------------------------------------------------------------------------
+// splitAtAntimeridian
+// ---------------------------------------------------------------------------
+
+describe('splitAtAntimeridian', () => {
+  it('returns [] for empty input', () => {
+    expect(splitAtAntimeridian([])).toEqual([]);
+  });
+
+  it('wraps a single point in one segment', () => {
+    const result = splitAtAntimeridian([[0, 45]]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual([[0, 45]]);
+  });
+
+  it('returns one segment when no antimeridian is crossed', () => {
+    const segs = splitAtAntimeridian([[0, 0], [10, 0], [20, 0]]);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toEqual([[0, 0], [10, 0], [20, 0]]);
+  });
+
+  it('splits an eastbound crossing (179°E → 179°W, crossing at +180°)', () => {
+    // dLon = -179 - 179 = -358 < -180 → eastward branch
+    const segs = splitAtAntimeridian([[179, 0], [-179, 0]]);
+    expect(segs).toHaveLength(2);
+    expect(segs[0][0]).toEqual([179, 0]);
+    expect(segs[0][segs[0].length - 1][0]).toBe(180);
+    expect(segs[1][0][0]).toBe(-180);
+    expect(segs[1][segs[1].length - 1]).toEqual([-179, 0]);
+    // Both boundary points share the same interpolated latitude
+    expect(segs[0][segs[0].length - 1][1]).toBeCloseTo(segs[1][0][1], 10);
+  });
+
+  it('splits a westbound crossing (179°W → 179°E, crossing at -180°)', () => {
+    // dLon = 179 - (-179) = 358 > 180 → westward branch
+    const segs = splitAtAntimeridian([[-179, 0], [179, 0]]);
+    expect(segs).toHaveLength(2);
+    expect(segs[0][0]).toEqual([-179, 0]);
+    expect(segs[0][segs[0].length - 1][0]).toBe(-180);
+    expect(segs[1][0][0]).toBe(180);
+    expect(segs[1][segs[1].length - 1]).toEqual([179, 0]);
+    expect(segs[0][segs[0].length - 1][1]).toBeCloseTo(segs[1][0][1], 10);
+  });
+
+  it('handles a large longitude span eastbound crossing', () => {
+    // 170°E → 170°W: dLon = -340, well past the -180 threshold
+    const segs = splitAtAntimeridian([[170, 45], [-170, 45]]);
+    expect(segs).toHaveLength(2);
+    expect(segs[0][0]).toEqual([170, 45]);
+    expect(segs[0][segs[0].length - 1][0]).toBe(180);
+    expect(segs[1][0][0]).toBe(-180);
+    expect(segs[1][segs[1].length - 1]).toEqual([-170, 45]);
+    // Symmetric case: same lat at both ends, t = 0.5 → boundary lat = 45
+    expect(segs[0][segs[0].length - 1][1]).toBeCloseTo(45, 5);
+    expect(segs[1][0][1]).toBeCloseTo(45, 5);
+  });
+
+  it('handles multiple antimeridian crossings (→ 3 segments)', () => {
+    // 170°E → 170°W → 170°E: two crossings
+    const segs = splitAtAntimeridian([[170, 0], [-170, 0], [170, 0]]);
+    expect(segs).toHaveLength(3);
+    // Original endpoints are preserved in the outer segments
+    expect(segs[0][0]).toEqual([170, 0]);
+    expect(segs[2][segs[2].length - 1]).toEqual([170, 0]);
+    // All join points fall on ±180°
+    expect(segs[0][segs[0].length - 1][0]).toBe(180);
+    expect(segs[1][0][0]).toBe(-180);
+    expect(segs[1][segs[1].length - 1][0]).toBe(-180);
+    expect(segs[2][0][0]).toBe(180);
+  });
+
+  it('interpolates latitude in Mercator space, not linearly', () => {
+    // 179°E → 178°W: dLon = -357, dLonUnwrapped = 3, t = (180-179)/3 = 1/3.
+    // Mercator-interpolated boundary latitude at t=1/3 from 30° to 60° is
+    // ~41.9°, which differs measurably from the linear value of 40°.
+    const segs = splitAtAntimeridian([[179, 30], [-178, 60]]);
+    expect(segs).toHaveLength(2);
+    const latAtBoundary = segs[0][segs[0].length - 1][1];
+    expect(latAtBoundary).toBeGreaterThan(30);
+    expect(latAtBoundary).toBeLessThan(60);
+    // Differs from naive linear interpolation (30 + 1/3 * 30 = 40)
+    expect(latAtBoundary).not.toBeCloseTo(40, 1);
+    // Both segment boundary points agree
+    expect(segs[1][0][1]).toBeCloseTo(latAtBoundary, 10);
+  });
+
+  it('boundary points at ±180° are synthetic — not present in the input', () => {
+    // The function inserts ±180° boundary points only as segment join points.
+    // This is the invariant that prevents them from being persisted as route
+    // waypoints when the route is saved after editing.
+    const input: [number, number][] = [[179, 0], [-179, 0]];
+    const segs = splitAtAntimeridian(input);
+    const allPoints = segs.flat() as [number, number][];
+    // Original waypoints survive
+    expect(allPoints).toContainEqual([179, 0]);
+    expect(allPoints).toContainEqual([-179, 0]);
+    // Exactly two synthetic boundary points exist
+    const synthetic = allPoints.filter((p) => Math.abs(p[0]) === 180);
+    expect(synthetic).toHaveLength(2);
+    // None of the original input coordinates touch ±180°
+    expect(input.some((p) => Math.abs(p[0]) === 180)).toBe(false);
+  });
+
+  it('does not mutate the input array', () => {
+    const input: [number, number][] = [[170, 0], [-170, 0]];
+    const copy: [number, number][] = input.map((p) => [p[0], p[1]]);
+    splitAtAntimeridian(input);
+    expect(input[0]).toEqual(copy[0]);
+    expect(input[1]).toEqual(copy[1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapifyCoords — longitude unwrapping used to build the scratch geometry
+// for the OL Modify interaction during route editing
+// ---------------------------------------------------------------------------
+
+describe('mapifyCoords', () => {
+  it('returns a short route unchanged', () => {
+    const coords: [number, number][] = [[0, 0], [10, 0], [20, 0]];
+    expect(mapifyCoords(coords)).toEqual([[0, 0], [10, 0], [20, 0]]);
+  });
+
+  it('unwraps an eastbound crossing into continuous coordinates > 180°', () => {
+    // 170°E → 170°W going east: the raw -170 unwraps to +190 relative to 170
+    const coords: [number, number][] = [[170, 0], [-170, 0]];
+    const result = mapifyCoords(coords);
+    expect(result[0][0]).toBeCloseTo(170, 5);
+    expect(result[1][0]).toBeCloseTo(190, 5);
+  });
+
+  it('unwraps a westbound crossing into continuous coordinates < -180°', () => {
+    // 170°W → 170°E going west: the raw +170 unwraps to -190 relative to -170
+    const coords: [number, number][] = [[-170, 0], [170, 0]];
+    const result = mapifyCoords(coords);
+    expect(result[0][0]).toBeCloseTo(-170, 5);
+    expect(result[1][0]).toBeCloseTo(-190, 5);
+  });
+
+  it('normalises a first point that is outside [-180, 180]', () => {
+    const coords: [number, number][] = [[185, 0], [190, 0]];
+    const result = mapifyCoords(coords);
+    expect(result[0][0]).toBeCloseTo(-175, 5); // 185 - 360
+  });
+
+  it('returns a single-point array unchanged', () => {
+    const coords: [number, number][] = [[90, 45]];
+    expect(mapifyCoords(coords)).toEqual([[90, 45]]);
+  });
+});

--- a/src/app/modules/map/ol/lib/util.spec.ts
+++ b/src/app/modules/map/ol/lib/util.spec.ts
@@ -150,4 +150,14 @@ describe('mapifyCoords', () => {
     const coords: [number, number][] = [[90, 45]];
     expect(mapifyCoords(coords)).toEqual([[90, 45]]);
   });
+
+  it('does not mutate the input tuples (regression: shallow-copy callers are safe)', () => {
+    // Before the fix, coords[i][0] -= 360 wrote through shallow-copied tuples
+    // back to the cached SK route coordinates. Verify the originals are intact.
+    const original: [number, number][] = [[170, 0], [-170, 0]];
+    const snapshot: [number, number][] = original.map((p) => [p[0], p[1]]);
+    mapifyCoords(original);
+    expect(original[0]).toEqual(snapshot[0]);
+    expect(original[1]).toEqual(snapshot[1]);
+  });
 });

--- a/src/app/modules/map/ol/lib/util.spec.ts
+++ b/src/app/modules/map/ol/lib/util.spec.ts
@@ -17,14 +17,25 @@ describe('splitAtAntimeridian', () => {
   });
 
   it('returns one segment when no antimeridian is crossed', () => {
-    const segs = splitAtAntimeridian([[0, 0], [10, 0], [20, 0]]);
+    const segs = splitAtAntimeridian([
+      [0, 0],
+      [10, 0],
+      [20, 0]
+    ]);
     expect(segs).toHaveLength(1);
-    expect(segs[0]).toEqual([[0, 0], [10, 0], [20, 0]]);
+    expect(segs[0]).toEqual([
+      [0, 0],
+      [10, 0],
+      [20, 0]
+    ]);
   });
 
   it('splits an eastbound crossing (179°E → 179°W, crossing at +180°)', () => {
     // dLon = -179 - 179 = -358 < -180 → eastward branch
-    const segs = splitAtAntimeridian([[179, 0], [-179, 0]]);
+    const segs = splitAtAntimeridian([
+      [179, 0],
+      [-179, 0]
+    ]);
     expect(segs).toHaveLength(2);
     expect(segs[0][0]).toEqual([179, 0]);
     expect(segs[0][segs[0].length - 1][0]).toBe(180);
@@ -36,7 +47,10 @@ describe('splitAtAntimeridian', () => {
 
   it('splits a westbound crossing (179°W → 179°E, crossing at -180°)', () => {
     // dLon = 179 - (-179) = 358 > 180 → westward branch
-    const segs = splitAtAntimeridian([[-179, 0], [179, 0]]);
+    const segs = splitAtAntimeridian([
+      [-179, 0],
+      [179, 0]
+    ]);
     expect(segs).toHaveLength(2);
     expect(segs[0][0]).toEqual([-179, 0]);
     expect(segs[0][segs[0].length - 1][0]).toBe(-180);
@@ -47,7 +61,10 @@ describe('splitAtAntimeridian', () => {
 
   it('handles a large longitude span eastbound crossing', () => {
     // 170°E → 170°W: dLon = -340, well past the -180 threshold
-    const segs = splitAtAntimeridian([[170, 45], [-170, 45]]);
+    const segs = splitAtAntimeridian([
+      [170, 45],
+      [-170, 45]
+    ]);
     expect(segs).toHaveLength(2);
     expect(segs[0][0]).toEqual([170, 45]);
     expect(segs[0][segs[0].length - 1][0]).toBe(180);
@@ -60,7 +77,11 @@ describe('splitAtAntimeridian', () => {
 
   it('handles multiple antimeridian crossings (→ 3 segments)', () => {
     // 170°E → 170°W → 170°E: two crossings
-    const segs = splitAtAntimeridian([[170, 0], [-170, 0], [170, 0]]);
+    const segs = splitAtAntimeridian([
+      [170, 0],
+      [-170, 0],
+      [170, 0]
+    ]);
     expect(segs).toHaveLength(3);
     // Original endpoints are preserved in the outer segments
     expect(segs[0][0]).toEqual([170, 0]);
@@ -76,7 +97,10 @@ describe('splitAtAntimeridian', () => {
     // 179°E → 178°W: dLon = -357, dLonUnwrapped = 3, t = (180-179)/3 = 1/3.
     // Mercator-interpolated boundary latitude at t=1/3 from 30° to 60° is
     // ~41.9°, which differs measurably from the linear value of 40°.
-    const segs = splitAtAntimeridian([[179, 30], [-178, 60]]);
+    const segs = splitAtAntimeridian([
+      [179, 30],
+      [-178, 60]
+    ]);
     expect(segs).toHaveLength(2);
     const latAtBoundary = segs[0][segs[0].length - 1][1];
     expect(latAtBoundary).toBeGreaterThan(30);
@@ -91,7 +115,10 @@ describe('splitAtAntimeridian', () => {
     // The function inserts ±180° boundary points only as segment join points.
     // This is the invariant that prevents them from being persisted as route
     // waypoints when the route is saved after editing.
-    const input: [number, number][] = [[179, 0], [-179, 0]];
+    const input: [number, number][] = [
+      [179, 0],
+      [-179, 0]
+    ];
     const segs = splitAtAntimeridian(input);
     const allPoints = segs.flat() as [number, number][];
     // Original waypoints survive
@@ -105,7 +132,10 @@ describe('splitAtAntimeridian', () => {
   });
 
   it('does not mutate the input array', () => {
-    const input: [number, number][] = [[170, 0], [-170, 0]];
+    const input: [number, number][] = [
+      [170, 0],
+      [-170, 0]
+    ];
     const copy: [number, number][] = input.map((p) => [p[0], p[1]]);
     splitAtAntimeridian(input);
     expect(input[0]).toEqual(copy[0]);
@@ -120,13 +150,24 @@ describe('splitAtAntimeridian', () => {
 
 describe('mapifyCoords', () => {
   it('returns a short route unchanged', () => {
-    const coords: [number, number][] = [[0, 0], [10, 0], [20, 0]];
-    expect(mapifyCoords(coords)).toEqual([[0, 0], [10, 0], [20, 0]]);
+    const coords: [number, number][] = [
+      [0, 0],
+      [10, 0],
+      [20, 0]
+    ];
+    expect(mapifyCoords(coords)).toEqual([
+      [0, 0],
+      [10, 0],
+      [20, 0]
+    ]);
   });
 
   it('unwraps an eastbound crossing into continuous coordinates > 180°', () => {
     // 170°E → 170°W going east: the raw -170 unwraps to +190 relative to 170
-    const coords: [number, number][] = [[170, 0], [-170, 0]];
+    const coords: [number, number][] = [
+      [170, 0],
+      [-170, 0]
+    ];
     const result = mapifyCoords(coords);
     expect(result[0][0]).toBeCloseTo(170, 5);
     expect(result[1][0]).toBeCloseTo(190, 5);
@@ -134,14 +175,20 @@ describe('mapifyCoords', () => {
 
   it('unwraps a westbound crossing into continuous coordinates < -180°', () => {
     // 170°W → 170°E going west: the raw +170 unwraps to -190 relative to -170
-    const coords: [number, number][] = [[-170, 0], [170, 0]];
+    const coords: [number, number][] = [
+      [-170, 0],
+      [170, 0]
+    ];
     const result = mapifyCoords(coords);
     expect(result[0][0]).toBeCloseTo(-170, 5);
     expect(result[1][0]).toBeCloseTo(-190, 5);
   });
 
   it('normalises a first point that is outside [-180, 180]', () => {
-    const coords: [number, number][] = [[185, 0], [190, 0]];
+    const coords: [number, number][] = [
+      [185, 0],
+      [190, 0]
+    ];
     const result = mapifyCoords(coords);
     expect(result[0][0]).toBeCloseTo(-175, 5); // 185 - 360
   });
@@ -154,7 +201,10 @@ describe('mapifyCoords', () => {
   it('does not mutate the input tuples (regression: shallow-copy callers are safe)', () => {
     // Before the fix, coords[i][0] -= 360 wrote through shallow-copied tuples
     // back to the cached SK route coordinates. Verify the originals are intact.
-    const original: [number, number][] = [[170, 0], [-170, 0]];
+    const original: [number, number][] = [
+      [170, 0],
+      [-170, 0]
+    ];
     const snapshot: [number, number][] = original.map((p) => [p[0], p[1]]);
     mapifyCoords(original);
     expect(original[0]).toEqual(snapshot[0]);

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -80,6 +80,53 @@ export function mapifyCoords(
   return coords;
 }
 
+/**
+ * Split a LineString at each antimeridian (±180°) crossing.
+ * Input coordinates must be in [-180, 180].
+ * Returns an array of segments, each fully within [-180, 180], with
+ * interpolated endpoints at exactly ±180° where crossings occur.
+ * Each segment can be passed independently to fromLonLatArray so that
+ * OpenLayers wrapX cloning works correctly on each compact piece.
+ */
+export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
+  if (coords.length < 2) return coords.length === 0 ? [] : [coords];
+
+  const segments: Coordinate[][] = [];
+  let current: Coordinate[] = [[coords[0][0], coords[0][1]]];
+
+  for (let i = 1; i < coords.length; i++) {
+    const [x0, y0] = current[current.length - 1];
+    const [x1, y1] = [coords[i][0], coords[i][1]];
+    const dLon = x1 - x0;
+
+    if (dLon > 180) {
+      // Westward crossing: x0 is east (positive), x1 is west (negative)
+      const dLonUnwrapped = dLon - 360;
+      const t = (-180 - x0) / dLonUnwrapped;
+      const yIntercept = y0 + t * (y1 - y0);
+      current.push([-180, yIntercept]);
+      segments.push(current);
+      current = [[180, yIntercept], [x1, y1]];
+    } else if (dLon < -180) {
+      // Eastward crossing: x0 is west (negative), x1 is east (positive)
+      const dLonUnwrapped = dLon + 360;
+      const t = (180 - x0) / dLonUnwrapped;
+      const yIntercept = y0 + t * (y1 - y0);
+      current.push([180, yIntercept]);
+      segments.push(current);
+      current = [[-180, yIntercept], [x1, y1]];
+    } else {
+      current.push([x1, y1]);
+    }
+  }
+
+  if (current.length >= 2) {
+    segments.push(current);
+  }
+
+  return segments;
+}
+
 // ** return adjusted radius to correctly render circle on ground at given position.
 export function mapifyRadius(radius: number, position: Coordinate): number {
   if (typeof radius === 'undefined' || typeof position === 'undefined') {

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -88,6 +88,17 @@ export function mapifyCoords(
  * Each segment can be passed independently to fromLonLatArray so that
  * OpenLayers wrapX cloning works correctly on each compact piece.
  */
+/** Convert latitude (degrees) to Mercator Y. */
+function latToMercY(latDeg: number): number {
+  const latRad = (latDeg * Math.PI) / 180;
+  return Math.log(Math.tan(Math.PI / 4 + latRad / 2));
+}
+
+/** Convert Mercator Y back to latitude (degrees). */
+function mercYToLat(mercY: number): number {
+  return ((2 * Math.atan(Math.exp(mercY)) - Math.PI / 2) * 180) / Math.PI;
+}
+
 export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
   if (coords.length < 2) return coords.length === 0 ? [] : [coords];
 
@@ -103,7 +114,9 @@ export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
       // Westward crossing: x0 is east (positive), x1 is west (negative)
       const dLonUnwrapped = dLon - 360;
       const t = (-180 - x0) / dLonUnwrapped;
-      const yIntercept = y0 + t * (y1 - y0);
+      const yIntercept = mercYToLat(
+        latToMercY(y0) + t * (latToMercY(y1) - latToMercY(y0))
+      );
       current.push([-180, yIntercept]);
       segments.push(current);
       current = [[180, yIntercept], [x1, y1]];
@@ -111,7 +124,9 @@ export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
       // Eastward crossing: x0 is west (negative), x1 is east (positive)
       const dLonUnwrapped = dLon + 360;
       const t = (180 - x0) / dLonUnwrapped;
-      const yIntercept = y0 + t * (y1 - y0);
+      const yIntercept = mercYToLat(
+        latToMercY(y0) + t * (latToMercY(y1) - latToMercY(y0))
+      );
       current.push([180, yIntercept]);
       segments.push(current);
       current = [[-180, yIntercept], [x1, y1]];

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -40,42 +40,23 @@ export function fromLonLatArray(
   }
 }
 
-/** DateLine Crossing:
- * returns true if point is in the zone for dateline transition
- * zoneValue: lower end of 180 to xx range within which Longitude must fall for retun value to be true
- **/
-export function inDLCrossingZone(coord: Coordinate, zoneValue = 170) {
-  return Math.abs(coord[0]) >= zoneValue ? true : false;
-}
-
-// update linestring coords for map display (including dateline crossing)
-export function mapifyCoords(
-  coords: Array<Coordinate>,
-  zoneValue?: number
-): Array<Coordinate> {
-  if (coords.length === 0) {
+/**
+ * Unwrap longitudes so that consecutive points never jump by more than 180°,
+ * then shift the whole line so the first coordinate is in [-180, 180].
+ * This keeps the resulting extent within one Mercator world width so that
+ * OpenLayers wrapX can clone the feature correctly in adjacent world copies.
+ */
+export function mapifyCoords(coords: Array<Coordinate>): Array<Coordinate> {
+  if (coords.length < 2) {
     return coords;
   }
-  let dlCrossing = 0;
-  const last = coords[0];
-  for (let i = 0; i < coords.length; i++) {
-    if (
-      inDLCrossingZone(coords[i], zoneValue) ||
-      inDLCrossingZone(last, zoneValue)
-    ) {
-      dlCrossing =
-        last[0] > 0 && coords[i][0] < 0
-          ? 1
-          : last[0] < 0 && coords[i][0] > 0
-            ? -1
-            : 0;
-      if (dlCrossing === 1) {
-        coords[i][0] = coords[i][0] + 360;
-      }
-      if (dlCrossing === -1) {
-        coords[i][0] = Math.abs(coords[i][0]) - 360;
-      }
-    }
+  // Normalise the first point to [-180, 180].
+  while (coords[0][0] > 180) coords[0][0] -= 360;
+  while (coords[0][0] < -180) coords[0][0] += 360;
+  // Unwrap subsequent points relative to their predecessor.
+  for (let i = 1; i < coords.length; i++) {
+    while (coords[i][0] - coords[i - 1][0] > 180) coords[i][0] -= 360;
+    while (coords[i - 1][0] - coords[i][0] > 180) coords[i][0] += 360;
   }
   return coords;
 }

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -102,7 +102,10 @@ export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
       );
       current.push([-180, yIntercept]);
       segments.push(current);
-      current = [[180, yIntercept], [x1, y1]];
+      current = [
+        [180, yIntercept],
+        [x1, y1]
+      ];
     } else if (dLon < -180) {
       // Eastward crossing: x0 is east (positive), x1 is west (negative)
       const dLonUnwrapped = dLon + 360;
@@ -112,7 +115,10 @@ export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
       );
       current.push([180, yIntercept]);
       segments.push(current);
-      current = [[-180, yIntercept], [x1, y1]];
+      current = [
+        [-180, yIntercept],
+        [x1, y1]
+      ];
     } else {
       current.push([x1, y1]);
     }

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -61,14 +61,6 @@ export function mapifyCoords(coords: Array<Coordinate>): Array<Coordinate> {
   return coords;
 }
 
-/**
- * Split a LineString at each antimeridian (±180°) crossing.
- * Input coordinates must be in [-180, 180].
- * Returns an array of segments, each fully within [-180, 180], with
- * interpolated endpoints at exactly ±180° where crossings occur.
- * Each segment can be passed independently to fromLonLatArray so that
- * OpenLayers wrapX cloning works correctly on each compact piece.
- */
 /** Convert latitude (degrees) to Mercator Y. */
 function latToMercY(latDeg: number): number {
   const latRad = (latDeg * Math.PI) / 180;
@@ -80,6 +72,14 @@ function mercYToLat(mercY: number): number {
   return ((2 * Math.atan(Math.exp(mercY)) - Math.PI / 2) * 180) / Math.PI;
 }
 
+/**
+ * Split a LineString at each antimeridian (±180°) crossing.
+ * Input coordinates must be in [-180, 180].
+ * Returns an array of segments, each fully within [-180, 180], with
+ * interpolated endpoints at exactly ±180° where crossings occur.
+ * Each segment can be passed independently to fromLonLatArray so that
+ * OpenLayers wrapX cloning works correctly on each compact piece.
+ */
 export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
   if (coords.length < 2) return coords.length === 0 ? [] : [coords];
 
@@ -92,7 +92,7 @@ export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
     const dLon = x1 - x0;
 
     if (dLon > 180) {
-      // Westward crossing: x0 is east (positive), x1 is west (negative)
+      // Westward crossing: x0 is west (negative), x1 is east (positive)
       const dLonUnwrapped = dLon - 360;
       const t = (-180 - x0) / dLonUnwrapped;
       const yIntercept = mercYToLat(
@@ -102,7 +102,7 @@ export function splitAtAntimeridian(coords: Coordinate[]): Coordinate[][] {
       segments.push(current);
       current = [[180, yIntercept], [x1, y1]];
     } else if (dLon < -180) {
-      // Eastward crossing: x0 is west (negative), x1 is east (positive)
+      // Eastward crossing: x0 is east (positive), x1 is west (negative)
       const dLonUnwrapped = dLon + 360;
       const t = (180 - x0) / dLonUnwrapped;
       const yIntercept = mercYToLat(

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -50,15 +50,17 @@ export function mapifyCoords(coords: Array<Coordinate>): Array<Coordinate> {
   if (coords.length < 2) {
     return coords;
   }
+  // Deep-copy the tuples so the caller's coordinate objects are not modified.
+  const out: Array<Coordinate> = coords.map((p) => [p[0], p[1]] as Coordinate);
   // Normalise the first point to [-180, 180].
-  while (coords[0][0] > 180) coords[0][0] -= 360;
-  while (coords[0][0] < -180) coords[0][0] += 360;
+  while (out[0][0] > 180) out[0][0] -= 360;
+  while (out[0][0] < -180) out[0][0] += 360;
   // Unwrap subsequent points relative to their predecessor.
-  for (let i = 1; i < coords.length; i++) {
-    while (coords[i][0] - coords[i - 1][0] > 180) coords[i][0] -= 360;
-    while (coords[i - 1][0] - coords[i][0] > 180) coords[i][0] += 360;
+  for (let i = 1; i < out.length; i++) {
+    while (out[i][0] - out[i - 1][0] > 180) out[i][0] -= 360;
+    while (out[i - 1][0] - out[i][0] > 180) out[i][0] += 360;
   }
-  return coords;
+  return out;
 }
 
 /** Convert latitude (degrees) to Mercator Y. */

--- a/src/app/modules/map/ol/lib/vessel/layer-vessel-trail.component.ts
+++ b/src/app/modules/map/ol/lib/vessel/layer-vessel-trail.component.ts
@@ -14,10 +14,10 @@ import { Feature } from 'ol';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Style, Stroke } from 'ol/style';
-import { Geometry, MultiLineString, LineString } from 'ol/geom';
+import { Geometry, MultiLineString } from 'ol/geom';
 import { MapComponent } from '../map.component';
 import { Extent, Coordinate } from '../models';
-import { fromLonLatArray, mapifyCoords } from '../util';
+import { fromLonLatArray, splitAtAntimeridian } from '../util';
 import { AsyncSubject } from 'rxjs';
 
 // ** Freeboard Vessel trail component **
@@ -131,10 +131,12 @@ export class VesselTrailComponent implements OnInit, OnDestroy, OnChanges {
     if (!this.localTrail) {
       return;
     }
-    const c = fromLonLatArray(mapifyCoords(this.localTrail));
+    const ca = splitAtAntimeridian(this.localTrail).map((seg) =>
+      fromLonLatArray(seg)
+    );
     if (!this.trailLocal) {
       // create feature
-      this.trailLocal = new Feature(new LineString(c));
+      this.trailLocal = new Feature(new MultiLineString(ca));
       this.trailLocal.setId('trail.self.local');
       this.trailLocal.setStyle(this.buildStyle('local'));
     } else {
@@ -144,7 +146,7 @@ export class VesselTrailComponent implements OnInit, OnDestroy, OnChanges {
       ) as Feature;
       if (this.localTrail && Array.isArray(this.localTrail)) {
         const g: Geometry = this.trailLocal.getGeometry();
-        (g as LineString).setCoordinates(c);
+        (g as MultiLineString).setCoordinates(ca);
       }
     }
   }
@@ -153,9 +155,9 @@ export class VesselTrailComponent implements OnInit, OnDestroy, OnChanges {
     if (!this.serverTrail) {
       return;
     }
-    const ca = this.serverTrail.map((t: Array<Coordinate>) => {
-      return fromLonLatArray(mapifyCoords(t));
-    });
+    const ca = this.serverTrail.flatMap((t: Array<Coordinate>) =>
+      splitAtAntimeridian(t).map((seg) => fromLonLatArray(seg))
+    );
     if (!this.trailServer) {
       // create feature
       this.trailServer = new Feature(new MultiLineString(ca));


### PR DESCRIPTION
## Problem

Tracks and routes are drawn using `mapifyCoords` which also handles the drawing across the antimeridian.
   The function had two bugs that caused tracks and routes to "jump" across
   the globe when crossing the antimeridian:

   - Segments with a large longitudinal range were not handled correctly.
   - Each point was compared to the *first* point rather than its predecessor,
     so jumps accumulated on multi-segment tracks.

   Additionally, unwrapping coordinates beyond ±180° (the old fix) caused
   OpenLayers to render features only once instead of cloning them into adjacent
   world copies — so a circum-global track would appear to vanish on one half
   of the screen.

   ## Solution

   `mapifyCoords` is replaced by `splitAtAntimeridian`, which splits each
   crossing segment at exactly ±180°, inserting Mercator-interpolated boundary
   points. All resulting sub-segments stay within [-180°, 180°], so OL's wrapX
   mechanism correctly clones every piece into adjacent world copies.

   ## Scope

   This PR touches three related areas, all of which are required for correct
   antimeridian behaviour:

   **1. Track / trail rendering** (`layer-vessel-trail`, `layer-tracks`,
   `layer-aistargets-track`): replace `mapifyCoords` with `splitAtAntimeridian`,
   change geometry type from `LineString` to `MultiLineString` where needed.

   **2. Route rendering and editing** (`layer-routes`): routes are now
   `MultiLineString` features split at the antimeridian.  Route editing required
   two coupled changes:
   - The OL `Modify` interaction sees a scratch `LineString` built with
     `mapifyCoords` (unwrapped, no split-boundary vertices), so the user never
     drags a phantom ±180° vertex.
   - After each vertex drop, `FreeboardRouteLayerComponent.updateRouteSegments`
     re-splits at the antimeridian and updates the rendered `MultiLineString`.
     The coordinates passed back to `measurementCoords` (and saved to the route)
     are always the original waypoints — the ±180° boundary points are never
     persisted.

   Without the editing changes, @panaaj's concern from the original review
   (phantom vertices becoming saved waypoints) would apply.

   **3. World-copy popup and overlay placement** (`map.component.ts`,
   `fb-map.component.ts`): click events now use `transform()` instead of
   `toLonLat()` so that the raw Mercator x-coordinate (which encodes the world
   copy, e.g. 190° for world +1) is preserved. Vessel / AIS / AtoN popups and
   overlays are shifted to the world copy the user actually clicked — without
   this, clicking a vessel in the eastern world copy would place the popup in
   the primary [-180°, 180°] copy, visually detached from the icon.

   These three areas form a single coherent fix: the rendering change alone
   produces correct visuals, but the editing and popup changes are necessary for
   correct interactive behaviour once features span ±180°.

   ## Testing

   `src/app/modules/map/ol/lib/util.spec.ts` covers `splitAtAntimeridian`:
   eastbound crossing, westbound crossing, large longitude span, multiple
   crossings, Mercator latitude interpolation, and the invariant that ±180°
   boundary points are not present in the original coordinate list (and therefore
   cannot be persisted as route waypoints).

## Some screenshots of the problem and how it looks fixed
 
Broken
<img width="1919" height="356" alt="Screenshot From 2026-04-16 22-32-09" src="https://github.com/user-attachments/assets/c446584f-0e79-4670-9811-3e0b3c6c6d97" />
Fixed
<img width="1920" height="388" alt="Screenshot From 2026-04-17 08-10-03" src="https://github.com/user-attachments/assets/b1f1b692-1a6d-49c2-8857-1f83eb60633f" />
Broken:
<img width="1920" height="388" alt="Screenshot From 2026-04-16 22-33-11" src="https://github.com/user-attachments/assets/fda5a8c7-ebba-46c0-9146-dab3a0f071f5" />

Fixed
<img width="1920" height="388" alt="Screenshot From 2026-04-17 08-07-22" src="https://github.com/user-attachments/assets/342efdff-7df1-4c53-8a70-e3d8801609e7" />


Route broken:
<img width="1009" height="330" alt="Screenshot From 2026-04-17 18-42-19" src="https://github.com/user-attachments/assets/26197f16-d2aa-447e-a971-fc4d42488333" />
 Route fixed:
<img width="1009" height="330" alt="Screenshot From 2026-04-17 18-45-56" src="https://github.com/user-attachments/assets/cda1a697-84a1-4d41-88dd-dd8ddec5e0d3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Improved map rendering and overlay alignment when crossing the international date line (vessels, AIS tracks, routes, and trails).
  - Popovers now consistently open at the selected wrapped “world copy” position.
  - Route editing preserves correct geometry (avoids phantom vertices) and refreshes visible route segments immediately.
  - Route waypoint markers and directional symbols display correctly near ±180°.
  - Map click and right-click coordinates now retain wrapped longitude.

- **Tests**
  - Added coverage for antimeridian splitting and coordinate unwrapping helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->