### PR TITLE
fix(skresources): tolerate routes and waypoints missing feature.properties

### DIFF
--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -989,7 +989,7 @@ export class SKResourceService {
     }
     // ensure coords & coordsMeta array lengths are aligned
     if (
-      rte.feature.properties.coordinatesMeta &&
+      rte.feature?.properties?.coordinatesMeta &&
       rte.feature.properties.coordinatesMeta.length !==
         rte.feature.geometry.coordinates.length
     ) {
@@ -1246,6 +1246,9 @@ export class SKResourceService {
     if (typeof (wpt as any).position !== 'undefined') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (wpt as any).position;
+    }
+    if (wpt.feature && !wpt.feature.properties) {
+      wpt.feature.properties = {};
     }
     if (!wpt.name) {
       if (wpt.feature.properties.name) {


### PR DESCRIPTION
## Problem

Reported by a user running an openplotter.local install:

```
TypeError: can't access property "coordinatesMeta", t.feature.properties is undefined
    transformRoute https://openplotter.local/@signalk/freeboard-sk/main-6U2EOOC2.js:81
    transform ...
    listFromServer ...
```

A single malformed route in the SignalK resource store takes out the whole freeboard-sk resources UI on every fetch. The user produced this reproducer: a route that has `feature.type` and `feature.geometry` but no `feature.properties`:

```json
{
  "key": "87ddb937-dd24-417d-bddb-421f914b0e82",
  "value": {
    "name": "Marcs Route Test",
    "feature": {
      "type": "Feature",
      "geometry": { "type": "LineString", "coordinates": [[...], [...], [...], [...]] }
    },
    "timestamp": "...",
    "$source": "resources-provider"
  }
}
```

GeoJSON RFC-7946 says `properties` is required on every Feature (can be `null`, must be present), so this payload is malformed. But the server stores it, and freeboard-sk should not crash the whole routes list because one third-party producer shipped a slightly-off route — the [recently-merged note-properties fix](https://github.com/SignalK/freeboard-sk/pull/347) already established the shape-tolerance precedent.

## Root cause

Two call sites in `src/app/modules/skresources/resources.service.ts` dereference `feature.properties` without any guard, while sibling reads in the same functions use optional chaining:

1. **`transformRoute` line 992** — the `coordinatesMeta` length-alignment check. The matching block above at line 969 (`rte.feature?.properties?.points`) is already guarded; this one was missed. This is what the user hit.
2. **`transformWaypoint` lines 1251, 1260, 1263, 1267** — four unguarded reads of `wpt.feature.properties.*`. Same shape bug class, same file. A waypoint without `feature.properties` would crash on the same line as routes do today — just hasn't been triggered yet because ONA Plotter doesn't produce malformed waypoints.

Both hotspots have existed on master since 2023-04-17.

## Fix

Two minimal changes in one file:

### `transformRoute` — add `?.` to the coordinatesMeta guard

```diff
-    if (
-      rte.feature.properties.coordinatesMeta &&
+    if (
+      rte.feature?.properties?.coordinatesMeta &&
       rte.feature.properties.coordinatesMeta.length !==
         rte.feature.geometry.coordinates.length
     ) {
       delete rte.feature.properties.coordinatesMeta;
     }
```

If `feature.properties` is undefined, the `&&` short-circuits and the block is skipped. Inside the block everything stays unguarded because we know `properties.coordinatesMeta` exists.

### `transformWaypoint` — normalise `feature.properties = {}` at the top

```diff
 private transformWaypoint(wpt: WaypointResource, id: string): SKWaypoint {
   // ...
+  if (wpt.feature && !wpt.feature.properties) {
+    wpt.feature.properties = {};
+  }
   if (!wpt.name) {
     if (wpt.feature.properties.name) {
```

One line covers all four subsequent unguarded reads without needing to change each one individually. Matches the shape-tolerance pattern already used for notes in #347.

## Compatibility

Both changes are backwards-compatible: well-formed routes and waypoints behave exactly as before, only the malformed-resource crash path is repaired.

## Verification

No existing unit tests for `resources.service.ts` to update. Manual verification: with the patched build, freeboard-sk loads the resources list cleanly against a SignalK server that contains the reproducer route above, whereas master crashes with the reported TypeError on the same server state.