### PR TITLE
Render S-57 RIVERS and LAKARE polygons by default

### DIFF
--- a/src/app/modules/map/ol/lib/charts/s57.service.ts
+++ b/src/app/modules/map/ol/lib/charts/s57.service.ts
@@ -51,7 +51,15 @@ export const DefaultOptions: Options = {
   boundaries: 'Plain',
   colors: 4,
   colorTable: 0, //color scheme
-  otherLayers: ['SOUNDG', 'OBSTRN', 'UWTROC', 'WRECKS', 'DEPCNT'],
+  otherLayers: [
+    'SOUNDG',
+    'OBSTRN',
+    'UWTROC',
+    'WRECKS',
+    'DEPCNT',
+    'RIVERS',
+    'LAKARE'
+  ],
   depthUnit: 'm'
 };
 

--- a/src/app/modules/settings/settings.facade.ts
+++ b/src/app/modules/settings/settings.facade.ts
@@ -123,7 +123,9 @@ export class SettingsOptions {
         ['LNDMRK', 'Landmarks'],
         ['DISMAR', 'Distance Marks'],
         ['CURENT', 'Currents'],
-        ['MAGVAR', 'Magnetic Variation']
+        ['MAGVAR', 'Magnetic Variation'],
+        ['RIVERS', 'Rivers'],
+        ['LAKARE', 'Lakes']
       ])
     }
   };


### PR DESCRIPTION
## Summary
Render S-57 RIVERS and LAKARE **polygons** by default. Currently they're invisible on most NOAA ENCs even though the S-52 lookup rules for them already exist in `chartsymbols.xml`.

## Why they're invisible today
S-52 categorises the polygon (Area) lookups for `RIVERS` and `LAKARE` as `display-cat: Other`. `getStyle` in `s57Style.ts` only returns styles when the lookup's `displayCategory` is `DISPLAYBASE`, `STANDARD`, `MARINERS_STANDARD`, or the layer name is in `options.otherLayers` — anything else falls through to `return null` and the feature is invisible. Result: rivers and lakes that NOAA encodes as polygons (most of them outside the open coastline — wider rivers, lakes, drainage basins) never draw, even though the S-52 symbolisation `AC(DEPVS);LS(SOLD,1,CHBLK)` is present and correct in `chartsymbols.xml`.

This was reported via the Signal K Discord against US ENC charts and is reproducible with any NOAA bundle that has wider rivers (Florida, Indiana, Mid-Atlantic, etc.).

## Fix
Add `'RIVERS'` and `'LAKARE'` to the `otherLayers` default in `DefaultOptions`, alongside the existing precedent of pulling in `SOUNDG` / `OBSTRN` / `UWTROC` / `WRECKS` / `DEPCNT` (also non-Standard but universally rendered).

Also expose them in the Settings dialog multi-select (`settings.facade.ts`) so users can toggle them like the other layers there.

## What about CANALS?
Deliberately not included — its lookups are already `display-cat: Displaybase` and pass the filter unmodified. No change needed.

## Line-geometry RIVERS
Already worked — the `Lines`-table lookup for RIVERS has `display-cat: Standard`. This PR is purely about the polygon case.

## Files changed
- `src/app/modules/map/ol/lib/charts/s57.service.ts` — add `RIVERS`, `LAKARE` to `DefaultOptions.otherLayers`.
- `src/app/modules/settings/settings.facade.ts` — add the human-readable labels so the Settings dropdown shows them.

## Tested
- `npm run build` — clean (only preexisting CommonJS warnings unrelated to this change).
