### PR TITLE
S-57: draw real-water DEPARE polygons above LNDARE

### DIFF
--- a/src/app/modules/map/ol/lib/charts/s57Style.ts
+++ b/src/app/modules/map/ol/lib/charts/s57Style.ts
@@ -1047,8 +1047,21 @@ export class S57Style {
     switch (layer) {
       case 'SEAARE':
         return 2;
-      case 'DEPARE':
-        return 3;
+      case 'DEPARE': {
+        // S-52 assigns DEPARE and LNDARE the same display priority ('Area 1' = 2),
+        // so the spec doesn't mandate which paints on top. We split DEPARE into
+        // two cases:
+        //   • DRVAL2 > 0 (real water at chart datum): draw above LNDARE so
+        //     constructed marina basins, lagoons and dredged channels that
+        //     producers encode as "land + water-on-top" render as water in
+        //     the renderer. Without this the basin appears as land even
+        //     though the chart contains correct depth data.
+        //   • Otherwise (drying flats, intertidal zones with DRVAL2 ≤ 0):
+        //     keep below LNDARE so they render as land at chart datum, which
+        //     is correct per S-52 convention for such areas.
+        const drval2 = properties['DRVAL2'];
+        return typeof drval2 === 'number' && drval2 > 0 ? 5.5 : 3;
+      }
       case 'DEPCNT':
         return 4;
       case 'LNDARE':


### PR DESCRIPTION
## Summary
Draw real-water `DEPARE` polygons (those with `DRVAL2 > 0`) above `LNDARE` instead of below it. Drying flats and intertidal zones (`DRVAL2 ≤ 0`) keep their current order below land. Affects rendering only — no source data is changed.

## Why
S-52 assigns `DEPARE` and `LNDARE` the **same display priority** ("Area 1" / priority 2). The spec does not mandate paint order between them. The existing `layerOrder()` in `s57Style.ts` puts LNDARE above DEPARE, which produces a visible bug on a known class of NOAA US ENC charts: marina basins and inland coastal lagoons that producers encode as "coarse LNDARE polygon over real-water DEPARE" render as solid land at high zooms even though the chart contains correct depth data and soundings underneath.

The basin appears as land. The chart data is right; the visual is wrong.

### Reproducible cases (US ENC, freely available)
- **US5CHIHV** (Michigan City, Indiana) — Outer Basin renders as tan with mooring slips drawn on top
- **US5FL41M / US4FL2EJ** (Palm Beach, Florida) — Lake Worth lagoon renders as tan with depth soundings drawn on top
- **NOAA Florida bundle** (`FL_ENCs.zip`) and Indiana bundle (`IN_ENCs.zip`) both exhibit this on the affected harbours

In each of these, `ogr2ogr` confirms the LNDARE polygon's exterior ring covers the basin without a hole, while one or more `DEPARE` features with `DRVAL2 > 0` describe the actual water depth in that footprint. With LNDARE on top, the water never paints.

## What changes
A two-branch case for `DEPARE` in `layerOrder()`:

```ts
case 'DEPARE': {
  const drval2 = properties['DRVAL2'];
  return typeof drval2 === 'number' && drval2 > 0 ? 5.5 : 3;
}
```

- `DRVAL2 > 0` (real water at chart datum) → **5.5**, above LNDARE (5)
- Anything else (drying flats, missing DRVAL2) → **3**, below LNDARE (existing behavior)

## Why this is safe
- **Drying flats are deliberately not affected.** A polygon with `DRVAL2 ≤ 0` has at least part of its surface exposed at chart datum, and S-52 convention is to render such areas as land. Keeping them at order 3 preserves that.
- **No other layer's order changes.** `SEAARE`, `DEPCNT`, `LNDARE`, `BUAARE`, `SOUNDG` are all unmoved.
- **Non-affected producers see no change in practice.** Where the LNDARE polygon already cuts a proper hole for the water body (the more common encoding outside US ENC), the LNDARE doesn't cover the DEPARE in the first place, so there's no DEPARE-on-top to be visible.
- **No source-data change.** This is a `renderOrder` tweak only; the same `.mbtiles` will render correctly across all renderers, this PR just makes Freeboard-SK match what the chart actually says.

## Tested
- `npm run build` — clean (only preexisting CommonJS warnings unrelated to this change).
- Behavior verified by inspection of the rendered tile pyramid against the source S-57 cells listed above.
