### PR TITLE
fix(s57-popover): tolerate stringified-array list attributes

### DIFF
--- a/src/app/modules/map/popovers/s57-popover.component.ts
+++ b/src/app/modules/map/popovers/s57-popover.component.ts
@@ -410,16 +410,48 @@ const PROP_DISPLAY: { key: string; label: string }[] = [
   { key: 'HORWID', label: 'Width' }
 ];
 
+// Normalise an S-57 list-typed value (COLOUR, STATUS, …) into a flat array
+// of code strings. Different chart producers and MBTiles converters serialise
+// these differently:
+//   - flat scalar:           "3"           (preferred — newer charts)
+//   - comma-separated:       "3,1"
+//   - native array:          ["3", "1"]    (rare, but possible)
+//   - JSON-stringified array: '["3","1"]'  (legacy MBTiles where an
+//     intermediate GeoJSON→MVT step stringified arrays)
+function toCodeList(val: unknown): string[] {
+  if (Array.isArray(val)) {
+    return val.map((v) => String(v).trim()).filter((v) => v !== '');
+  }
+  const s = String(val).trim();
+  if (s === '' || s === '[]') {
+    return [];
+  }
+  if (s.startsWith('[') && s.endsWith(']')) {
+    try {
+      const parsed = JSON.parse(s) as unknown;
+      if (Array.isArray(parsed)) {
+        return parsed.map((v) => String(v).trim()).filter((v) => v !== '');
+      }
+    } catch {
+      // not JSON — fall through to comma-split
+    }
+  }
+  return s
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v !== '');
+}
+
 function decodeValue(key: string, val: unknown): string {
-  const s = String(val);
+  const codes = toCodeList(val);
+  if (codes.length === 0) {
+    return '';
+  }
   const table = DECODE_TABLES[key];
   if (!table) {
-    return s;
+    return codes.join(', ');
   }
-  // Handle comma-separated multi-values (e.g. COLOUR "1,3")
-  const parts = s.split(',');
-  const decoded = parts.map((p) => table[p.trim()] || p.trim());
-  return decoded.join(', ');
+  return codes.map((c) => table[c] || c).join(', ');
 }
 
 const DEPTH_KEYS = new Set(['DEPTH', 'VALSOU', 'DRVAL1', 'DRVAL2', 'VALDCO']);


### PR DESCRIPTION
## Summary

S-57 list-typed attributes (COLOUR, STATUS, CATSPM, COLPAT, CATLIT, …) arrive in MVT feature properties in any of these shapes, depending on the chart producer / converter:

- scalar: `"3"`
- comma-separated: `"3,1"`
- native array: `["3","1"]`
- **JSON-stringified array**: `'["3","1"]'` — common when an upstream GeoJSON→MVT step stringifies arrays, since MVT properties must be scalar

The previous popup decoder only handled the scalar/comma-separated forms, so charts with stringified arrays rendered as the literal string `["3"]` in the popup instead of decoding to "Red". Empty arrays rendered as `[]`.

This change adds a `toCodeList` normaliser that handles all four shapes, then decodes via the existing per-attribute tables. Empty arrays/strings now return `""` so the popup row is hidden (cleaner than showing `Colour: []`).

## Tested

- Bench-tested the decoder against all input shapes (scalar number, scalar string, comma-separated, native array, JSON-stringified array, empty array, empty string, unknown code) — all produce expected output.
- Built with `npm run build:all`; existing 33 tests pass via `npm test`.
- End-to-end: clicked a Saint Joseph beacon on a NOAA US ENC chart at zoom 9 (where the MBTiles carries `COLOUR='["1"]'`, `CATSPM='["27"]'`, `STATUS='["1"]'`). Popup now displays "Colour: White / Purpose: Warning / Status: Permanent" instead of `["1"]` / `["27"]` / `["1"]`.