### PR TITLE
perf(app): lazy-load dialog components on demand

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,7 +11,6 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { OverlayContainer } from '@angular/cdk/overlay';
-import { Observable, Subject } from 'rxjs';
 
 // standalone
 import { CommonModule } from '@angular/common';
@@ -45,10 +44,8 @@ import {
   AtoNPropertiesModal,
   AircraftPropertiesModal,
   ActiveResourcePropertiesModal,
-  ResourceImportDialog,
   ResourceSetModal,
   ResourceSetFeatureModal,
-  SettingsDialog,
   SKStreamFacade,
   SKSTREAM_MODE,
   StreamOptions,
@@ -63,8 +60,6 @@ import {
   WeatherForecastModal,
   CourseSettingsModal,
   NotificationManager,
-  GPXImportDialog,
-  GPXExportDialog,
   CourseService,
   SettingsFacade,
   AutopilotService,
@@ -89,13 +84,18 @@ import {
   RegionPanel
 } from 'src/app/modules';
 
-import {
+import type { ResourceImportDialog } from 'src/app/modules/skresources/components/resourcesets/resource-upload-dialog';
+import type { SettingsDialog } from 'src/app/modules/settings/components/settings-dialog';
+import type { GPXImportDialog } from 'src/app/modules/gpx/gpxload-dialog';
+import type { GPXExportDialog } from 'src/app/modules/gpx/gpxsave-dialog';
+
+import type {
   AboutDialog,
-  LoginDialog,
-  PlaybackDialog,
-  GeoJSONImportDialog,
-  Trail2RouteDialog
-} from 'src/app/lib/components/dialogs';
+  LoginDialog
+} from 'src/app/lib/components/dialogs/common-dialogs';
+import type { PlaybackDialog } from 'src/app/lib/components/dialogs/playback-dialog';
+import type { GeoJSONImportDialog } from 'src/app/lib/components/dialogs/geojson/geojson-dialog';
+import type { Trail2RouteDialog } from 'src/app/lib/components/dialogs/trail2route-dialog';
 import { Convert } from 'src/app/lib/convert';
 import { GeoUtils } from 'src/app/lib/geoutils';
 
@@ -610,7 +610,9 @@ export class AppComponent {
     }
   }
   // ** create route from vessel trail **
-  protected trailToRoute() {
+  protected async trailToRoute() {
+    const { Trail2RouteDialog } =
+      await import('src/app/lib/components/dialogs/trail2route-dialog');
     this.dialog
       .open(Trail2RouteDialog, {
         disableClose: true,
@@ -1071,8 +1073,9 @@ export class AppComponent {
 
   // ********* MAIN MENU ACTIONS *************
 
-  // ** open about dialog **
-  protected openAbout() {
+  protected async openAbout() {
+    const { AboutDialog } =
+      await import('src/app/lib/components/dialogs/common-dialogs');
     this.dialog
       .open(AboutDialog, {
         disableClose: false,
@@ -1088,8 +1091,9 @@ export class AppComponent {
       .subscribe(() => this.focusMap());
   }
 
-  // ** open settings dialog **
-  protected openSettings() {
+  protected async openSettings() {
+    const { SettingsDialog } =
+      await import('src/app/modules/settings/components/settings-dialog');
     this.dialog
       .open(SettingsDialog, {
         disableClose: true,
@@ -1118,7 +1122,9 @@ export class AppComponent {
   }
 
   /** process GPX file */
-  protected processGPX(f: { data: string | ArrayBuffer; name: string }) {
+  protected async processGPX(f: { data: string | ArrayBuffer; name: string }) {
+    const { GPXImportDialog } =
+      await import('src/app/modules/gpx/gpxload-dialog');
     this.dialog
       .open(GPXImportDialog, {
         disableClose: true,
@@ -1148,7 +1154,9 @@ export class AppComponent {
   }
 
   /** Export resources to GPX file */
-  protected exportToGPX() {
+  protected async exportToGPX() {
+    const { GPXExportDialog } =
+      await import('src/app/modules/gpx/gpxsave-dialog');
     this.dialog
       .open(GPXExportDialog, {
         disableClose: true,
@@ -1177,7 +1185,12 @@ export class AppComponent {
   }
 
   /** process GeoJSON file */
-  protected processGeoJSON(f: { data: string | ArrayBuffer; name: string }) {
+  protected async processGeoJSON(f: {
+    data: string | ArrayBuffer;
+    name: string;
+  }) {
+    const { GeoJSONImportDialog } =
+      await import('src/app/lib/components/dialogs/geojson/geojson-dialog');
     this.dialog
       .open(GeoJSONImportDialog, {
         disableClose: true,
@@ -1208,7 +1221,9 @@ export class AppComponent {
   }
 
   /** Import ResourceSet */
-  protected importResourceSet() {
+  protected async importResourceSet() {
+    const { ResourceImportDialog } =
+      await import('src/app/modules/skresources/components/resourcesets/resource-upload-dialog');
     this.dialog
       .open(ResourceImportDialog, {
         disableClose: true,
@@ -1232,13 +1247,13 @@ export class AppComponent {
       });
   }
 
-  // ** show login dialog **
-  protected showLogin(
+  protected async showLogin(
     message?: string,
     cancelWarning = true,
     onConnect?: boolean
-  ): Observable<boolean> {
-    const lis: Subject<boolean> = new Subject();
+  ): Promise<void> {
+    const { LoginDialog } =
+      await import('src/app/lib/components/dialogs/common-dialogs');
     this.dialog
       .open(LoginDialog, {
         disableClose: true,
@@ -1260,7 +1275,6 @@ export class AppComponent {
                 this.queryAfterConnect();
               }
               this.app.isLoggedIn.set(true);
-              lis.next(true);
             },
             error: () => {
               // ** auth failed
@@ -1301,22 +1315,20 @@ export class AppComponent {
           });
           if (onConnect) {
             this.showLogin(null, false, true);
-          } else {
-            if (cancelWarning) {
-              this.app.showAlert(
-                'Login Cancelled:',
-                `Update operations are NOT available until you have authenticated to the Signal K server.`
-              );
-            }
-            lis.next(false);
+          } else if (cancelWarning) {
+            this.app.showAlert(
+              'Login Cancelled:',
+              `Update operations are NOT available until you have authenticated to the Signal K server.`
+            );
           }
         }
         this.focusMap();
       });
-    return lis.asObservable();
   }
 
-  protected showPlaybackSettings() {
+  protected async showPlaybackSettings() {
+    const { PlaybackDialog } =
+      await import('src/app/lib/components/dialogs/playback-dialog');
     this.dialog
       .open(PlaybackDialog, {
         disableClose: false

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -15,9 +15,9 @@ import {
   ConfirmDialog,
   WelcomeDialog,
   MessageBarComponent,
-  MsgBox,
-  ErrorListDialog
-} from './lib/components/dialogs';
+  MsgBox
+} from './lib/components/dialogs/common-dialogs';
+import { ErrorListDialog } from './lib/components/dialogs/errorlist-dialog';
 
 import { Convert, SI_BASE_UNIT, TARGET_UNIT } from './lib/convert';
 import { SignalKClient } from 'signalk-client-angular';

--- a/src/app/lib/components/dialogs/index.ts
+++ b/src/app/lib/components/dialogs/index.ts
@@ -1,8 +1,10 @@
-export * from './common-dialogs';
-export * from './errorlist-dialog';
-export * from './playback-dialog';
-export * from './geojson/geojson-dialog';
-export * from './trail2route-dialog';
+export {
+  AlertDialog,
+  ConfirmDialog,
+  WelcomeDialog,
+  MessageBarComponent,
+  MsgBox
+} from './common-dialogs';
 export * from './multiselectlist-dialog';
 export * from './singleselectlist-dialog';
 export * from './slider-dialog';

--- a/src/app/modules/gpx/index.ts
+++ b/src/app/modules/gpx/index.ts
@@ -1,2 +1,0 @@
-export * from './gpxload-dialog';
-export * from './gpxsave-dialog';

--- a/src/app/modules/index.ts
+++ b/src/app/modules/index.ts
@@ -2,7 +2,6 @@ export * from './alarms';
 export * from './autopilot';
 export * from './buddies/buddy.service';
 export * from './course';
-export * from './gpx';
 export * from './map';
 export * from './settings';
 export * from './skresources';

--- a/src/app/modules/settings/index.ts
+++ b/src/app/modules/settings/index.ts
@@ -1,2 +1,1 @@
 export * from './settings.facade';
-export * from './components/settings-dialog';

--- a/src/app/modules/skresources/index.ts
+++ b/src/app/modules/skresources/index.ts
@@ -45,7 +45,6 @@ export * from './components/groups/grouplist';
 
 export * from './components/resourcesets/resourceset-list-modal';
 export * from './components/resourcesets/resourceset-feature-properties-modal';
-export * from './components/resourcesets/resource-upload-dialog';
 
 export * from './components/infolayers/infolayerlist';
 export * from './components/infolayers/infolayer-properties-dialog';


### PR DESCRIPTION
## Summary
Convert seven eagerly-imported dialog components to dynamic `import(...)`
loaded on user action. Main-bundle preloaded weight drops by ~121 KB.

## Root cause
Nine dialogs (Settings, GPXImport, GPXExport, Playback, Login, GeoJSONImport,
ResourceImport, About, Trail2Route) opened only on user action but were
imported statically in `app.component.ts`, anchoring them in the eager bundle
graph. Even after switching to `await import(...)`, barrel re-exports in
`app.facade.ts` and `src/app/modules/{gpx,settings,skresources}/index.ts`
kept the implementations preloaded.

## Fix
- Replace runtime imports in `app.component.ts` with `import type` and load
  each dialog via `await import(specific-path)` inside the open-handler.
  All nine handlers become async; templates ignore the returned promise.
- Point `app.facade.ts` at specific file paths for the six dialogs it uses
  (AlertDialog, ConfirmDialog, WelcomeDialog, MessageBarComponent, MsgBox,
  ErrorListDialog) instead of the lib/components/dialogs barrel.
- Remove the lazy-loaded dialog re-exports from
  `lib/components/dialogs/index.ts`, `modules/settings/index.ts`,
  `modules/gpx/index.ts`, and `modules/skresources/index.ts`.
- Two of the nine (AboutDialog, LoginDialog) share `common-dialogs.ts` with
  eager dialogs; splitting that file is a focused follow-up so this PR
  stays scoped to import-graph changes.

## Tested
- `npx tsc --noEmit -p tsconfig.app.json` clean.
- `npm run build:web`: preloaded weight 3,224,577 B -> 3,100,975 B (-123,602 B / -3.8%). Seven new lazy chunks emitted (4-63 KB each, sum 121 KB) and none appear in the modulepreload list of index.html.