### PR TITLE
fix(*): adopt takeUntilDestroyed across leaking subscriptions

### DIFF
--- a/src/app/modules/alarms/components/anchor-watch.component.ts
+++ b/src/app/modules/alarms/components/anchor-watch.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DestroyRef,
   Input,
   Output,
   EventEmitter,
@@ -11,6 +12,7 @@ import {
   signal,
   computed
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -85,6 +87,7 @@ export class AnchorWatchComponent {
   private anchor = inject(AnchorService);
   protected app = inject(AppFacade);
   private signalk = inject(SignalKClient);
+  private destroyRef = inject(DestroyRef);
 
   protected radiusValue = signal<number>(0); // incoming alarm radius
   protected formattedRadiusValue = computed(() => {
@@ -220,6 +223,7 @@ export class AnchorWatchComponent {
           '/plugins/anchoralarm/setRadius',
           typeof value === 'number' ? { radius: value } : {}
         )
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe({
           next: () => {
             this.app.config.anchor.radius = value;
@@ -251,6 +255,7 @@ export class AnchorWatchComponent {
       .post('/plugins/anchoralarm/setManualAnchor', {
         rodeLength: this.app.config.anchor.rodeLength
       })
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
           this.app.saveConfig();
@@ -287,6 +292,7 @@ export class AnchorWatchComponent {
         '/plugins/anchoralarm/dropAnchor',
         typeof radius === 'number' ? { radius: radius } : {}
       )
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
           this.app.saveConfig();
@@ -302,12 +308,15 @@ export class AnchorWatchComponent {
    * @description Raise the Anchor
    */
   raiseAnchor() {
-    this.signalk.post('/plugins/anchoralarm/raiseAnchor', {}).subscribe(
-      () => undefined,
-      (err: HttpErrorResponse) => {
-        this.app.parseHttpErrorResponse(err);
-      }
-    );
+    this.signalk
+      .post('/plugins/anchoralarm/raiseAnchor', {})
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(
+        () => undefined,
+        (err: HttpErrorResponse) => {
+          this.app.parseHttpErrorResponse(err);
+        }
+      );
   }
 
   /**

--- a/src/app/modules/map/popovers/vessel-popover.component.ts
+++ b/src/app/modules/map/popovers/vessel-popover.component.ts
@@ -2,6 +2,7 @@
 
 import {
   Component,
+  DestroyRef,
   Input,
   Output,
   EventEmitter,
@@ -9,6 +10,7 @@ import {
   SimpleChanges,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -257,6 +259,7 @@ export class VesselPopoverComponent {
 
   protected app = inject(AppFacade);
   protected buddies = inject(Buddies);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {}
 
@@ -336,29 +339,35 @@ export class VesselPopoverComponent {
   toggleBuddy() {
     const urn = this.vessel.id.split('.').slice(1).join('.');
     if (this.vessel.buddy) {
-      this.buddies.remove(urn).subscribe(
-        () => {
-          //console.log('buddy revedmo:', urn);
-          this.app.showMessage(`Buddy successfully removed.`, false, 3000);
-        },
-        (err: HttpErrorResponse) => {
-          this.app.showMessage(`Error removing buddy!`, false, 3000);
-        }
-      );
+      this.buddies
+        .remove(urn)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(
+          () => {
+            //console.log('buddy revedmo:', urn);
+            this.app.showMessage(`Buddy successfully removed.`, false, 3000);
+          },
+          (err: HttpErrorResponse) => {
+            this.app.showMessage(`Error removing buddy!`, false, 3000);
+          }
+        );
     } else {
       const name =
         this.vessel.name ??
         this.vessel.mmsi ??
         this.vessel.callsignVhf ??
         urn.slice(-5);
-      this.buddies.add(urn, name).subscribe(
-        () => {
-          this.app.showMessage(`Buddy added (${name})`, false, 3000);
-        },
-        (err: HttpErrorResponse) => {
-          this.app.showMessage(`Error adding buddy!(${name})`, false, 5000);
-        }
-      );
+      this.buddies
+        .add(urn, name)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(
+          () => {
+            this.app.showMessage(`Buddy added (${name})`, false, 3000);
+          },
+          (err: HttpErrorResponse) => {
+            this.app.showMessage(`Error adding buddy!(${name})`, false, 5000);
+          }
+        );
     }
   }
 

--- a/src/app/modules/skresources/components/ais/aircraft-properties-modal.ts
+++ b/src/app/modules/skresources/components/ais/aircraft-properties-modal.ts
@@ -1,4 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   MatBottomSheetRef,
   MAT_BOTTOM_SHEET_DATA
@@ -104,6 +105,7 @@ export class AircraftPropertiesModal {
     id: string;
     icon: string;
   }>(MAT_BOTTOM_SHEET_DATA);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {}
 
@@ -118,9 +120,12 @@ export class AircraftPropertiesModal {
     }
     const path = this.data.id.split('.').join('/');
 
-    this.sk.api.get(path).subscribe((v) => {
-      this.properties = this.parseAircraft(v);
-    });
+    this.sk.api
+      .get(path)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((v) => {
+        this.properties = this.parseAircraft(v);
+      });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/modules/skresources/components/ais/aton-properties-modal.ts
+++ b/src/app/modules/skresources/components/ais/aton-properties-modal.ts
@@ -1,4 +1,5 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   MatBottomSheetRef,
   MAT_BOTTOM_SHEET_DATA
@@ -103,6 +104,7 @@ export class AtoNPropertiesModal implements OnInit {
     icon: string;
     type: 'aton' | 'sar' | 'meteo';
   }>(MAT_BOTTOM_SHEET_DATA);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {}
 
@@ -121,13 +123,16 @@ export class AtoNPropertiesModal implements OnInit {
     }
     const path = this.data.id.split('.').join('/');
 
-    this.sk.api.get(path).subscribe((v) => {
-      if (this.data.type === 'meteo') {
-        this.properties = this.parseMeteo(v);
-      } else {
-        this.properties = this.parseAtoN(v);
-      }
-    });
+    this.sk.api
+      .get(path)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((v) => {
+        if (this.data.type === 'meteo') {
+          this.properties = this.parseMeteo(v);
+        } else {
+          this.properties = this.parseAtoN(v);
+        }
+      });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -1,12 +1,14 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  DestroyRef,
   effect,
   signal,
   input,
   inject,
   output
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatIconModule } from '@angular/material/icon';
@@ -73,6 +75,7 @@ export class ChartListComponent extends ResourceListBase {
   private dialog = inject(MatDialog);
   private skgroups = inject(SKResourceGroupService);
   private mapInteract = inject(FBMapInteractService);
+  private destroyRef = inject(DestroyRef);
 
   constructor(protected override skres: SKResourceService) {
     super('charts', skres);
@@ -244,6 +247,7 @@ export class ChartListComponent extends ResourceListBase {
         }
       })
       .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((result: SliderInputDialogResult) => {
         if (result?.apply) {
           const op = toRatio(result.value);
@@ -309,22 +313,25 @@ export class ChartListComponent extends ResourceListBase {
       );
       return;
     }
-    dref.afterClosed().subscribe((sources) => {
-      if (sources && sources.length !== 0) {
-        if (['wmts', 'wms'].includes(type)) {
-          sources[0].source = 'resources-provider';
-          this.skres.newChart(sources[0]);
-          return;
+    dref
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((sources) => {
+        if (sources && sources.length !== 0) {
+          if (['wmts', 'wms'].includes(type)) {
+            sources[0].source = 'resources-provider';
+            this.skres.newChart(sources[0]);
+            return;
+          }
+          if (['json'].includes(type)) {
+            sources[0].source = 'resources-provider';
+            const c = new SKChart(sources[0]);
+            c.source = 'resources-provider';
+            this.skres.newChart(c);
+            return;
+          }
         }
-        if (['json'].includes(type)) {
-          sources[0].source = 'resources-provider';
-          const c = new SKChart(sources[0]);
-          c.source = 'resources-provider';
-          this.skres.newChart(c);
-          return;
-        }
-      }
-    });
+      });
   }
 
   /**
@@ -366,6 +373,7 @@ export class ChartListComponent extends ResourceListBase {
           }
         })
         .afterClosed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(async (selGrp) => {
           if (selGrp) {
             try {

--- a/src/app/modules/skresources/components/charts/jsonmapsource-dialog.ts
+++ b/src/app/modules/skresources/components/charts/jsonmapsource-dialog.ts
@@ -1,4 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   MatDialogModule,
   MatDialogRef,
@@ -167,6 +168,7 @@ export class JsonMapSourceDialog {
   protected dialogRef = inject(MatDialogRef<JsonMapSourceDialog>);
   private http = inject(HttpClient);
   protected data = inject<SKChart>(MAT_DIALOG_DATA);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {}
 
@@ -180,40 +182,43 @@ export class JsonMapSourceDialog {
     this.fetchError = false;
     this.isFetching = true;
     this.provider = undefined;
-    this.http.get(uri).subscribe({
-      next: (res: TileJson | MapboxStyle) => {
-        this.isFetching = false;
-        if (!res.name) {
-          this.errorMsg = 'Invalid response received!';
-        } else {
-          const c = this.parseFileContents(res, uri);
-          if (c) {
-            this.provider = c as ChartProvider;
-            this.details = {
-              type: (res as TileJson).tilejson ? 'TileJSON' : 'Mapbox Style',
-              name: res.name,
-              version: (res as MapboxStyle).version
-                ? (res as MapboxStyle).version
-                : (res as TileJson).tilejson,
-              layers: (res as MapboxStyle).layers
-                ? (res as MapboxStyle).layers.map((l) => l.id)
-                : (res as TileJson).vector_layers
-                  ? (res as TileJson).vector_layers.map((l) => l.id)
-                  : []
-            };
-            this.dialogRef.close([this.provider]);
+    this.http
+      .get(uri)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res: TileJson | MapboxStyle) => {
+          this.isFetching = false;
+          if (!res.name) {
+            this.errorMsg = 'Invalid response received!';
           } else {
-            this.fetchError = true;
-            this.errorMsg = 'Invalid file contents!';
+            const c = this.parseFileContents(res, uri);
+            if (c) {
+              this.provider = c as ChartProvider;
+              this.details = {
+                type: (res as TileJson).tilejson ? 'TileJSON' : 'Mapbox Style',
+                name: res.name,
+                version: (res as MapboxStyle).version
+                  ? (res as MapboxStyle).version
+                  : (res as TileJson).tilejson,
+                layers: (res as MapboxStyle).layers
+                  ? (res as MapboxStyle).layers.map((l) => l.id)
+                  : (res as TileJson).vector_layers
+                    ? (res as TileJson).vector_layers.map((l) => l.id)
+                    : []
+              };
+              this.dialogRef.close([this.provider]);
+            } else {
+              this.fetchError = true;
+              this.errorMsg = 'Invalid file contents!';
+            }
           }
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isFetching = false;
+          this.fetchError = true;
+          this.errorMsg = err.message;
         }
-      },
-      error: (err: HttpErrorResponse) => {
-        this.isFetching = false;
-        this.fetchError = true;
-        this.errorMsg = err.message;
-      }
-    });
+      });
   }
 
   parseFileContents(json: TileJson | MapboxStyle, uri: string): ChartProvider {

--- a/src/app/modules/skresources/components/groups/group-dialog.ts
+++ b/src/app/modules/skresources/components/groups/group-dialog.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
@@ -268,6 +269,7 @@ export class ResourceGroupDialog implements OnInit {
     addMode: boolean;
     group: SKResourceGroup;
   }>(MAT_DIALOG_DATA);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {}
 
@@ -452,6 +454,7 @@ export class ResourceGroupDialog implements OnInit {
         }
       })
       .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((items: RListEntry[]) => {
         if (items) {
           // routes

--- a/src/app/modules/skresources/components/infolayers/infolayerlist.ts
+++ b/src/app/modules/skresources/components/infolayers/infolayerlist.ts
@@ -1,4 +1,11 @@
-import { Component, ChangeDetectionStrategy, output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  output
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatIconModule } from '@angular/material/icon';
@@ -72,6 +79,8 @@ export class InfoLayerListComponent extends ResourceListBase {
 
   private timeDim: Map<string, TimeDef> = new Map();
   private fetchedUrls: string[] = [];
+
+  private destroyRef = inject(DestroyRef);
 
   constructor(
     protected app: AppFacade,
@@ -235,6 +244,7 @@ export class InfoLayerListComponent extends ResourceListBase {
         'YES',
         'NO'
       )
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(async (result: { ok: boolean }) => {
         if (result && result.ok) {
           try {
@@ -360,35 +370,41 @@ export class InfoLayerListComponent extends ResourceListBase {
       this.app.showAlert('Message', `Invalid source type (${type}) provided! `);
       return;
     }
-    dref.afterClosed().subscribe((sources) => {
-      if (sources && sources.length !== 0) {
-        const req = [];
-        sources.forEach((cs) => {
-          req.push(
-            this.signalk.api.post(
-              this.app.skApiVersion,
-              `/resources/infolayers?provider=resources-provider`,
-              cs
-            )
-          );
-        });
+    dref
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((sources) => {
+        if (sources && sources.length !== 0) {
+          const req = [];
+          sources.forEach((cs) => {
+            req.push(
+              this.signalk.api.post(
+                this.app.skApiVersion,
+                `/resources/infolayers?provider=resources-provider`,
+                cs
+              )
+            );
+          });
 
-        const r = forkJoin(req).pipe(catchError((error) => of(error)));
-        r.subscribe((r) => {
-          if (r.error) {
-            this.app.showAlert(
-              'Add Overlay',
-              `Error saving overlay source!\n(${r.error.statusCode}: ${r.error.message})`
-            );
-          } else {
-            this.app.showAlert(
-              'Add Overlay',
-              'Overlay sources added successfully.'
-            );
-            this.initItems();
-          }
-        });
-      }
-    });
+          const r = forkJoin(req).pipe(
+            catchError((error) => of(error)),
+            takeUntilDestroyed(this.destroyRef)
+          );
+          r.subscribe((r) => {
+            if (r.error) {
+              this.app.showAlert(
+                'Add Overlay',
+                `Error saving overlay source!\n(${r.error.statusCode}: ${r.error.message})`
+              );
+            } else {
+              this.app.showAlert(
+                'Add Overlay',
+                'Overlay sources added successfully.'
+              );
+              this.initItems();
+            }
+          });
+        }
+      });
   }
 }

--- a/src/app/modules/skresources/components/regions/region-panel.ts
+++ b/src/app/modules/skresources/components/regions/region-panel.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DestroyRef,
   effect,
   inject,
   input,
@@ -7,6 +8,7 @@ import {
   output,
   signal
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -65,6 +67,7 @@ export class RegionPanel {
   private skres = inject(SKResourceService);
   protected skgroups = inject(SKResourceGroupService);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {
     effect(() => {
@@ -150,6 +153,7 @@ export class RegionPanel {
             'There are currently no groups defined.\nYou will need to first create a group and then add the resource.\n\nDo you want to create a new group?',
             'Group'
           )
+          .pipe(takeUntilDestroyed(this.destroyRef))
           .subscribe((r) => {
             if (r) {
               this.skgroups.editGroupInfo();
@@ -166,6 +170,7 @@ export class RegionPanel {
           }
         })
         .afterClosed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(async (selGrp) => {
           if (selGrp) {
             try {

--- a/src/app/modules/skresources/components/regions/regionlist.ts
+++ b/src/app/modules/skresources/components/regions/regionlist.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DestroyRef,
   Input,
   ChangeDetectionStrategy,
   signal,
@@ -7,6 +8,7 @@ import {
   output,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatIconModule } from '@angular/material/icon';
@@ -61,6 +63,7 @@ export class RegionListComponent extends ResourceListBase {
   private worker = inject(SKWorkerService);
   private dialog = inject(MatDialog);
   private skgroups = inject(SKResourceGroupService);
+  private destroyRef = inject(DestroyRef);
 
   constructor(protected override skres: SKResourceService) {
     super('regions', skres);
@@ -192,6 +195,7 @@ export class RegionListComponent extends ResourceListBase {
           }
         })
         .afterClosed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(async (selGrp) => {
           if (selGrp) {
             try {

--- a/src/app/modules/skresources/components/routes/build-route.component.ts
+++ b/src/app/modules/skresources/components/routes/build-route.component.ts
@@ -2,10 +2,12 @@ import {
   Component,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  DestroyRef,
   signal,
   output,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -150,6 +152,7 @@ export class BuildRouteComponent {
   protected app = inject(AppFacade);
   private skres = inject(SKResourceService);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {}
 
@@ -205,6 +208,7 @@ export class BuildRouteComponent {
           'Changes have not been saved.\nDo you want to save?',
           'Unsaved Changes'
         )
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe((res: boolean) => {
           if (res) {
             this.doSave();

--- a/src/app/modules/skresources/components/routes/route-panel.ts
+++ b/src/app/modules/skresources/components/routes/route-panel.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DestroyRef,
   effect,
   inject,
   input,
@@ -7,6 +8,7 @@ import {
   output,
   signal
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -86,6 +88,7 @@ export class RoutePanel {
   protected skgroups = inject(SKResourceGroupService);
   private dialog = inject(MatDialog);
   private bottomSheet = inject(MatBottomSheet);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {
     effect(() => {
@@ -269,6 +272,7 @@ export class RoutePanel {
         }
       })
       .afterDismissed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((deactivate: boolean) => {
         if (deactivate) {
           //this.clearDestination();
@@ -293,6 +297,7 @@ export class RoutePanel {
             'There are currently no groups defined.\nYou will need to first create a group and then add the resource.\n\nDo you want to create a new group?',
             'Group'
           )
+          .pipe(takeUntilDestroyed(this.destroyRef))
           .subscribe((r) => {
             if (r) {
               this.skgroups.editGroupInfo();
@@ -309,6 +314,7 @@ export class RoutePanel {
           }
         })
         .afterClosed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(async (selGrp) => {
           if (selGrp) {
             try {

--- a/src/app/modules/skresources/components/routes/routelist.ts
+++ b/src/app/modules/skresources/components/routes/routelist.ts
@@ -1,12 +1,14 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  DestroyRef,
   signal,
   effect,
   inject,
   output,
   input
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatIconModule } from '@angular/material/icon';
@@ -70,6 +72,7 @@ export class RouteListComponent extends ResourceListBase {
   private worker = inject(SKWorkerService);
   private dialog = inject(MatDialog);
   private skgroups = inject(SKResourceGroupService);
+  private destroyRef = inject(DestroyRef);
 
   constructor(protected override skres: SKResourceService) {
     super('routes', skres);
@@ -225,6 +228,7 @@ export class RouteListComponent extends ResourceListBase {
           }
         })
         .afterClosed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(async (selGrp) => {
           if (selGrp) {
             try {

--- a/src/app/modules/skresources/components/waypoints/waypoint-panel.ts
+++ b/src/app/modules/skresources/components/waypoints/waypoint-panel.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  DestroyRef,
   effect,
   inject,
   input,
@@ -7,6 +8,7 @@ import {
   output,
   signal
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CoordsPipe } from 'src/app/lib/pipes';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -69,6 +71,7 @@ export class WaypointPanel {
   private course = inject(CourseService);
   protected skgroups = inject(SKResourceGroupService);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {
     effect(() => {
@@ -154,6 +157,7 @@ export class WaypointPanel {
             'There are currently no groups defined.\nYou will need to first create a group and then add the resource.\n\nDo you want to create a new group?',
             'Group'
           )
+          .pipe(takeUntilDestroyed(this.destroyRef))
           .subscribe((r) => {
             if (r) {
               this.skgroups.editGroupInfo();
@@ -170,6 +174,7 @@ export class WaypointPanel {
           }
         })
         .afterClosed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(async (selGrp) => {
           if (selGrp) {
             try {

--- a/src/app/modules/skresources/components/waypoints/waypointlist.ts
+++ b/src/app/modules/skresources/components/waypoints/waypointlist.ts
@@ -1,12 +1,14 @@
 import {
   Component,
   ChangeDetectionStrategy,
+  DestroyRef,
   signal,
   effect,
   output,
   inject,
   input
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -65,6 +67,7 @@ export class WaypointListComponent extends ResourceListBase {
   private worker = inject(SKWorkerService);
   private dialog = inject(MatDialog);
   private skgroups = inject(SKResourceGroupService);
+  private destroyRef = inject(DestroyRef);
 
   constructor(protected override skres: SKResourceService) {
     super('waypoints', skres);
@@ -226,6 +229,7 @@ export class WaypointListComponent extends ResourceListBase {
           }
         })
         .afterClosed()
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(async (selGrp) => {
           if (selGrp) {
             try {

--- a/src/app/modules/weather/weather-forecast-modal.ts
+++ b/src/app/modules/weather/weather-forecast-modal.ts
@@ -1,7 +1,8 @@
 /** Weather Forecast Component **
  ********************************/
 
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, DestroyRef, Inject, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -281,6 +282,8 @@ export class WeatherForecastModal implements OnInit {
   };
   private maxForecasts = 12;
 
+  private destroyRef = inject(DestroyRef);
+
   constructor(
     public app: AppFacade,
     private sk: SignalKClient,
@@ -315,78 +318,81 @@ export class WeatherForecastModal implements OnInit {
     }
     const path = `/weather/forecasts/point?lat=${pos[1]}&lon=${pos[0]}`;
     this.isFetching = true;
-    this.sk.api.get(2, path).subscribe(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (forecasts: any) => {
-        this.isFetching = false;
-        forecasts = forecasts.slice(0, this.maxForecasts);
-        Object.values(forecasts)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .forEach((v: any) => {
-            const forecastData: WeatherData = { wind: {} };
-            forecastData.description = v['description'] ?? '';
-            const d = new Date(v['date']);
-            forecastData.time = d
-              ? `${d.getHours()}:${('00' + d.getMinutes()).slice(-2)}`
-              : '';
+    this.sk.api
+      .get(2, path)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (forecasts: any) => {
+          this.isFetching = false;
+          forecasts = forecasts.slice(0, this.maxForecasts);
+          Object.values(forecasts)
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .forEach((v: any) => {
+              const forecastData: WeatherData = { wind: {} };
+              forecastData.description = v['description'] ?? '';
+              const d = new Date(v['date']);
+              forecastData.time = d
+                ? `${d.getHours()}:${('00' + d.getMinutes()).slice(-2)}`
+                : '';
 
-            if (typeof v.outside?.temperature !== 'undefined') {
-              forecastData.temperature = this.app.formatValueForDisplay(
-                v.outside.temperature,
-                'K',
-                { noSymbol: true }
-              );
-            } else {
-              forecastData.temperature = '--';
-            }
-            if (typeof v.outside?.dewPointTemperature !== 'undefined') {
-              forecastData.dewPoint = this.app.formatValueForDisplay(
-                v.outside?.dewPointTemperature,
-                'K',
-                { noSymbol: true }
-              );
-            } else {
-              forecastData.dewPoint = '--';
-            }
+              if (typeof v.outside?.temperature !== 'undefined') {
+                forecastData.temperature = this.app.formatValueForDisplay(
+                  v.outside.temperature,
+                  'K',
+                  { noSymbol: true }
+                );
+              } else {
+                forecastData.temperature = '--';
+              }
+              if (typeof v.outside?.dewPointTemperature !== 'undefined') {
+                forecastData.dewPoint = this.app.formatValueForDisplay(
+                  v.outside?.dewPointTemperature,
+                  'K',
+                  { noSymbol: true }
+                );
+              } else {
+                forecastData.dewPoint = '--';
+              }
 
-            forecastData.humidity =
-              typeof v.outside?.absoluteHumidity !== 'undefined'
-                ? `${(v.outside?.absoluteHumidity * 100).toFixed(0)}`
-                : '--';
-            forecastData.pressure =
-              typeof v.outside?.pressure !== 'undefined'
-                ? `${Math.round(v.outside?.pressure)}`
-                : '--';
-
-            forecastData.rain =
-              typeof v.outside?.precipitationVolume !== 'undefined'
-                ? `${(v.outside?.precipitationVolume * 1000).toFixed(2)}`
-                : '--';
-
-            if (typeof v.wind !== 'undefined') {
-              forecastData.wind.speed =
-                typeof v.wind.speedTrue !== 'undefined'
-                  ? `${this.app.formatSpeed(v.wind.speedTrue, true)}`
+              forecastData.humidity =
+                typeof v.outside?.absoluteHumidity !== 'undefined'
+                  ? `${(v.outside?.absoluteHumidity * 100).toFixed(0)}`
+                  : '--';
+              forecastData.pressure =
+                typeof v.outside?.pressure !== 'undefined'
+                  ? `${Math.round(v.outside?.pressure)}`
                   : '--';
 
-              forecastData.wind.gust =
-                typeof v.wind.gust !== 'undefined'
-                  ? `${this.app.formatSpeed(v.wind.gust, true)}`
+              forecastData.rain =
+                typeof v.outside?.precipitationVolume !== 'undefined'
+                  ? `${(v.outside?.precipitationVolume * 1000).toFixed(2)}`
                   : '--';
 
-              forecastData.wind.direction =
-                typeof v.wind.directionTrue !== 'undefined'
-                  ? `${this.toCardinal(Convert.radiansToDegrees(v.wind.directionTrue))}`
-                  : '--';
-            }
-            this.forecasts.push(forecastData);
-          });
-      },
-      () => {
-        this.isFetching = false;
-        this.errorText = 'Error retrieving weather data!';
-      }
-    );
+              if (typeof v.wind !== 'undefined') {
+                forecastData.wind.speed =
+                  typeof v.wind.speedTrue !== 'undefined'
+                    ? `${this.app.formatSpeed(v.wind.speedTrue, true)}`
+                    : '--';
+
+                forecastData.wind.gust =
+                  typeof v.wind.gust !== 'undefined'
+                    ? `${this.app.formatSpeed(v.wind.gust, true)}`
+                    : '--';
+
+                forecastData.wind.direction =
+                  typeof v.wind.directionTrue !== 'undefined'
+                    ? `${this.toCardinal(Convert.radiansToDegrees(v.wind.directionTrue))}`
+                    : '--';
+              }
+              this.forecasts.push(forecastData);
+            });
+        },
+        () => {
+          this.isFetching = false;
+          this.errorText = 'Error retrieving weather data!';
+        }
+      );
   }
 
   toCardinal(value: number) {


### PR DESCRIPTION
## Summary
Adds `takeUntilDestroyed(this.destroyRef)` to 32 `.subscribe()` call sites
across 16 components that previously had zero teardown.

## Root cause
Each component subscribed to HTTP, dialog `afterClosed()`, bottom-sheet
`afterDismissed()`, confirm dialogs, or buddy/anchor signalk POST observables
inside event handlers or `ngOnInit`, and never cleaned up. When the host
component was destroyed, the subscription stayed alive until the source
completed, leaking the closure and any `this` it referenced.

## Fix
- Inject `DestroyRef` once per component and pipe `takeUntilDestroyed(this.destroyRef)` before every leaking `.subscribe()`. The destroyRef-based form is required because the subscribe calls live outside the injection context (event handlers, lifecycle hooks).
- Only touching the 16 components flagged as having zero current cleanup; files that already use manual unsubscribe in `ngOnDestroy` or an `obsList` pattern are deferred to a follow-up so this PR stays narrow.
- Services and workers are also deferred because their DI / lifetime differs from components (no `DestroyRef` available the same way).

## Tested
- `npx tsc --noEmit -p tsconfig.app.json` clean.