### PR TITLE
perf(app): parallelize resource fetch with user-config load

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -731,6 +731,7 @@ export class AppComponent {
         next: () => {
           this.signalk.authToken = this.app.getFBToken();
           this.app.watchSKLogin();
+          this.fetchResources(true); // pre-config: parallelize with config load
           this.app
             .loadUserConfigfromServer()
             .then((loaded: boolean) => {
@@ -746,7 +747,7 @@ export class AppComponent {
               }
             })
             .finally(() => {
-              this.fetchResources(true); // fetch all resource types from server
+              this.fetchResources(true); // post-config: re-apply user selections
             });
           this.getFeatures();
           this.app.data.server = this.signalk.server.info;

--- a/src/app/modules/skresources/custom-resources-service.ts
+++ b/src/app/modules/skresources/custom-resources-service.ts
@@ -48,10 +48,14 @@ export class FBCustomResourceService {
    */
   public async initCustomCollections() {
     const rcs = {};
-    for (const cr of this.app.CUSTOM_RESOURCES) {
-      let r = await this.checkCustomCollection(cr.name, cr.description);
-      rcs[cr.featureKey] = r;
-    }
+    await Promise.all(
+      this.app.CUSTOM_RESOURCES.map(async (cr) => {
+        rcs[cr.featureKey] = await this.checkCustomCollection(
+          cr.name,
+          cr.description
+        );
+      })
+    );
     return rcs;
   }
 


### PR DESCRIPTION
## Summary
Two related changes that parallelize startup HTTP work, kept in one PR
because both target the same `connectSignalKServer` cold-boot path:

1. **Resource fetch alongside user config**: fire `fetchResources(true)`
   before the user-config load chain so HTTP requests for routes, waypoints,
   charts, regions, and tracks run in parallel with the two sequential
   config requests, instead of waiting for them to complete.
2. **Parallel custom resource probes**: rewrite
   `FBCustomResourceService.initCustomCollections` from a serial
   `for ... await checkCustomCollection(...)` to a single `Promise.all`
   over the `CUSTOM_RESOURCES` map.

## Root cause
- `connectSignalKServer` chained the resource fetch behind
  `loadUserConfigfromServer().then(...).finally(...)`, serializing the
  resource-list HTTP round trips after the two config requests even though
  the resource fetch does not depend on their results for the initial
  population.
- `initCustomCollections` ran each `checkCustomCollection(...)` serially.
  Each probe does a GET `/signalk/{skApiVersion}/api/resources/{name}` and,
  on failure, a POST to `/plugins/resources-provider/_config/{name}`. With
  N custom resources, startup paid N sequential round trips before
  `getFeatures()` resolved. The probes are independent (each writes its
  own `rcs[cr.featureKey]` slot, and the function already converts GET/POST
  failures into `resolve(false)`).

## Fix
- `app.component.ts`: add a single pre-config `this.fetchResources(true)`
  call immediately before the `loadUserConfigfromServer()` chain. Populate
  resource lists using default `app.config.selections` (tracks defaults to
  `null` which means unfiltered; routes, waypoints, and regions default to
  `[]` which means none selected). Re-run the existing `.finally` re-fetch
  after the user config loads so any persisted selections are honored.
- `custom-resources-service.ts`: replace the serial loop with
  `await Promise.all(this.app.CUSTOM_RESOURCES.map(async (cr) => { rcs[cr.featureKey] = await this.checkCustomCollection(cr.name, cr.description); }))`.

## Tradeoffs
Cold boot now makes 2x HTTP requests for each resource type in the
config-and-resources change. The brief default-filtered cache state (empty
routes, waypoints, and regions plus OSM-only charts) is replaced once user
config loads. A race window exists where pre-config requests could land
after post-config requests on slow networks, overwriting fresh state with
defaults; mitigating it via version-tagged signal updates is left to a
follow-up since it requires touching every refresh* method.

## Tested
- `npx tsc --noEmit -p tsconfig.app.json` clean.

Closes #377