### PR TITLE
perf(map): raise tile concurrency and cancel superseded vector tile loads

### DIFF
--- a/src/app/modules/map/ol/lib/charts/layer-vector-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-vector-chart.component.ts
@@ -18,6 +18,7 @@ import { MapComponent } from '../map.component';
 import { FBChart } from 'src/app/types';
 import { initPMTilesVectorLayer } from './pmtiles-utils';
 import { extentFromBounds, resolveLayerMaxZoom } from './chart-utils';
+import { createAbortableVectorTileLoader } from './tile-loader-abort';
 
 // ** Freeboard Vector TileLayer Chart **
 @Component({
@@ -33,6 +34,7 @@ export class VectorChartLayerComponent implements OnDestroy {
   protected mapMaxZoom = input<number>();
 
   private layer: VectorTileLayer;
+  private abortPendingTileLoads?: () => void;
   private changeDetectorRef = inject(ChangeDetectorRef);
   private mapComponent = inject(MapComponent);
 
@@ -48,6 +50,8 @@ export class VectorChartLayerComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
+    this.abortPendingTileLoads?.();
+    this.abortPendingTileLoads = undefined;
     const map = this.mapComponent.getMap();
     if (this.layer) {
       map.removeLayer(this.layer);
@@ -76,6 +80,8 @@ export class VectorChartLayerComponent implements OnDestroy {
       if (chart[1].url.indexOf('.pmtiles') !== -1) {
         this.layer = initPMTilesVectorLayer(chart[1], this.zIndex());
       } else {
+        const abortableLoader = createAbortableVectorTileLoader();
+        this.abortPendingTileLoads = abortableLoader.abortPending;
         this.layer = new VectorTileLayer({
           source: new VectorTileSource({
             url: chart[1].url,
@@ -85,7 +91,8 @@ export class VectorChartLayerComponent implements OnDestroy {
                   ? chart[1].layers
                   : null
             }),
-            maxZoom: maxZ
+            maxZoom: maxZ,
+            tileLoadFunction: abortableLoader.tileLoadFunction
           }),
           preload: 0,
           zIndex: this.zIndex(),
@@ -100,7 +107,7 @@ export class VectorChartLayerComponent implements OnDestroy {
         this.layer.setMaxZoom(layerMaxZ);
         this.layer.setExtent(extentFromBounds(chart[1].bounds));
         if (chart[1].style) {
-          applyStyle(this.layer as any, chart[1].style);
+          applyStyle(this.layer, chart[1].style);
         }
         this.layer.set('id', chart[0]);
         this.layer.set('chartId', chart[0]);

--- a/src/app/modules/map/ol/lib/charts/tile-loader-abort.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/tile-loader-abort.spec.ts
@@ -61,12 +61,11 @@ afterEach(() => {
 
 describe('createAbortableVectorTileLoader', () => {
   it('loads, decodes, and releases a successful request', async () => {
-    const fetchMock = vi.fn(
-      (_src: string, _init?: RequestInit): Promise<Response> =>
-        Promise.resolve(
-          new Response(new Uint8Array([1, 2, 3]), { status: 200 })
-        )
-    );
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(new Uint8Array([1, 2, 3]), { status: 200 })
+      );
     vi.stubGlobal('fetch', fetchMock);
     const { tileLoadFunction, abortPending } =
       createAbortableVectorTileLoader();

--- a/src/app/modules/map/ol/lib/charts/tile-loader-abort.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/tile-loader-abort.spec.ts
@@ -1,0 +1,176 @@
+import type { FeatureLike } from 'ol/Feature';
+import type { Extent } from 'ol/extent';
+import type Projection from 'ol/proj/Projection';
+import type VectorTile from 'ol/VectorTile';
+import TileState from 'ol/TileState';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createAbortableVectorTileLoader } from './tile-loader-abort';
+
+type TileLoader = (
+  extent: Extent,
+  resolution: number,
+  projection: Projection
+) => void;
+
+function makeTile(z = 9) {
+  let loader: TileLoader | undefined;
+  const states: number[] = [];
+  const decodedFeatures = [{} as FeatureLike];
+  const setFeatures = vi.fn();
+  const readFeatures = vi.fn(() => decodedFeatures);
+  const tile = {
+    getTileCoord: () => [z, 0, 0],
+    setLoader: (nextLoader: TileLoader) => {
+      loader = nextLoader;
+    },
+    setState: (state: number) => states.push(state),
+    getFormat: () => ({ readFeatures }),
+    setFeatures
+  } as unknown as VectorTile<FeatureLike>;
+
+  return {
+    tile,
+    states,
+    readFeatures,
+    setFeatures,
+    decodedFeatures,
+    start: () => loader?.([] as unknown as Extent, 1, {} as Projection)
+  };
+}
+
+function abortAwarePendingFetch(
+  signals: AbortSignal[]
+): (src: string, init?: RequestInit) => Promise<Response> {
+  return (_src, init) => {
+    const signal = init?.signal;
+    if (!signal) return Promise.reject(new Error('missing abort signal'));
+    signals.push(signal);
+    return new Promise<Response>((_resolve, reject) => {
+      signal.addEventListener(
+        'abort',
+        () => reject(new DOMException('Aborted', 'AbortError')),
+        { once: true }
+      );
+    });
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('createAbortableVectorTileLoader', () => {
+  it('loads, decodes, and releases a successful request', async () => {
+    const fetchMock = vi.fn(
+      (_src: string, _init?: RequestInit): Promise<Response> =>
+        Promise.resolve(
+          new Response(new Uint8Array([1, 2, 3]), { status: 200 })
+        )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { tileLoadFunction, abortPending } =
+      createAbortableVectorTileLoader();
+    const tile = makeTile();
+
+    tileLoadFunction(tile.tile, 'https://example.test/tile.pbf');
+    tile.start();
+
+    await vi.waitFor(() => {
+      expect(tile.states).toEqual([TileState.LOADING, TileState.LOADED]);
+    });
+    expect(tile.readFeatures).toHaveBeenCalledOnce();
+    expect(tile.setFeatures).toHaveBeenCalledWith(tile.decodedFeatures);
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+    expect(signal?.aborted).toBe(false);
+
+    abortPending();
+
+    expect(signal?.aborted).toBe(false);
+  });
+
+  it('keeps repeated requests at the same zoom active until teardown', async () => {
+    const signals: AbortSignal[] = [];
+    vi.stubGlobal('fetch', vi.fn(abortAwarePendingFetch(signals)));
+    const { tileLoadFunction, abortPending } =
+      createAbortableVectorTileLoader();
+    const first = makeTile(10);
+    const second = makeTile(10);
+
+    tileLoadFunction(first.tile, 'https://example.test/first.pbf');
+    tileLoadFunction(second.tile, 'https://example.test/second.pbf');
+    first.start();
+    second.start();
+
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => !signal.aborted)).toBe(true);
+
+    abortPending();
+
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+    await vi.waitFor(() => {
+      expect(first.states).toEqual([TileState.LOADING, TileState.ERROR]);
+      expect(second.states).toEqual([TileState.LOADING, TileState.ERROR]);
+    });
+  });
+
+  it('aborts a superseded zoom without canceling the current zoom', async () => {
+    const signals: AbortSignal[] = [];
+    vi.stubGlobal('fetch', vi.fn(abortAwarePendingFetch(signals)));
+    const { tileLoadFunction, abortPending } =
+      createAbortableVectorTileLoader();
+    const oldZoom = makeTile(8);
+    const currentZoom = makeTile(12);
+
+    tileLoadFunction(oldZoom.tile, 'https://example.test/old.pbf');
+    oldZoom.start();
+    tileLoadFunction(currentZoom.tile, 'https://example.test/current.pbf');
+    currentZoom.start();
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+    await vi.waitFor(() => {
+      expect(oldZoom.states).toEqual([TileState.LOADING, TileState.ERROR]);
+    });
+
+    abortPending();
+
+    expect(signals[1]?.aborted).toBe(true);
+    await vi.waitFor(() => {
+      expect(currentZoom.states).toEqual([TileState.LOADING, TileState.ERROR]);
+    });
+  });
+
+  it('marks an HTTP error response as an error without decoding it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('missing', { status: 404 })))
+    );
+    const { tileLoadFunction } = createAbortableVectorTileLoader();
+    const tile = makeTile();
+
+    tileLoadFunction(tile.tile, 'https://example.test/missing.pbf');
+    tile.start();
+
+    await vi.waitFor(() => {
+      expect(tile.states).toEqual([TileState.LOADING, TileState.ERROR]);
+    });
+    expect(tile.readFeatures).not.toHaveBeenCalled();
+    expect(tile.setFeatures).not.toHaveBeenCalled();
+  });
+
+  it('marks ordinary fetch failures as errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('offline')))
+    );
+    const { tileLoadFunction } = createAbortableVectorTileLoader();
+    const tile = makeTile();
+
+    tileLoadFunction(tile.tile, 'https://example.test/tile.pbf');
+    tile.start();
+
+    await vi.waitFor(() => {
+      expect(tile.states).toEqual([TileState.LOADING, TileState.ERROR]);
+    });
+  });
+});

--- a/src/app/modules/map/ol/lib/charts/tile-loader-abort.ts
+++ b/src/app/modules/map/ol/lib/charts/tile-loader-abort.ts
@@ -1,0 +1,112 @@
+import TileState from 'ol/TileState';
+import type VectorTile from 'ol/VectorTile';
+import type { FeatureLike } from 'ol/Feature';
+import type { Extent } from 'ol/extent';
+import type Projection from 'ol/proj/Projection';
+
+type PendingByZoom = Map<number, Set<AbortController>>;
+
+type VectorTileLoadFunction = (
+  tile: VectorTile<FeatureLike>,
+  src: string
+) => void;
+
+interface AbortableVectorTileLoader {
+  tileLoadFunction: VectorTileLoadFunction;
+  abortPending: () => void;
+}
+
+/**
+ * Abort and drop controllers held under zoom levels other than `z`, then
+ * return (or create) the controller bucket for `z`. Keeps the vector
+ * loader's per-zoom bookkeeping in lockstep.
+ */
+function bucketForZoom(
+  pending: PendingByZoom,
+  z: number
+): Set<AbortController> {
+  for (const [oldZ, controllers] of pending) {
+    if (oldZ !== z) {
+      for (const c of controllers) c.abort();
+      pending.delete(oldZ);
+    }
+  }
+  let set = pending.get(z);
+  if (!set) {
+    set = new Set();
+    pending.set(z, set);
+  }
+  return set;
+}
+
+function releaseController(
+  pending: PendingByZoom,
+  z: number,
+  controller: AbortController
+) {
+  const s = pending.get(z);
+  if (s) {
+    s.delete(controller);
+    if (s.size === 0) pending.delete(z);
+  }
+}
+
+function abortPendingControllers(pending: PendingByZoom): void {
+  for (const controllers of pending.values()) {
+    for (const controller of controllers) controller.abort();
+  }
+  pending.clear();
+}
+
+/**
+ * Build an OL VectorTile `tileLoadFunction` that aborts in-flight loads from
+ * superseded zoom levels. When a new tile request arrives at zoom Z, any
+ * outstanding controllers for zoom !== Z are aborted so they free up the
+ * browser's connection pool for the now-visible level. The fetch is wrapped
+ * inside `tile.setLoader` because OL's VectorTile contract has the tile own
+ * its decoded features.
+ */
+export function createAbortableVectorTileLoader(): AbortableVectorTileLoader {
+  const pending: PendingByZoom = new Map();
+
+  const tileLoadFunction: VectorTileLoadFunction = (tile, src) => {
+    const z = tile.getTileCoord()[0];
+
+    tile.setLoader(
+      (extent: Extent, _resolution: number, projection: Projection) => {
+        const bucket = bucketForZoom(pending, z);
+        const controller = new AbortController();
+        bucket.add(controller);
+
+        tile.setState(TileState.LOADING);
+        fetch(src, { signal: controller.signal })
+          .then((r) => {
+            if (!r.ok) {
+              throw new Error(`Vector tile request failed: HTTP ${r.status}`);
+            }
+            return r.arrayBuffer();
+          })
+          .then((data) => {
+            const format = tile.getFormat();
+            const features = format.readFeatures(data, {
+              extent,
+              featureProjection: projection
+            }) as FeatureLike[];
+            tile.setFeatures(features);
+            tile.setState(TileState.LOADED);
+          })
+          .catch(() => {
+            tile.setState(TileState.ERROR);
+          })
+          .finally(() => {
+            releaseController(pending, z, controller);
+          });
+      }
+    );
+  };
+
+  return {
+    tileLoadFunction,
+    abortPending: () => abortPendingControllers(pending)
+  };
+}

--- a/src/app/modules/map/ol/lib/charts/tile-loader-abort.ts
+++ b/src/app/modules/map/ol/lib/charts/tile-loader-abort.ts
@@ -39,6 +39,7 @@ function bucketForZoom(
   return set;
 }
 
+/** Release a completed controller and remove its empty zoom bucket. */
 function releaseController(
   pending: PendingByZoom,
   z: number,
@@ -51,6 +52,7 @@ function releaseController(
   }
 }
 
+/** Abort every outstanding request and clear the loader's bookkeeping. */
 function abortPendingControllers(pending: PendingByZoom): void {
   for (const controllers of pending.values()) {
     for (const controller of controllers) controller.abort();

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -171,7 +171,11 @@ export class MapComponent implements OnInit, OnDestroy {
     // outside the zone eliminates that; the specific handlers that must update
     // Angular state re-enter the zone via ngZone.run() (see below).
     this.ngZone.runOutsideAngular(() => {
-      this.map = new Map();
+      this.map = new Map({
+        // 2x OL default (16); keeps the browser HTTP/1.1 per-host connection
+        // pool fully fed during zoom-out tile bursts.
+        maxTilesLoading: 32
+      });
       this.map.setTarget(target);
       this.map.setProperties(this.properties, true);
       // register the map in the injectable mapService


### PR DESCRIPTION
## What problem does this solve?

Rapid zooming on HTTP/1.1 vector chart sources leaves superseded requests consuming browser connection slots and OpenLayers tile-queue capacity. The visible zoom level can therefore wait behind tiles the user has already left.

## How does it work?

The map raises `maxTilesLoading` from 16 to 32. Non-PMTiles `VectorTile` sources use an abortable loader grouped by zoom level, so a new zoom cancels requests from older levels. Every failed or canceled tile reaches the terminal `ERROR` state, non-success HTTP responses reject before decoding, completed controllers leave the bookkeeping map, and component teardown aborts remaining requests.

Raster and PMTiles loading are unchanged.

## What changes for the user?

Vector charts recover and settle more quickly after rapid zoom changes, especially when their tile server uses HTTP/1.1. There is no new control or visual change.

## How was this tested?

- `npm run test:ci -- --include src/app/modules/map/ol/lib/charts/tile-loader-abort.spec.ts`: 1 file and 5 tests passed, covering success, repeated same-zoom loads, supersession, teardown, HTTP errors, fetch errors, and cleanup.
- ESLint, Prettier, and `tsc` checks pass locally.
- Signal K Plugin CI passes on Linux x64 and arm64, macOS, and Windows with Node 22 and 24, plus emulated armv7 with Node 20, on commit `a916856e`.
- A real OpenLayers map used the production loader against a delayed local HTTP/1.1 MVT endpoint for 30 rapid zoom cycles. The queue started at 0, peaked at 9, returned to 0 after every cycle, and ended at 0. The server recorded 344 requests, 187 superseded-request aborts, 157 completions, 0 left in flight, and a maximum of 6 in flight. Chromium reported no console errors or page errors. Temporary instrumentation was removed.

## Checklist

- [x] One logical change; version numbers untouched.
- [x] `features/` untouched; the user-facing change is described above instead.
- [x] Skimmed [`DEV-LESSONS-LEARNED.md`](../docs/freeboard/DEV-LESSONS-LEARNED.md) for traps relevant to this change.
- [x] Tests added/updated for new behavior and `npm run test:ci` passes.