### PR TITLE
perf(s57): cache derived text-style config across features

### DIFF
--- a/src/app/modules/map/ol/lib/charts/s57Style.ts
+++ b/src/app/modules/map/ol/lib/charts/s57Style.ts
@@ -8,11 +8,19 @@ const DEPARE = 42; // Depth Area
 
 const LOOKUPINDEXKEY = '$lupIndex';
 
+type TextStyleConfig = {
+  textAlign: CanvasTextAlign;
+  textBaseline: CanvasTextBaseline;
+  offsetX: number;
+  offsetY: number;
+};
+
 export class S57Style {
   private s57Service: S57Service;
   private selectedSafeContour = 1000;
   private currentResolution = 0;
   private instructionMatch = new RegExp('([A-Z][A-Z])\\((.*)\\)');
+  private textStyleConfigCache = new Map<string, TextStyleConfig>();
 
   constructor(s57Service: S57Service) {
     this.s57Service = s57Service;
@@ -39,35 +47,37 @@ export class S57Style {
 
   //TODO implement more parameters
   private getTextStyle(params: string[]): Style {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let textBaseline: any = 'middle';
-    let offsetY = 0;
-    if (params[1] === '3') {
-      textBaseline = 'top';
-      offsetY = 15;
-    } else if (params[1] === '1') {
-      textBaseline = 'bottom';
-      offsetY = -15;
+    const configKey = (params[0] ?? '') + '|' + (params[1] ?? '');
+    let config = this.textStyleConfigCache.get(configKey);
+    if (!config) {
+      let textBaseline: CanvasTextBaseline = 'middle';
+      let offsetY = 0;
+      if (params[1] === '3') {
+        textBaseline = 'top';
+        offsetY = 15;
+      } else if (params[1] === '1') {
+        textBaseline = 'bottom';
+        offsetY = -15;
+      }
+      let textAlign: CanvasTextAlign = 'left';
+      let offsetX = 15;
+      if (params[0] === '2') {
+        textAlign = 'right';
+        offsetX = -15;
+      } else if (params[0] === '1') {
+        textAlign = 'center';
+        offsetX = 0;
+      }
+      config = { textAlign, textBaseline, offsetX, offsetY };
+      this.textStyleConfigCache.set(configKey, config);
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let textAlign: any = 'left';
-    let offsetX = 15;
-    if (params[0] === '2') {
-      textAlign = 'right';
-      offsetX = -15;
-    } else if (params[0] === '1') {
-      textAlign = 'center';
-      offsetX = 0;
-    }
-
     const style = new Style({
       text: new Text({
-        textAlign: textAlign,
-        textBaseline: textBaseline,
+        textAlign: config.textAlign,
+        textBaseline: config.textBaseline,
         scale: 1.5,
-        offsetX: offsetX,
-        offsetY: offsetY
+        offsetX: config.offsetX,
+        offsetY: config.offsetY
       })
     });
     style.setZIndex(99); // text always on top


### PR DESCRIPTION
## Summary
`S57Style.getTextStyle` was deriving `textAlign`, `textBaseline`, `offsetX`,
and `offsetY` from `params` on every TX/TE feature render. Only `params[0]`
and `params[1]` feed those four values, and they are S57 alignment tokens
('0'..'3') so the input space has at most nine distinct configurations per
chart.

## Fix
Memoize the derived config in a `Map` keyed by `'param0|param1'`. Cache
size is bounded by 9. Per-feature work on cache hit drops to a `Map.get`
plus the unavoidable `new Style` + `new Text` allocations.

As a side benefit, `textAlign` and `textBaseline` now have proper `Canvas*`
types so the two `eslint-disable @typescript-eslint/no-explicit-any` shims
could be removed.

## Why the Style is still allocated per call
The declutter pass in the S57 layer reads styles asynchronously and OL's
`Text.clone()` would be heavier than the simple `Text` constructor used
here, so sharing or cloning the `Style` is not worthwhile.

## Tested
- `npx tsc --noEmit -p tsconfig.app.json` clean.