### PR TITLE
feat(charts): honor chart tileSize for raster tile sources

### DIFF
--- a/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
@@ -87,7 +87,10 @@ export class RasterChartLayerComponent implements OnDestroy {
           this.layer = new TileLayer({
             source: new XYZ({
               url: chart[1].url,
-              maxZoom: maxZ
+              maxZoom: maxZ,
+              // Charts with 512px tiles (e.g. some MBTiles basemaps) must be
+              // addressed on a 512px grid; the default is 256.
+              tileSize: chart[1].tileSize ?? 256
             }),
             preload: 0,
             zIndex: this.zIndex(),

--- a/src/app/modules/skresources/resource-classes.ts
+++ b/src/app/modules/skresources/resource-classes.ts
@@ -127,6 +127,7 @@ export class SKChart {
   format: string;
   minZoom = 0;
   maxZoom = 24;
+  tileSize = 256;
   type: string;
   url: string;
   source: string;
@@ -145,6 +146,8 @@ export class SKChart {
       typeof chart?.minzoom !== 'undefined' ? chart.minzoom : this.minZoom;
     this.maxZoom =
       typeof chart?.maxzoom !== 'undefined' ? chart.maxzoom : this.maxZoom;
+    this.tileSize =
+      typeof chart?.tileSize !== 'undefined' ? chart.tileSize : this.tileSize;
     this.type = chart?.type ? chart.type : undefined;
     this.url = chart?.url ? chart.url : undefined;
     this.scale =

--- a/src/app/types/resources/signalk.ts
+++ b/src/app/types/resources/signalk.ts
@@ -66,6 +66,10 @@ export interface ChartResource {
   scale?: number;
   url?: string;
   layers?: string[];
+  // Tile edge length in pixels (e.g. 512). Omitted means the conventional
+  // 256. Raster tile sources must be built on the matching grid or 512px
+  // tiles render at the wrong scale.
+  tileSize?: number;
   defaultOpacity?: number;
   proxy?: boolean;
   $source?: string;


### PR DESCRIPTION
## Problem

Raster charts are always addressed on a 256px tile grid (OpenLayers' XYZ default). A chart whose tiles are 512px — common for some MBTiles basemaps — therefore renders at the wrong scale: tiles land on the wrong grid cells and the layer is misaligned/zoomed.

## Change

Thread an optional `tileSize` from the chart resource through to the OpenLayers raster source:

- `ChartResource` gains `tileSize?: number`.
- `SKChart` carries `tileSize`, defaulting to `256`.
- The raster `XYZ` source in `RasterChartLayerComponent` passes `tileSize: chart[1].tileSize ?? 256`.

Default `256` everywhere, so existing charts are completely unaffected — only a chart that explicitly advertises `tileSize` (e.g. `512`) changes behaviour. The `.pmtiles` path is untouched (it already sets `tileSize: [512, 512]`).

## Context

The companion `signalk-charts-provider-simple` (2.1.0) already advertises `tileSize` on the v2 chart descriptor when it detects 512px tiles, so this is the consumer side that makes such charts render correctly in Freeboard.

## Tested

- `npm run build` (`ng build`) — succeeds.
- `prettier --check` on the changed files — clean.
- Default-256 path is unchanged for existing charts (no `tileSize` in the descriptor ⇒ `?? 256`).