### PR TITLE
feat(charts): Custom map symbols via symbol providers

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -109,6 +109,7 @@ import {
   SKResourceType,
   WaypointPanel
 } from './modules/skresources';
+import { SymbolService, setSymbolRegistry } from './modules/icons';
 
 interface DrawEndEvent {
   coordinates: LineString | Position | Polygon;
@@ -263,6 +264,7 @@ export class AppComponent {
   private settings = inject(SettingsFacade);
   protected autopilot = inject(AutopilotService);
   protected radarApi = inject(RadarAPIService);
+  private symbols = inject(SymbolService);
 
   constructor() {
     // set self to active vessel
@@ -769,7 +771,7 @@ export class AppComponent {
               }
             })
             .finally(() => {
-              this.fetchResources(true); // fetch all resource types from server
+              this.loadSymbolsThenFetchResources();
             });
           this.getFeatures();
           this.app.data.server = this.signalk.server.info;
@@ -1868,6 +1870,15 @@ export class AppComponent {
   }
 
   // ******** SIGNAL K STREAM *************
+
+  /** Load external symbols then fetch all resource types. */
+  private async loadSymbolsThenFetchResources(): Promise<void> {
+    await this.symbols.load();
+    // Register SymbolService with the module-level hook so pure functions
+    // in app.icons.ts can resolve external symbols without DI injection.
+    setSymbolRegistry(this.symbols);
+    this.fetchResources(true);
+  }
 
   /** fetch resource types from server */
   private fetchResources(allTypes = false) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1316,7 +1316,7 @@ export class AppComponent {
               this.app.persistToken(r['token']);
               this.app.loadUserConfigfromServer().then((loaded: boolean) => {
                 if (loaded) {
-                  this.fetchResources(true);
+                  this.loadSymbolsThenFetchResources();
                 }
               });
               if (onConnect) {

--- a/src/app/modules/gpx/gpxload-dialog.ts
+++ b/src/app/modules/gpx/gpxload-dialog.ts
@@ -18,6 +18,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { AppFacade } from 'src/app/app.facade';
 import { SignalKClient } from 'signalk-client-angular';
 import { SKResourceService, SKTrack } from 'src/app/modules';
+import { SymbolService } from 'src/app/modules/icons';
 import {
   GPX,
   GPXRoute,
@@ -86,6 +87,7 @@ export class GPXImportDialog implements OnInit {
   protected dialogRef = inject(MatDialogRef<GPXImportDialog>);
   private skres = inject(SKResourceService);
   private signalk = inject(SignalKClient);
+  private symbols = inject(SymbolService);
 
   constructor(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -403,7 +405,7 @@ export class GPXImportDialog implements OnInit {
           this.subCount--;
           if (Math.floor(r['statusCode'] / 100) === 2) {
             this.app.debug('SUCCESS: Route added.');
-            this.app.config.selections.routes.push(skObj[0]);
+            this.skres.selectionAdd('routes', skObj[0]);
           } else {
             this.errorCount++;
           }
@@ -442,6 +444,14 @@ export class GPXImportDialog implements OnInit {
     }
     if (pt.sym) {
       wpt.feature.properties['sym'] = pt.sym;
+      // Match the GPX <sym> to a symbol (by gpxSym, then local id). On a match,
+      // use that symbol as the icon — as a 'waypoint' type so the override
+      // resolves on the map. No match → leave the default (rule 3).
+      const ref = this.symbols.resolveGpxSym(pt.sym);
+      if (ref) {
+        wpt.type = 'waypoint';
+        wpt.feature.properties['skIcon'] = ref;
+      }
     }
 
     this.subCount++;
@@ -456,7 +466,9 @@ export class GPXImportDialog implements OnInit {
           this.subCount--;
           if (Math.floor(r['statusCode'] / 100) === 2) {
             this.app.debug('SUCCESS: Waypoint added.');
-            this.app.config.selections.waypoints.push(wptObj[0]);
+            // selectionAdd handles the unfiltered (null) selection safely;
+            // a raw push throws when the selection filter is null.
+            this.skres.selectionAdd('waypoints', wptObj[0]);
           } else {
             this.errorCount++;
           }

--- a/src/app/modules/gpx/gpxload-dialog.ts
+++ b/src/app/modules/gpx/gpxload-dialog.ts
@@ -435,6 +435,10 @@ export class GPXImportDialog implements OnInit {
     }
     if (pt.type) {
       wpt.type = pt.type;
+      // Preserve the imported GPX <type> for export; a symbol match below may
+      // override the internal type to 'waypoint', but the file's type must
+      // still round-trip via feature.properties['type'] (see sk2gpx).
+      wpt.feature.properties['type'] = pt.type;
     }
     if (pt.cmt) {
       wpt.feature.properties['cmt'] = pt.cmt;

--- a/src/app/modules/gpx/sk2gpx.ts
+++ b/src/app/modules/gpx/sk2gpx.ts
@@ -8,6 +8,7 @@ import {
   GPXTrack,
   GPXTrackSegment
 } from './gpxlib';
+import { getSymbolGpxMapping } from 'src/app/modules/icons';
 
 export class SK2GPX {
   public gpx: GPX;
@@ -110,6 +111,18 @@ export class SK2GPX {
     wpt.src = w.feature.properties['src'] || null;
     wpt.sym = w.feature.properties['sym'] || null;
     wpt.type = w.feature.properties['type'] || null;
+    // If a 'waypoint'-type waypoint uses a symbol, write that symbol's GPX
+    // mapping back to the file — gpxType → <type> and gpxSym → <sym> — using
+    // whichever values the symbol actually provides.
+    if (w.type === 'waypoint') {
+      const gpx = getSymbolGpxMapping(w.feature.properties['skIcon']);
+      if (gpx?.gpxType) {
+        wpt.type = gpx.gpxType;
+      }
+      if (gpx?.gpxSym) {
+        wpt.sym = gpx.gpxSym;
+      }
+    }
     wpt.fix = w.feature.properties['fix'] || null;
     wpt.sat = w.feature.properties['sat'] || null;
     wpt.hdop = w.feature.properties['hdop'] || null;

--- a/src/app/modules/icons/app.icons.ts
+++ b/src/app/modules/icons/app.icons.ts
@@ -13,6 +13,57 @@ import { AtoNsType1 } from './atons';
 import { WaypointIcons, getWaypointDefs } from './waypoints';
 import { VesselAisIcons, AIS_TYPE_IDS } from './vessels';
 
+// ---- Module-level hook for SymbolService ----
+// SymbolService calls setSymbolRegistry(this) after load() so that the pure
+// functions below can resolve external symbols without requiring DI injection
+// at every call site.  When null (pre-load or no provider) behavior is
+// identical to today.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _symbolRegistry: any = null;
+
+export const setSymbolRegistry = (registry: {
+  resolveDisplayIcon(ref: string): AppIconDef | null;
+  getExternalNoteIcons(showAll: boolean): Array<{ id: string; name: string }>;
+  getExternalWaypointIcons(showAll: boolean): AppIconDef[];
+  hasExternalVersion(id: string): boolean;
+  getGpxMapping(ref: string): { gpxType?: string; gpxSym?: string } | null;
+} | null): void => {
+  _symbolRegistry = registry;
+};
+
+/**
+ * @description Return the GPX mapping ({gpxType, gpxSym}) for the symbol
+ * referenced by the supplied skIcon, or null when it is not an external symbol.
+ * Used by GPX export to write a symbol's gpxType/gpxSym back to the file.
+ */
+export const getSymbolGpxMapping = (
+  ref?: string
+): { gpxType?: string; gpxSym?: string } | null => {
+  if (!ref || !_symbolRegistry) {
+    return null;
+  }
+  return _symbolRegistry.getGpxMapping(ref);
+};
+
+/**
+ * @description Compute the value to persist as a waypoint's skIcon for a
+ * selected built-in/external icon.
+ * - Qualified refs ("namespace:id", "default:id") are saved as-is.
+ * - A bare built-in id is pinned to "default:<id>" when an external override
+ *   exists (so a future custom version won't silently replace this selection);
+ *   otherwise it is saved bare.
+ */
+export const persistSkIcon = (svgIcon?: string): string => {
+  const id = svgIcon ?? '';
+  if (!id || id.includes(':')) {
+    return id;
+  }
+  if (_symbolRegistry && _symbolRegistry.hasExternalVersion(id)) {
+    return `default:${id}`;
+  }
+  return id;
+};
+
 export interface AppIconSet {
   path: string;
   files: Array<string>;
@@ -47,7 +98,21 @@ export const getSvgList = (): Array<{ id: string; path: string }> => {
   addToList(VesselAisIcons);
   addToList(WaypointIcons);
   addToList(AtoNsType1);
+  // Fallback icon for unresolvable symbol references
+  svgList.push({ id: 'no-such-symbol', path: './assets/img/no-such-symbol.svg' });
   return svgList;
+};
+
+/**
+ * Set of all built-in icon ids (bare names, default namespace).
+ * Populated lazily on first call; used by SymbolService for resolution.
+ */
+let _builtinIconIds: Set<string> | null = null;
+export const getBuiltinIconIds = (): Set<string> => {
+  if (!_builtinIconIds) {
+    _builtinIconIds = new Set(getSvgList().map((s) => s.id));
+  }
+  return _builtinIconIds;
 };
 
 /**
@@ -78,13 +143,13 @@ export const getResourceIcon = (
         : (resource as SKRegion).feature.properties?.skIcon;
     if (!icon) {
       return iconDef;
-    } else {
-      return {
-        class: undefined,
-        svgIcon: `${icon}`,
-        name: undefined
-      };
     }
+    // Route through symbol registry if available
+    if (_symbolRegistry) {
+      const resolved = _symbolRegistry.resolveDisplayIcon(icon);
+      if (resolved) return { class: undefined, ...resolved, name: undefined };
+    }
+    return { class: undefined, svgIcon: `${icon}`, name: undefined };
   }
   if (resourceType === 'notes') {
     let iconDef = {
@@ -101,13 +166,13 @@ export const getResourceIcon = (
         : (resource as SKNote).properties?.skIcon;
     if (!icon) {
       return iconDef;
-    } else {
-      return {
-        class: undefined,
-        svgIcon: `${icon}`,
-        name: undefined
-      };
     }
+    // Route through symbol registry if available
+    if (_symbolRegistry) {
+      const resolved = _symbolRegistry.resolveDisplayIcon(icon);
+      if (resolved) return { class: undefined, ...resolved, name: undefined };
+    }
+    return { class: undefined, svgIcon: `${icon}`, name: undefined };
   }
   if (resourceType === 'waypoints') {
     const wptDefs = getWaypointDefs();
@@ -121,20 +186,55 @@ export const getResourceIcon = (
         : (resource as SKWaypoint).type;
     const wid = skIcon ?? wptType ?? 'default';
 
-    if (!resource || wid === 'default' || !wptDefs[wid]) {
+    if (!resource || wid === 'default') {
       return {
         class: undefined,
         svgIcon: 'waypoint',
         name: undefined
       };
-    } else {
+    }
+    // Only the 'waypoint' type participates in symbol overrides; other types
+    // (start-pin, pseudoaton, …) always render their built-in icon. Ignore the
+    // 'no-such-symbol' fallback so an unresolved/foreign value (e.g. a GPX
+    // <type>) falls back to the default waypoint icon, not the missing marker.
+    if (_symbolRegistry && wptType === 'waypoint') {
+      const resolved = _symbolRegistry.resolveDisplayIcon(wid);
+      if (resolved && resolved.svgIcon !== 'no-such-symbol') {
+        return { class: undefined, ...resolved, name: undefined };
+      }
+    }
+    if (!wptDefs[wid]) {
       return {
         class: undefined,
-        svgIcon: wid,
+        svgIcon: 'waypoint',
         name: undefined
       };
     }
+    return {
+      class: undefined,
+      svgIcon: wid,
+      name: undefined
+    };
   }
+};
+
+/**
+ * @description Resolve a skIcon reference to a Material-resolvable svgIcon name,
+ * applying external-symbol overrides when the registry is present. Returns the
+ * input unchanged when no registry/override applies.
+ * Used by list/panel views that bind skIcon directly to <mat-icon [svgIcon]>.
+ */
+export const resolveSkIcon = (ref?: string): string => {
+  if (!ref) {
+    return ref ?? '';
+  }
+  if (_symbolRegistry) {
+    const resolved = _symbolRegistry.resolveDisplayIcon(ref);
+    if (resolved?.svgIcon) {
+      return resolved.svgIcon;
+    }
+  }
+  return ref;
 };
 
 /**
@@ -225,34 +325,77 @@ export const getAisIcon = (id: number | string): AppIconDef => {
 };
 
 /**
- * @description Return a list of Note icon selection options
+ * @description Return a list of Note icon selection options.
+ * Built-in POIs are shown resolved: an overridden POI shows its override and the
+ * built-in default is hidden. Note-role external symbols with new ids are also
+ * shown. When showAll is true, the list also includes external symbols of any
+ * role plus a "default" entry for each built-in that has been overridden.
  */
-export const selListNoteIcons = (): Array<{ id: string; name: string }> => {
-  const icons = PoiIcons.files.map((file: string) => {
+export const selListNoteIcons = (
+  showAll = false
+): Array<{ id: string; name: string }> => {
+  const icons: Array<{ id: string; name: string }> = [
+    { id: '', name: `local_offer` }
+  ];
+
+  // Built-in POIs, resolved (override hides the default; persistSkIcon() decides
+  // the saved value when one is selected).
+  PoiIcons.files.forEach((file: string) => {
     const name = file.slice(0, file.lastIndexOf('.'));
-    return {
-      id: name,
-      name: name
-    };
+    icons.push({ id: _symbolRegistry ? resolveSkIcon(name) : name, name });
   });
-  icons.unshift({
-    id: '',
-    name: `local_offer`
-  });
+
+  if (_symbolRegistry) {
+    const builtins = getBuiltinIconIds();
+    const localId = (ref: string) =>
+      ref.includes(':') ? ref.slice(ref.indexOf(':') + 1) : ref;
+    const isNewId = (i: { id: string }) => !builtins.has(localId(i.id));
+
+    // Note-role external symbols with a new id (overrides already shown above).
+    const noteSymbols = _symbolRegistry
+      .getExternalNoteIcons(false)
+      .filter(isNewId);
+    icons.push(...noteSymbols);
+
+    if (showAll) {
+      // Remaining external symbols of any role, also with new ids.
+      const noteRefs = new Set(noteSymbols.map((s) => s.id));
+      const otherSymbols = _symbolRegistry
+        .getExternalNoteIcons(true)
+        .filter(isNewId)
+        .filter((s) => !noteRefs.has(s.id));
+      icons.push(...otherSymbols);
+
+      // "default" entries for overridden built-in POIs (saved as default:<id>).
+      const replacedDefaults = PoiIcons.files
+        .map((f) => f.slice(0, f.lastIndexOf('.')))
+        .filter((id) => _symbolRegistry.hasExternalVersion(id))
+        .map((id) => ({ id, name: id }));
+      icons.push(...replacedDefaults);
+    }
+  }
   return icons;
 };
 
 /**
- * @description Return a list of Waypoint icon selection options
+ * @description Return a list of Waypoint icon selection options.
+ * Only the "Waypoints" category supports external symbols. External symbols
+ * with the 'waypoint' role appear there; an override of a built-in replaces the
+ * built-in in place (its default is hidden). When showAll is true, the group
+ * also includes external symbols of any role plus a "default:" entry for each
+ * built-in that has been overridden (so the built-in can still be chosen).
+ * The other categories (Pseudo AtoN, Sightings, …) are built-in only.
  */
-export const selListWaypointIcons = (): Record<
+export const selListWaypointIcons = (
+  showAll = false
+): Record<
   string,
   {
     group: string;
     icons: Array<AppIconDef>;
   }
 > => {
-  const iconList = {
+  const iconList: Record<string, { group: string; icons: Array<AppIconDef> }> = {
     waypoint: {
       group: 'Waypoints',
       icons: [getResourceIcon('waypoints', 'waypoint')]
@@ -292,6 +435,43 @@ export const selListWaypointIcons = (): Record<
       return getResourceIcon('waypoints', name);
     })
   );
+
+  if (_symbolRegistry) {
+    const builtins = getBuiltinIconIds();
+    const localId = (ref: string) =>
+      ref.includes(':') ? ref.slice(ref.indexOf(':') + 1) : ref;
+    // Overrides of a built-in are already shown via the resolved built-in/POI
+    // entry above, so exclude them here to avoid listing the same id twice.
+    const isNewId = (i: AppIconDef) => !builtins.has(localId(i.svgIcon ?? ''));
+
+    // Waypoint-role external symbols with a new id (no built-in counterpart).
+    const wptSymbols = _symbolRegistry
+      .getExternalWaypointIcons(false)
+      .filter(isNewId);
+    iconList.waypoint.icons = iconList.waypoint.icons.concat(wptSymbols);
+
+    if (showAll) {
+      // Remaining external symbols of any role, also with new ids.
+      const wptRefs = new Set(wptSymbols.map((s) => s.svgIcon));
+      const otherSymbols = _symbolRegistry
+        .getExternalWaypointIcons(true)
+        .filter(isNewId)
+        .filter((s) => !wptRefs.has(s.svgIcon));
+      iconList.waypoint.icons = iconList.waypoint.icons.concat(otherSymbols);
+
+      // "default:" entries for built-ins that have been overridden, so the
+      // built-in version can still be chosen. Display uses the bare id (built-in
+      // artwork); persistSkIcon() saves it as default:<id>.
+      const waypointBuiltinIds = [
+        'waypoint',
+        ...PoiIcons.files.map((f) => f.slice(0, f.lastIndexOf('.')))
+      ];
+      const replacedDefaults = waypointBuiltinIds
+        .filter((id) => _symbolRegistry.hasExternalVersion(id))
+        .map((id) => ({ svgIcon: id, name: id }));
+      iconList.waypoint.icons = iconList.waypoint.icons.concat(replacedDefaults);
+    }
+  }
 
   return iconList;
 };

--- a/src/app/modules/icons/app.icons.ts
+++ b/src/app/modules/icons/app.icons.ts
@@ -12,6 +12,7 @@ import { PoiIcons } from './poi';
 import { AtoNsType1 } from './atons';
 import { WaypointIcons, getWaypointDefs } from './waypoints';
 import { VesselAisIcons, AIS_TYPE_IDS } from './vessels';
+import { RESERVED_DEFAULT_NS } from './symbol-ref';
 
 // ---- Module-level hook for SymbolService ----
 // SymbolService calls setSymbolRegistry(this) after load() so that the pure
@@ -193,11 +194,13 @@ export const getResourceIcon = (
         name: undefined
       };
     }
-    // Only the 'waypoint' type participates in symbol overrides; other types
-    // (start-pin, pseudoaton, …) always render their built-in icon. Ignore the
+    // The 'waypoint' type — and typeless resources, treated as generic
+    // waypoints — participate in symbol overrides; other types (start-pin,
+    // pseudoaton, …) always render their built-in icon. Ignore the
     // 'no-such-symbol' fallback so an unresolved/foreign value (e.g. a GPX
     // <type>) falls back to the default waypoint icon, not the missing marker.
-    if (_symbolRegistry && wptType === 'waypoint') {
+    const isGenericWaypoint = !wptType || wptType === 'waypoint';
+    if (_symbolRegistry && isGenericWaypoint) {
       const resolved = _symbolRegistry.resolveDisplayIcon(wid);
       if (resolved && resolved.svgIcon !== 'no-such-symbol') {
         return { class: undefined, ...resolved, name: undefined };
@@ -324,6 +327,21 @@ export const getAisIcon = (id: number | string): AppIconDef => {
   }
 };
 
+// Namespaces whose local id can shadow a built-in icon — so the ref is already
+// represented by the resolved built-in entry and must not be offered twice.
+// Other namespaces (notably `custom:` user symbols) are always distinct, even
+// when their local id collides with a built-in name, and must stay selectable.
+// ('fsk' mirrors FSK_NS in symbols.service; inlined to avoid a circular import.)
+const BUILTIN_SHADOW_NS = new Set(['', RESERVED_DEFAULT_NS, 'fsk']);
+
+/** True when `ref` duplicates a built-in already listed via its resolved entry. */
+const shadowsBuiltin = (ref: string, builtins: Set<string>): boolean => {
+  const idx = ref.indexOf(':');
+  const namespace = idx === -1 ? '' : ref.slice(0, idx);
+  const id = idx === -1 ? ref : ref.slice(idx + 1);
+  return BUILTIN_SHADOW_NS.has(namespace) && builtins.has(id);
+};
+
 /**
  * @description Return a list of Note icon selection options.
  * Built-in POIs are shown resolved: an overridden POI shows its override and the
@@ -347,9 +365,7 @@ export const selListNoteIcons = (
 
   if (_symbolRegistry) {
     const builtins = getBuiltinIconIds();
-    const localId = (ref: string) =>
-      ref.includes(':') ? ref.slice(ref.indexOf(':') + 1) : ref;
-    const isNewId = (i: { id: string }) => !builtins.has(localId(i.id));
+    const isNewId = (i: { id: string }) => !shadowsBuiltin(i.id, builtins);
 
     // Note-role external symbols with a new id (overrides already shown above).
     const noteSymbols = _symbolRegistry
@@ -438,11 +454,9 @@ export const selListWaypointIcons = (
 
   if (_symbolRegistry) {
     const builtins = getBuiltinIconIds();
-    const localId = (ref: string) =>
-      ref.includes(':') ? ref.slice(ref.indexOf(':') + 1) : ref;
     // Overrides of a built-in are already shown via the resolved built-in/POI
     // entry above, so exclude them here to avoid listing the same id twice.
-    const isNewId = (i: AppIconDef) => !builtins.has(localId(i.svgIcon ?? ''));
+    const isNewId = (i: AppIconDef) => !shadowsBuiltin(i.svgIcon ?? '', builtins);
 
     // Waypoint-role external symbols with a new id (no built-in counterpart).
     const wptSymbols = _symbolRegistry

--- a/src/app/modules/icons/index.ts
+++ b/src/app/modules/icons/index.ts
@@ -3,3 +3,6 @@ export * from './atons';
 export * from './poi';
 export * from './vessels';
 export * from './waypoints';
+export * from './symbol-ref';
+export * from './symbols.service';
+export * from './resolve-skicon.pipe';

--- a/src/app/modules/icons/resolve-skicon.pipe.ts
+++ b/src/app/modules/icons/resolve-skicon.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { resolveSkIcon } from './app.icons';
+
+/**
+ * Resolve a skIcon reference (bare id or "namespace:id") to a
+ * Material-resolvable svgIcon name, applying external-symbol overrides.
+ * Used by list/panel templates that bind skIcon directly to <mat-icon>.
+ */
+@Pipe({
+  name: 'resolveSkIcon',
+  standalone: true
+})
+export class ResolveSkIconPipe implements PipeTransform {
+  public transform(ref?: string): string {
+    return resolveSkIcon(ref);
+  }
+}

--- a/src/app/modules/icons/resolve-skicon.pipe.ts
+++ b/src/app/modules/icons/resolve-skicon.pipe.ts
@@ -8,7 +8,12 @@ import { resolveSkIcon } from './app.icons';
  */
 @Pipe({
   name: 'resolveSkIcon',
-  standalone: true
+  standalone: true,
+  // Impure: the underlying symbol registry is populated asynchronously, so the
+  // pipe must re-evaluate after it loads/reloads (not only when `ref` changes).
+  // Only used in two bounded note-list templates, and resolveSkIcon() is a
+  // cheap map lookup, so the per-CD cost is negligible.
+  pure: false
 })
 export class ResolveSkIconPipe implements PipeTransform {
   public transform(ref?: string): string {

--- a/src/app/modules/icons/symbol-ref.ts
+++ b/src/app/modules/icons/symbol-ref.ts
@@ -1,0 +1,47 @@
+/** Pure helpers for Symbol resource reference parsing and validation. */
+
+export const RESERVED_DEFAULT_NS = 'default';
+
+/**
+ * Parse a symbol reference into namespace and id components.
+ * Splits on the FIRST colon only — namespace must not contain colons.
+ */
+export const parseRef = (
+  ref: string
+): { namespace?: string; id: string } => {
+  const idx = ref.indexOf(':');
+  if (idx === -1) {
+    return { id: ref };
+  }
+  return {
+    namespace: ref.slice(0, idx),
+    id: ref.slice(idx + 1)
+  };
+};
+
+/** True when the reference contains a namespace qualifier. */
+export const isQualified = (ref: string): boolean => ref.includes(':');
+
+/** True when the reference uses the reserved built-in namespace. */
+export const isDefaultNs = (ref: string): boolean =>
+  ref.startsWith(`${RESERVED_DEFAULT_NS}:`);
+
+/**
+ * Return true when the symbol's URL is safe to load.
+ * Rejects other-origin absolute URLs and data:/javascript: schemes.
+ * Same-origin relative paths and absolute paths beginning with / are allowed.
+ */
+export const isRenderableSymbol = (sym: {
+  mediaType: string;
+  url: string;
+}): boolean => {
+  if (sym.mediaType !== 'image/svg+xml') return false;
+  const url = sym.url ?? '';
+  if (!url) return false;
+  // Reject data: and javascript: schemes
+  const lower = url.toLowerCase().trimStart();
+  if (lower.startsWith('data:') || lower.startsWith('javascript:')) return false;
+  // Reject absolute URLs pointing to other origins
+  if (/^https?:\/\//i.test(url)) return false;
+  return true;
+};

--- a/src/app/modules/icons/symbol-ref.ts
+++ b/src/app/modules/icons/symbol-ref.ts
@@ -41,7 +41,8 @@ export const isRenderableSymbol = (sym: {
   // Reject data: and javascript: schemes
   const lower = url.toLowerCase().trimStart();
   if (lower.startsWith('data:') || lower.startsWith('javascript:')) return false;
-  // Reject absolute URLs pointing to other origins
-  if (/^https?:\/\//i.test(url)) return false;
+  // Reject absolute URLs (any scheme) and protocol-relative URLs — both can
+  // point to other origins once trusted via bypassSecurityTrustResourceUrl().
+  if (/^[a-z][a-z0-9+.-]*:/i.test(lower) || lower.startsWith('//')) return false;
   return true;
 };

--- a/src/app/modules/icons/symbols.service.ts
+++ b/src/app/modules/icons/symbols.service.ts
@@ -12,8 +12,11 @@ import { AppIconDef, getBuiltinIconIds } from './app.icons';
 export const FALLBACK_ICON = 'no-such-symbol';
 
 // Freeboard's own vendor namespace. A symbol whose alias is `fsk:<built-in-id>`
-// overrides that built-in icon. `custom:<id>` symbols are offered as new
-// user-defined symbols. All other alias namespaces are ignored by Freeboard.
+// overrides that built-in icon, and a bare id resolves to that override when one
+// exists. `custom:<id>` symbols are offered as new user-defined symbols. A symbol
+// in any other namespace still renders by its exact alias (the image is shared
+// across apps); it is just never offered in a picker. An explicit `default:<id>`
+// always forces the bundled built-in, ignoring any `fsk:` override.
 export const FSK_NS = 'fsk';
 export const CUSTOM_NS = 'custom';
 
@@ -92,32 +95,37 @@ export class SymbolService implements SymbolRegistryLike {
     }
   }
 
-  // Register each of a symbol's relevant aliases. `fsk:<id>` overrides built-in
-  // `<id>`; `custom:<id>` is a user symbol; other namespaces are ignored.
+  // Index every alias of every namespace so a stored reference renders as named:
+  // the symbol image is shared across apps, so an icon another app wrote
+  // (garmin:anchor, a plugin's my-plugin:icon, …) must still draw. Only the
+  // built-in override table (`fsk:`) and the user-symbol pickers (`custom:`) are
+  // namespace-scoped; every other namespace renders but is never offered.
   private indexSymbol(sym: SymbolResource): void {
     for (const aliasStr of sym.alias) {
       const { namespace, id } = parseRef(aliasStr);
       if (!namespace || !id) continue;
 
+      const ref = `${namespace}:${id}`;
+      // `namespace:id` is globally unique per the spec, so the first alias wins.
+      if (this.byRef.has(ref)) continue;
+      const idx = this.toIndexed(sym, ref);
+      this.registerMaterial(namespace, id, sym.url);
+      this.registerMarker(ref, idx); // qualified render ref
+      this.byRef.set(ref, idx);
+
       if (namespace === FSK_NS) {
-        const ref = `${FSK_NS}:${id}`;
-        const idx = this.toIndexed(sym, ref);
-        this.registerMaterial(FSK_NS, id, sym.url);
-        this.registerMarker(ref, idx); // qualified render ref
         this.registerMarker(id, idx); // bare built-in id -> override (map markers)
-        this.byRef.set(ref, idx);
         if (!this.overrides.has(id)) this.overrides.set(id, idx);
       } else if (namespace === CUSTOM_NS) {
-        const ref = `${CUSTOM_NS}:${id}`;
-        if (this.byRef.has(ref)) continue;
-        const idx = this.toIndexed(sym, ref);
-        this.registerMaterial(CUSTOM_NS, id, sym.url);
-        this.registerMarker(ref, idx);
-        this.byRef.set(ref, idx);
         this.userSymbols.push(idx);
       }
-      // other namespaces (garmin, opencpn, user, …) are not used by Freeboard
     }
+  }
+
+  // The two namespaces Freeboard adopts (its own vendor table plus user symbols).
+  // Rendering is namespace-agnostic, but offering and GPX auto-mapping are not.
+  private isAdoptedRef(ref: string): boolean {
+    return ref.startsWith(`${FSK_NS}:`) || ref.startsWith(`${CUSTOM_NS}:`);
   }
 
   private toIndexed(sym: SymbolResource, ref: string): IndexedSymbol {
@@ -215,9 +223,11 @@ export class SymbolService implements SymbolRegistryLike {
    */
   resolveGpxSym(sym: string): string | null {
     if (!sym) return null;
-    // 1. gpxSym exact match.
+    // 1. gpxSym exact match. Auto-mapping only ever picks an adopted symbol
+    // (fsk: or custom:), never a foreign one the user cannot re-pick in the UI.
     let fallback: string | null = null;
     for (const [ref, s] of this.byRef.entries()) {
+      if (!this.isAdoptedRef(ref)) continue;
       if (s.gpxSym === sym) {
         if (ref.startsWith(`${CUSTOM_NS}:`)) return ref;
         fallback = fallback ?? ref;
@@ -226,6 +236,7 @@ export class SymbolService implements SymbolRegistryLike {
     if (fallback) return fallback;
     // 2. local id exact match.
     for (const ref of this.byRef.keys()) {
+      if (!this.isAdoptedRef(ref)) continue;
       const id = ref.slice(ref.indexOf(':') + 1);
       if (id === sym) {
         if (ref.startsWith(`${CUSTOM_NS}:`)) return ref;

--- a/src/app/modules/icons/symbols.service.ts
+++ b/src/app/modules/icons/symbols.service.ts
@@ -6,16 +6,28 @@ import { SignalKClient } from 'signalk-client-angular';
 import { AppFacade } from 'src/app/app.facade';
 import { SymbolResource, SymbolRole } from 'src/app/types/symbols';
 import { MapImageRegistry } from '../map/ol/lib/map-image-registry.service';
-import {
-  isQualified,
-  isDefaultNs,
-  isRenderableSymbol,
-  parseRef,
-  RESERVED_DEFAULT_NS
-} from './symbol-ref';
+import { isQualified, isDefaultNs, isRenderableSymbol, parseRef } from './symbol-ref';
 import { AppIconDef, getBuiltinIconIds } from './app.icons';
 
 export const FALLBACK_ICON = 'no-such-symbol';
+
+// Freeboard's own vendor namespace. A symbol whose alias is `fsk:<built-in-id>`
+// overrides that built-in icon. `custom:<id>` symbols are offered as new
+// user-defined symbols. All other alias namespaces are ignored by Freeboard.
+export const FSK_NS = 'fsk';
+export const CUSTOM_NS = 'custom';
+
+// One renderable reference into a provider symbol (a single alias's worth).
+interface IndexedSymbol {
+  ref: string; // canonical render ref, e.g. "custom:dive-flag" or "fsk:dive-site"
+  url: string;
+  scale?: number;
+  anchor?: [number, number];
+  name: string;
+  roles: SymbolRole[];
+  gpxType?: string;
+  gpxSym?: string;
+}
 
 /** Interface for the module-level hook used by pure functions in app.icons.ts */
 export interface SymbolRegistryLike {
@@ -38,10 +50,12 @@ export class SymbolService implements SymbolRegistryLike {
   /** True after load() has completed (success or error). */
   readonly loaded = signal(false);
 
-  /** Index by canonical "namespace:id" */
-  private byRef = new Map<string, SymbolResource>();
-  /** Index by local id → list of symbols (for unqualified lookup) */
-  private byLocalId = new Map<string, SymbolResource[]>();
+  /** Index by render ref ("custom:id" / "fsk:id") for qualified lookups. */
+  private byRef = new Map<string, IndexedSymbol>();
+  /** Built-in id -> the fsk override symbol for it (first alias wins). */
+  private overrides = new Map<string, IndexedSymbol>();
+  /** User-defined symbols (custom: aliases) for the icon selectors. */
+  private userSymbols: IndexedSymbol[] = [];
   /** Set of built-in icon ids (bare names from getSvgList). */
   private builtinIds: Set<string>;
 
@@ -52,9 +66,9 @@ export class SymbolService implements SymbolRegistryLike {
   /** Fetch /resources/symbols, index, and register all renderable symbols. */
   async load(): Promise<void> {
     try {
-      const result = await firstValueFrom(
+      const result = (await firstValueFrom(
         this.signalk.api.get(this.app.skApiVersion, '/resources/symbols')
-      ) as Record<string, unknown>;
+      )) as Record<string, unknown>;
 
       if (!result || typeof result !== 'object') {
         if (isDevMode()) console.debug('[SymbolService] No symbols returned from server.');
@@ -64,19 +78,8 @@ export class SymbolService implements SymbolRegistryLike {
       for (const [key, raw] of Object.entries(result)) {
         const sym = raw as SymbolResource;
         if (!this.isValidSymbol(sym, key)) continue;
-        const ref = `${sym.namespace}:${sym.id}`;
-        if (this.byRef.has(ref)) {
-          if (isDevMode()) console.debug(`[SymbolService] Duplicate symbol ref "${ref}", skipping.`);
-          continue;
-        }
-        this.byRef.set(ref, sym);
-        const existing = this.byLocalId.get(sym.id) ?? [];
-        existing.push(sym);
-        this.byLocalId.set(sym.id, existing);
+        this.indexSymbol(sym);
       }
-
-      this.registerMaterialIcons();
-      this.registerMapMarkers();
     } catch (err: unknown) {
       if (isDevMode()) {
         const status = (err as { status?: number })?.status;
@@ -89,185 +92,178 @@ export class SymbolService implements SymbolRegistryLike {
     }
   }
 
-  /** Register all indexed SVG symbols with Angular Material's icon registry. */
-  private registerMaterialIcons(): void {
-    for (const sym of this.byRef.values()) {
-      this.iconReg.addSvgIconInNamespace(
-        sym.namespace,
-        sym.id,
-        this.dom.bypassSecurityTrustResourceUrl(sym.url)
-      );
+  // Register each of a symbol's relevant aliases. `fsk:<id>` overrides built-in
+  // `<id>`; `custom:<id>` is a user symbol; other namespaces are ignored.
+  private indexSymbol(sym: SymbolResource): void {
+    for (const aliasStr of sym.alias) {
+      const { namespace, id } = parseRef(aliasStr);
+      if (!namespace || !id) continue;
+
+      if (namespace === FSK_NS) {
+        const ref = `${FSK_NS}:${id}`;
+        const idx = this.toIndexed(sym, ref);
+        this.registerMaterial(FSK_NS, id, sym.url);
+        this.registerMarker(ref, idx); // qualified render ref
+        this.registerMarker(id, idx); // bare built-in id -> override (map markers)
+        this.byRef.set(ref, idx);
+        if (!this.overrides.has(id)) this.overrides.set(id, idx);
+      } else if (namespace === CUSTOM_NS) {
+        const ref = `${CUSTOM_NS}:${id}`;
+        if (this.byRef.has(ref)) continue;
+        const idx = this.toIndexed(sym, ref);
+        this.registerMaterial(CUSTOM_NS, id, sym.url);
+        this.registerMarker(ref, idx);
+        this.byRef.set(ref, idx);
+        this.userSymbols.push(idx);
+      }
+      // other namespaces (garmin, opencpn, user, …) are not used by Freeboard
     }
   }
 
-  /** Push all indexed symbols into MapImageRegistry as marker definitions. */
-  private registerMapMarkers(): void {
-    for (const [ref, sym] of this.byRef.entries()) {
-      this.mapImages.registerSymbolMarker(ref, {
-        path: sym.url,
-        scale: sym.scale,
-        anchor: sym.anchor
-      });
-    }
+  private toIndexed(sym: SymbolResource, ref: string): IndexedSymbol {
+    return {
+      ref,
+      url: sym.url,
+      scale: sym.scale,
+      anchor: sym.anchor,
+      name: sym.name,
+      roles: Array.isArray(sym.roles) ? sym.roles : [],
+      gpxType: sym.gpxType,
+      gpxSym: sym.gpxSym
+    };
+  }
+
+  private registerMaterial(namespace: string, id: string, url: string): void {
+    this.iconReg.addSvgIconInNamespace(
+      namespace,
+      id,
+      this.dom.bypassSecurityTrustResourceUrl(url)
+    );
+  }
+
+  private registerMarker(ref: string, idx: IndexedSymbol): void {
+    this.mapImages.registerSymbolMarker(ref, {
+      path: idx.url,
+      scale: idx.scale,
+      anchor: idx.anchor
+    });
   }
 
   /**
    * Resolve a skIcon reference to an AppIconDef whose svgIcon is a
-   * Material-resolvable name, applying spec precedence rules.
-   *
-   * Returns null when ref is falsy (caller should use its own default).
+   * Material-resolvable name. Returns null when ref is falsy.
    */
   resolveDisplayIcon(ref: string): AppIconDef | null {
     if (!ref) return null;
 
     if (isDefaultNs(ref)) {
-      // Force built-in: strip "default:" prefix
+      // Force built-in: strip "default:" prefix.
       const { id } = parseRef(ref);
-      return this.builtinIds.has(id)
-        ? { svgIcon: id }
-        : { svgIcon: FALLBACK_ICON };
+      return this.builtinIds.has(id) ? { svgIcon: id } : { svgIcon: FALLBACK_ICON };
     }
 
     if (isQualified(ref)) {
-      // Qualified external reference
-      return this.byRef.has(ref)
-        ? { svgIcon: ref }
-        : { svgIcon: FALLBACK_ICON };
+      // Qualified external reference (custom:id or fsk:id).
+      return this.byRef.has(ref) ? { svgIcon: ref } : { svgIcon: FALLBACK_ICON };
     }
 
-    // Unqualified: external-first, then built-in, then fallback
-    const candidates = this.byLocalId.get(ref);
-    if (candidates && candidates.length > 0) {
-      // Pick deterministically: first by sorted namespace
-      const winner = candidates.slice().sort((a, b) =>
-        a.namespace.localeCompare(b.namespace)
-      )[0];
-      return { svgIcon: `${winner.namespace}:${winner.id}` };
-    }
-    if (this.builtinIds.has(ref)) {
-      return { svgIcon: ref };
-    }
+    // Bare id: an fsk override replaces the built-in, else the built-in itself.
+    const ov = this.overrides.get(ref);
+    if (ov) return { svgIcon: ov.ref };
+    if (this.builtinIds.has(ref)) return { svgIcon: ref };
     return { svgIcon: FALLBACK_ICON };
   }
 
   /**
-   * Resolve a skIcon reference to a map-marker definition.
-   * Returns null when the ref should fall through to built-in rendering.
+   * Resolve a skIcon reference to a map-marker definition, or null to fall
+   * through to built-in rendering.
    */
   resolveMapMarker(
     ref: string
   ): { path: string; scale?: number; anchor?: [number, number] } | null {
-    if (!ref || isDefaultNs(ref)) return null;
-
-    if (isQualified(ref)) {
-      const sym = this.byRef.get(ref);
-      return sym ? { path: sym.url, scale: sym.scale, anchor: sym.anchor } : null;
-    }
-
-    // Unqualified: external-first
-    const candidates = this.byLocalId.get(ref);
-    if (candidates && candidates.length > 0) {
-      const winner = candidates.slice().sort((a, b) =>
-        a.namespace.localeCompare(b.namespace)
-      )[0];
-      return { path: winner.url, scale: winner.scale, anchor: winner.anchor };
-    }
-    return null;
+    const idx = this.resolveSymbol(ref);
+    return idx ? { path: idx.url, scale: idx.scale, anchor: idx.anchor } : null;
   }
 
   /**
-   * Return external symbols suitable for the note icon selector.
-   * Filtered to role 'note' by default; showAll returns all renderable symbols.
+   * Return user symbols (custom:) suitable for the note icon selector.
+   * Filtered to role 'note' by default; showAll returns all user symbols.
    */
   getExternalNoteIcons(showAll: boolean): Array<{ id: string; name: string }> {
-    const result: Array<{ id: string; name: string }> = [];
-    for (const [ref, sym] of this.byRef.entries()) {
-      if (!showAll && !this.hasRole(sym, 'note')) continue;
-      result.push({ id: ref, name: sym.name });
-    }
-    return result.sort((a, b) => a.name.localeCompare(b.name));
+    return this.userSymbols
+      .filter((s) => showAll || s.roles.includes('note'))
+      .map((s) => ({ id: s.ref, name: s.name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
   /**
-   * Return external symbols suitable for the waypoint icon selector.
-   * Filtered to role 'waypoint' by default; showAll returns all renderable symbols.
+   * Return user symbols (custom:) suitable for the waypoint icon selector.
+   * Filtered to role 'waypoint' by default; showAll returns all user symbols.
    */
   getExternalWaypointIcons(showAll: boolean): Array<AppIconDef> {
-    const result: AppIconDef[] = [];
-    for (const [ref, sym] of this.byRef.entries()) {
-      if (!showAll && !this.hasRole(sym, 'waypoint')) continue;
-      result.push({ svgIcon: ref, name: sym.name });
-    }
-    return result.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+    return this.userSymbols
+      .filter((s) => showAll || s.roles.includes('waypoint'))
+      .map((s) => ({ svgIcon: s.ref, name: s.name }))
+      .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
   }
 
   /**
    * Resolve a GPX waypoint `<sym>` value to a canonical symbol ref for import:
    *   1. exact match against a symbol's gpxSym, else
-   *   2. exact match against a symbol's local id (deterministic winner).
-   * Returns null when nothing matches (caller falls back to its default).
+   *   2. exact match against an alias's local id.
+   * Prefers a `custom:` ref. Returns null when nothing matches.
    */
   resolveGpxSym(sym: string): string | null {
     if (!sym) return null;
-    // 1. gpxSym exact match
+    // 1. gpxSym exact match.
+    let fallback: string | null = null;
     for (const [ref, s] of this.byRef.entries()) {
-      if (s.gpxSym === sym) return ref;
+      if (s.gpxSym === sym) {
+        if (ref.startsWith(`${CUSTOM_NS}:`)) return ref;
+        fallback = fallback ?? ref;
+      }
     }
-    // 2. local id exact match
-    const candidates = this.byLocalId.get(sym);
-    if (candidates && candidates.length > 0) {
-      const winner = candidates
-        .slice()
-        .sort((a, b) => a.namespace.localeCompare(b.namespace))[0];
-      return `${winner.namespace}:${winner.id}`;
+    if (fallback) return fallback;
+    // 2. local id exact match.
+    for (const ref of this.byRef.keys()) {
+      const id = ref.slice(ref.indexOf(':') + 1);
+      if (id === sym) {
+        if (ref.startsWith(`${CUSTOM_NS}:`)) return ref;
+        fallback = fallback ?? ref;
+      }
     }
-    return null;
+    return fallback;
   }
 
   /**
    * Return the GPX mapping ({gpxType, gpxSym}) of the symbol referenced by the
-   * supplied skIcon, or null when the ref is not an external symbol (built-in,
-   * "default:" pin, or unknown). Used by GPX export.
+   * supplied skIcon, or null when it is not an external symbol. Used by export.
    */
   getGpxMapping(ref: string): { gpxType?: string; gpxSym?: string } | null {
-    const sym = this.resolveSymbol(ref);
-    return sym ? { gpxType: sym.gpxType, gpxSym: sym.gpxSym } : null;
+    const idx = this.resolveSymbol(ref);
+    return idx ? { gpxType: idx.gpxType, gpxSym: idx.gpxSym } : null;
+  }
+
+  /** True when a built-in id has an fsk override. */
+  hasExternalVersion(id: string): boolean {
+    return this.overrides.has(id);
   }
 
   // ---- Private helpers ----
 
-  /** True when at least one external symbol shares the given bare local id. */
-  hasExternalVersion(id: string): boolean {
-    return this.byLocalId.has(id);
-  }
-
-  /** Resolve a skIcon ref to its external SymbolResource (null if built-in). */
-  private resolveSymbol(ref: string): SymbolResource | null {
+  /** Resolve a skIcon ref to its IndexedSymbol (null if built-in / unknown). */
+  private resolveSymbol(ref: string): IndexedSymbol | null {
     if (!ref || isDefaultNs(ref)) return null;
     if (isQualified(ref)) return this.byRef.get(ref) ?? null;
-    const candidates = this.byLocalId.get(ref);
-    if (candidates && candidates.length > 0) {
-      return candidates
-        .slice()
-        .sort((a, b) => a.namespace.localeCompare(b.namespace))[0];
-    }
-    return null;
-  }
-
-  private hasRole(sym: SymbolResource, role: SymbolRole): boolean {
-    return Array.isArray(sym.roles) && sym.roles.includes(role);
+    return this.overrides.get(ref) ?? null;
   }
 
   private isValidSymbol(sym: unknown, key: string): sym is SymbolResource {
     if (!sym || typeof sym !== 'object') return false;
     const s = sym as Partial<SymbolResource>;
-    if (!s.id || !s.namespace || !s.name || !s.url) return false;
-    if (s.namespace === RESERVED_DEFAULT_NS) {
-      if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": reserved namespace "default".`);
-      return false;
-    }
-    if (!/^[A-Za-z0-9_]+$/.test(s.namespace)) {
-      if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": invalid namespace "${s.namespace}".`);
+    if (!s.uuid || !s.name || !s.url) return false;
+    if (!Array.isArray(s.alias) || s.alias.length === 0) {
+      if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": no alias.`);
       return false;
     }
     if (!isRenderableSymbol(s as { mediaType: string; url: string })) {

--- a/src/app/modules/icons/symbols.service.ts
+++ b/src/app/modules/icons/symbols.service.ts
@@ -1,0 +1,279 @@
+import { inject, Injectable, isDevMode, signal } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { DomSanitizer } from '@angular/platform-browser';
+import { MatIconRegistry } from '@angular/material/icon';
+import { SignalKClient } from 'signalk-client-angular';
+import { AppFacade } from 'src/app/app.facade';
+import { SymbolResource, SymbolRole } from 'src/app/types/symbols';
+import { MapImageRegistry } from '../map/ol/lib/map-image-registry.service';
+import {
+  isQualified,
+  isDefaultNs,
+  isRenderableSymbol,
+  parseRef,
+  RESERVED_DEFAULT_NS
+} from './symbol-ref';
+import { AppIconDef, getBuiltinIconIds } from './app.icons';
+
+export const FALLBACK_ICON = 'no-such-symbol';
+
+/** Interface for the module-level hook used by pure functions in app.icons.ts */
+export interface SymbolRegistryLike {
+  resolveDisplayIcon(ref: string): AppIconDef | null;
+  resolveMapMarker(ref: string): { path: string; scale?: number; anchor?: [number, number] } | null;
+  getExternalNoteIcons(showAll: boolean): Array<{ id: string; name: string }>;
+  getExternalWaypointIcons(showAll: boolean): Array<AppIconDef>;
+  hasExternalVersion(id: string): boolean;
+  getGpxMapping(ref: string): { gpxType?: string; gpxSym?: string } | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SymbolService implements SymbolRegistryLike {
+  private app = inject(AppFacade);
+  private signalk = inject(SignalKClient);
+  private iconReg = inject(MatIconRegistry);
+  private dom = inject(DomSanitizer);
+  private mapImages = inject(MapImageRegistry);
+
+  /** True after load() has completed (success or error). */
+  readonly loaded = signal(false);
+
+  /** Index by canonical "namespace:id" */
+  private byRef = new Map<string, SymbolResource>();
+  /** Index by local id → list of symbols (for unqualified lookup) */
+  private byLocalId = new Map<string, SymbolResource[]>();
+  /** Set of built-in icon ids (bare names from getSvgList). */
+  private builtinIds: Set<string>;
+
+  constructor() {
+    this.builtinIds = getBuiltinIconIds();
+  }
+
+  /** Fetch /resources/symbols, index, and register all renderable symbols. */
+  async load(): Promise<void> {
+    try {
+      const result = await firstValueFrom(
+        this.signalk.api.get(this.app.skApiVersion, '/resources/symbols')
+      ) as Record<string, unknown>;
+
+      if (!result || typeof result !== 'object') {
+        if (isDevMode()) console.debug('[SymbolService] No symbols returned from server.');
+        return;
+      }
+
+      for (const [key, raw] of Object.entries(result)) {
+        const sym = raw as SymbolResource;
+        if (!this.isValidSymbol(sym, key)) continue;
+        const ref = `${sym.namespace}:${sym.id}`;
+        if (this.byRef.has(ref)) {
+          if (isDevMode()) console.debug(`[SymbolService] Duplicate symbol ref "${ref}", skipping.`);
+          continue;
+        }
+        this.byRef.set(ref, sym);
+        const existing = this.byLocalId.get(sym.id) ?? [];
+        existing.push(sym);
+        this.byLocalId.set(sym.id, existing);
+      }
+
+      this.registerMaterialIcons();
+      this.registerMapMarkers();
+    } catch (err: unknown) {
+      if (isDevMode()) {
+        const status = (err as { status?: number })?.status;
+        if (status !== 404) {
+          console.debug('[SymbolService] Could not load symbols:', err);
+        }
+      }
+    } finally {
+      this.loaded.set(true);
+    }
+  }
+
+  /** Register all indexed SVG symbols with Angular Material's icon registry. */
+  private registerMaterialIcons(): void {
+    for (const sym of this.byRef.values()) {
+      this.iconReg.addSvgIconInNamespace(
+        sym.namespace,
+        sym.id,
+        this.dom.bypassSecurityTrustResourceUrl(sym.url)
+      );
+    }
+  }
+
+  /** Push all indexed symbols into MapImageRegistry as marker definitions. */
+  private registerMapMarkers(): void {
+    for (const [ref, sym] of this.byRef.entries()) {
+      this.mapImages.registerSymbolMarker(ref, {
+        path: sym.url,
+        scale: sym.scale,
+        anchor: sym.anchor
+      });
+    }
+  }
+
+  /**
+   * Resolve a skIcon reference to an AppIconDef whose svgIcon is a
+   * Material-resolvable name, applying spec precedence rules.
+   *
+   * Returns null when ref is falsy (caller should use its own default).
+   */
+  resolveDisplayIcon(ref: string): AppIconDef | null {
+    if (!ref) return null;
+
+    if (isDefaultNs(ref)) {
+      // Force built-in: strip "default:" prefix
+      const { id } = parseRef(ref);
+      return this.builtinIds.has(id)
+        ? { svgIcon: id }
+        : { svgIcon: FALLBACK_ICON };
+    }
+
+    if (isQualified(ref)) {
+      // Qualified external reference
+      return this.byRef.has(ref)
+        ? { svgIcon: ref }
+        : { svgIcon: FALLBACK_ICON };
+    }
+
+    // Unqualified: external-first, then built-in, then fallback
+    const candidates = this.byLocalId.get(ref);
+    if (candidates && candidates.length > 0) {
+      // Pick deterministically: first by sorted namespace
+      const winner = candidates.slice().sort((a, b) =>
+        a.namespace.localeCompare(b.namespace)
+      )[0];
+      return { svgIcon: `${winner.namespace}:${winner.id}` };
+    }
+    if (this.builtinIds.has(ref)) {
+      return { svgIcon: ref };
+    }
+    return { svgIcon: FALLBACK_ICON };
+  }
+
+  /**
+   * Resolve a skIcon reference to a map-marker definition.
+   * Returns null when the ref should fall through to built-in rendering.
+   */
+  resolveMapMarker(
+    ref: string
+  ): { path: string; scale?: number; anchor?: [number, number] } | null {
+    if (!ref || isDefaultNs(ref)) return null;
+
+    if (isQualified(ref)) {
+      const sym = this.byRef.get(ref);
+      return sym ? { path: sym.url, scale: sym.scale, anchor: sym.anchor } : null;
+    }
+
+    // Unqualified: external-first
+    const candidates = this.byLocalId.get(ref);
+    if (candidates && candidates.length > 0) {
+      const winner = candidates.slice().sort((a, b) =>
+        a.namespace.localeCompare(b.namespace)
+      )[0];
+      return { path: winner.url, scale: winner.scale, anchor: winner.anchor };
+    }
+    return null;
+  }
+
+  /**
+   * Return external symbols suitable for the note icon selector.
+   * Filtered to role 'note' by default; showAll returns all renderable symbols.
+   */
+  getExternalNoteIcons(showAll: boolean): Array<{ id: string; name: string }> {
+    const result: Array<{ id: string; name: string }> = [];
+    for (const [ref, sym] of this.byRef.entries()) {
+      if (!showAll && !this.hasRole(sym, 'note')) continue;
+      result.push({ id: ref, name: sym.name });
+    }
+    return result.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
+   * Return external symbols suitable for the waypoint icon selector.
+   * Filtered to role 'waypoint' by default; showAll returns all renderable symbols.
+   */
+  getExternalWaypointIcons(showAll: boolean): Array<AppIconDef> {
+    const result: AppIconDef[] = [];
+    for (const [ref, sym] of this.byRef.entries()) {
+      if (!showAll && !this.hasRole(sym, 'waypoint')) continue;
+      result.push({ svgIcon: ref, name: sym.name });
+    }
+    return result.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+  }
+
+  /**
+   * Resolve a GPX waypoint `<sym>` value to a canonical symbol ref for import:
+   *   1. exact match against a symbol's gpxSym, else
+   *   2. exact match against a symbol's local id (deterministic winner).
+   * Returns null when nothing matches (caller falls back to its default).
+   */
+  resolveGpxSym(sym: string): string | null {
+    if (!sym) return null;
+    // 1. gpxSym exact match
+    for (const [ref, s] of this.byRef.entries()) {
+      if (s.gpxSym === sym) return ref;
+    }
+    // 2. local id exact match
+    const candidates = this.byLocalId.get(sym);
+    if (candidates && candidates.length > 0) {
+      const winner = candidates
+        .slice()
+        .sort((a, b) => a.namespace.localeCompare(b.namespace))[0];
+      return `${winner.namespace}:${winner.id}`;
+    }
+    return null;
+  }
+
+  /**
+   * Return the GPX mapping ({gpxType, gpxSym}) of the symbol referenced by the
+   * supplied skIcon, or null when the ref is not an external symbol (built-in,
+   * "default:" pin, or unknown). Used by GPX export.
+   */
+  getGpxMapping(ref: string): { gpxType?: string; gpxSym?: string } | null {
+    const sym = this.resolveSymbol(ref);
+    return sym ? { gpxType: sym.gpxType, gpxSym: sym.gpxSym } : null;
+  }
+
+  // ---- Private helpers ----
+
+  /** True when at least one external symbol shares the given bare local id. */
+  hasExternalVersion(id: string): boolean {
+    return this.byLocalId.has(id);
+  }
+
+  /** Resolve a skIcon ref to its external SymbolResource (null if built-in). */
+  private resolveSymbol(ref: string): SymbolResource | null {
+    if (!ref || isDefaultNs(ref)) return null;
+    if (isQualified(ref)) return this.byRef.get(ref) ?? null;
+    const candidates = this.byLocalId.get(ref);
+    if (candidates && candidates.length > 0) {
+      return candidates
+        .slice()
+        .sort((a, b) => a.namespace.localeCompare(b.namespace))[0];
+    }
+    return null;
+  }
+
+  private hasRole(sym: SymbolResource, role: SymbolRole): boolean {
+    return Array.isArray(sym.roles) && sym.roles.includes(role);
+  }
+
+  private isValidSymbol(sym: unknown, key: string): sym is SymbolResource {
+    if (!sym || typeof sym !== 'object') return false;
+    const s = sym as Partial<SymbolResource>;
+    if (!s.id || !s.namespace || !s.name || !s.url) return false;
+    if (s.namespace === RESERVED_DEFAULT_NS) {
+      if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": reserved namespace "default".`);
+      return false;
+    }
+    if (!/^[A-Za-z0-9_]+$/.test(s.namespace)) {
+      if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": invalid namespace "${s.namespace}".`);
+      return false;
+    }
+    if (!isRenderableSymbol(s as { mediaType: string; url: string })) {
+      if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": not renderable.`);
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/app/modules/icons/symbols.service.ts
+++ b/src/app/modules/icons/symbols.service.ts
@@ -69,6 +69,11 @@ export class SymbolService implements SymbolRegistryLike {
   /** Fetch /resources/symbols, index, and register all renderable symbols. */
   async load(): Promise<void> {
     try {
+      // Reset indexes so a reload reflects removed/changed provider symbols
+      // rather than accumulating stale entries across calls.
+      this.byRef.clear();
+      this.overrides.clear();
+      this.userSymbols = [];
       const result = (await firstValueFrom(
         this.signalk.api.get(this.app.skApiVersion, '/resources/symbols')
       )) as Record<string, unknown>;
@@ -272,9 +277,35 @@ export class SymbolService implements SymbolRegistryLike {
   private isValidSymbol(sym: unknown, key: string): sym is SymbolResource {
     if (!sym || typeof sym !== 'object') return false;
     const s = sym as Partial<SymbolResource>;
-    if (!s.uuid || !s.name || !s.url) return false;
-    if (!Array.isArray(s.alias) || s.alias.length === 0) {
+    if (
+      typeof s.uuid !== 'string' ||
+      typeof s.name !== 'string' ||
+      typeof s.url !== 'string' ||
+      typeof s.mediaType !== 'string'
+    ) {
+      return false;
+    }
+    // Aliases must be well-formed `namespace:id` (single colon, no whitespace).
+    const isAliasRef = (a: unknown): a is string =>
+      typeof a === 'string' && /^[^:\s]+:[^:\s]+$/.test(a);
+    if (
+      !Array.isArray(s.alias) ||
+      s.alias.length === 0 ||
+      s.alias.some((a) => !isAliasRef(a))
+    ) {
       if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": no alias.`);
+      return false;
+    }
+    // scale/anchor feed map markers directly — reject non-finite/malformed.
+    if (s.scale !== undefined && !Number.isFinite(s.scale)) {
+      return false;
+    }
+    if (
+      s.anchor !== undefined &&
+      (!Array.isArray(s.anchor) ||
+        s.anchor.length !== 2 ||
+        s.anchor.some((v) => !Number.isFinite(v)))
+    ) {
       return false;
     }
     if (!isRenderableSymbol(s as { mediaType: string; url: string })) {

--- a/src/app/modules/map/ol/lib/map-image-registry.service.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.ts
@@ -19,6 +19,7 @@ interface MapImages {
   poi: MapImageCollection;
   vessels: MapImageCollection;
   waypoints: MapImageCollection;
+  symbols: MapImageCollection;
 }
 
 export interface MapIconDef {
@@ -35,8 +36,12 @@ export class MapImageRegistry {
     atons: {},
     poi: {},
     vessels: {},
-    waypoints: {}
+    waypoints: {},
+    symbols: {}
   };
+
+  /** Definitions for external symbols registered by SymbolService. */
+  private symbolDefs: { [ref: string]: MapIconDef } = {};
 
   private atonImageDefs: any = {
     virtual: {},
@@ -61,14 +66,25 @@ export class MapImageRegistry {
    */
   getAtoN(id: number | string, virtual?: boolean): Icon {
     const vid = ATON_TYPE_IDS[id] ?? 'aton';
-    if (!this.icons.atons[vid]) {
-      this.buildIcon(
-        this.icons.atons,
-        virtual ? this.atonImageDefs.virtual : this.atonImageDefs.real,
-        vid
-      );
+    const variant = virtual ? 'virtual' : 'real';
+    const defs = virtual ? this.atonImageDefs.virtual : this.atonImageDefs.real;
+    // External symbol override keyed by "real-<vid>" / "virtual-<vid>"
+    // (matches the built-in svg basenames, e.g. "real-north", "virtual-port").
+    const ext = this.getExternalSymbol(`${variant}-${vid}`);
+    if (ext) {
+      return ext;
     }
-    return this.icons.atons[vid] ?? this.icons.atons['aton'];
+    // Cache key includes the real/virtual variant so the two do not collide
+    // (real-north and virtual-north use different artwork).
+    const key = `${variant}-${vid}`;
+    if (!this.icons.atons[key]) {
+      this.buildIcon(this.icons.atons, defs, vid, false, key);
+    }
+    const fallback = `${variant}-aton`;
+    if (!this.icons.atons[fallback]) {
+      this.buildIcon(this.icons.atons, defs, 'aton', false, fallback);
+    }
+    return this.icons.atons[key] ?? this.icons.atons[fallback];
   }
 
   /**
@@ -91,6 +107,11 @@ export class MapImageRegistry {
       });
     } else {
       const vid = AIS_TYPE_IDS[id];
+      // External symbol override keyed by the vessel icon id (e.g. "ais_cargo").
+      const ext = this.getExternalSymbol(vid);
+      if (ext) {
+        return ext;
+      }
       if (!this.icons.vessels[vid]) {
         this.buildIcon(this.icons.vessels, this.vesselImageDefs, vid, true);
       }
@@ -99,33 +120,102 @@ export class MapImageRegistry {
   }
 
   /**
-   * @description Returns image for the supplied Point of Interest identifier
-   * @param id Point of Interest identifier
-   * @returns Icon object
+   * Register an external symbol as a map-marker definition.
+   * Called by SymbolService after load(). ref is the canonical "namespace:id".
    */
-  getPOI(id: string): Icon {
-    id = id ?? 'default';
-    if (!this.icons.poi[id]) {
-      this.buildIcon(this.icons.poi, this.poiImageDefs, id);
+  registerSymbolMarker(ref: string, def: MapIconDef): void {
+    this.symbolDefs[ref] = def;
+    // Also register under the bare local id for unqualified skIcon lookups.
+    // External-first: first namespace registered for a given local id wins.
+    const colonIdx = ref.indexOf(':');
+    if (colonIdx !== -1) {
+      const localId = ref.slice(colonIdx + 1);
+      if (!(localId in this.symbolDefs)) {
+        this.symbolDefs[localId] = def;
+      }
     }
-    return this.icons.poi[id] ?? this.icons.poi.default;
   }
 
   /**
-   * @description Returns image for the supplied Waypoint type
+   * @description Returns image for the supplied symbol/POI identifier.
+   * Checks external symbol defs (namespace:id or bare local id) before falling
+   * back to built-in POI icons.
+   * @param id Symbol identifier — may be a qualified "namespace:id" external ref
+   *           or a bare built-in POI name.
+   * @returns Icon object
+   */
+  getSymbol(id: string): Icon {
+    id = id ?? 'default';
+    if (id.startsWith('default:')) {
+      // Forced built-in: strip the reserved prefix and skip override lookup.
+      id = id.slice('default:'.length);
+    } else if (id in this.symbolDefs) {
+      // External override (qualified or unqualified external ref).
+      if (!this.icons.symbols[id]) {
+        this.buildIcon(this.icons.symbols, this.symbolDefs, id);
+      }
+      return this.icons.symbols[id] ?? this.icons.poi['default'];
+    }
+    if (!this.icons.poi[id]) {
+      this.buildIcon(this.icons.poi, this.poiImageDefs, id);
+    }
+    return this.icons.poi[id] ?? this.icons.poi['default'];
+  }
+
+  /** @deprecated Use getSymbol() instead. */
+  getPOI(id: string): Icon {
+    return this.getSymbol(id);
+  }
+
+  /**
+   * @description Returns an Icon for an external symbol override registered
+   * for the supplied id, or null if none is registered.
+   * Unlike getSymbol(), this does NOT fall back to a built-in icon. Callers
+   * use it to decide whether to apply a symbol override or keep their own
+   * default rendering (e.g. programmatically-drawn shapes).
+   * @param id Symbol identifier (qualified "namespace:id" or bare local id).
+   * @returns Icon object or null
+   */
+  getExternalSymbol(id: string): Icon | null {
+    if (!id || !(id in this.symbolDefs)) {
+      return null;
+    }
+    if (!this.icons.symbols[id]) {
+      this.buildIcon(this.icons.symbols, this.symbolDefs, id);
+    }
+    return this.icons.symbols[id] ?? null;
+  }
+
+  /**
+   * @description Returns image for the supplied Waypoint type.
+   * Only the 'waypoint' type resolves external symbol overrides; other types
+   * (start-pin, pseudoaton, …) always render their built-in icon. A "default:"
+   * prefixed skIcon forces the built-in even when an override exists.
    * @param type Waypoint type
+   * @param skIcon Optional skIcon override — may be "namespace:id" or "default:id".
    * @returns Icon object
    */
   getWaypoint(type: string, skIcon?: string): Icon {
     type = !type ? 'default' : type;
-    const wid = skIcon ?? type;
+    let wid = skIcon ?? type;
+    if (type === 'waypoint') {
+      if (wid.startsWith('default:')) {
+        // Forced built-in: strip the reserved prefix and skip override lookup.
+        wid = wid.slice('default:'.length);
+      } else if (wid in this.symbolDefs) {
+        if (!this.icons.symbols[wid]) {
+          this.buildIcon(this.icons.symbols, this.symbolDefs, wid);
+        }
+        return this.icons.symbols[wid] ?? this.icons.waypoints['default'];
+      }
+    }
     if (!this.icons.waypoints[wid]) {
       this.buildIcon(this.icons.waypoints, this.waypointImageDefs, wid);
     }
     return (
       this.icons.waypoints[wid] ??
       this.icons.waypoints[type] ??
-      this.icons.waypoints.default
+      this.icons.waypoints['default']
     );
   }
 
@@ -141,10 +231,11 @@ export class MapImageRegistry {
     group: MapImageCollection,
     iconDef: { [id: string]: any },
     id: number | string,
-    rotate: boolean = false
+    rotate: boolean = false,
+    cacheKey: number | string = id
   ) {
     if (!iconDef[id]) return;
-    group[id] = new Icon({
+    group[cacheKey] = new Icon({
       src: iconDef[id].path,
       scale: iconDef[id].scale,
       anchor: iconDef[id].anchor,

--- a/src/app/modules/map/ol/lib/map-image-registry.service.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.ts
@@ -124,16 +124,10 @@ export class MapImageRegistry {
    * Called by SymbolService after load(). ref is the canonical "namespace:id".
    */
   registerSymbolMarker(ref: string, def: MapIconDef): void {
+    // Register exactly the supplied key. SymbolService registers both the
+    // qualified ref and (for fsk overrides only) the bare built-in id, so a
+    // bare lookup resolves to an override but not to an arbitrary custom symbol.
     this.symbolDefs[ref] = def;
-    // Also register under the bare local id for unqualified skIcon lookups.
-    // External-first: first namespace registered for a given local id wins.
-    const colonIdx = ref.indexOf(':');
-    if (colonIdx !== -1) {
-      const localId = ref.slice(colonIdx + 1);
-      if (!(localId in this.symbolDefs)) {
-        this.symbolDefs[localId] = def;
-      }
-    }
   }
 
   /**

--- a/src/app/modules/map/ol/lib/map-image-registry.service.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.ts
@@ -32,16 +32,19 @@ export interface MapIconDef {
   providedIn: 'root'
 })
 export class MapImageRegistry {
+  // Null-prototype caches so a resource-supplied id (e.g. a note skIcon of
+  // 'toString' or '__proto__') cannot collide with inherited Object keys on
+  // lookup or pollute the prototype on assignment.
   private icons: MapImages = {
-    atons: {},
-    poi: {},
-    vessels: {},
-    waypoints: {},
-    symbols: {}
+    atons: Object.create(null),
+    poi: Object.create(null),
+    vessels: Object.create(null),
+    waypoints: Object.create(null),
+    symbols: Object.create(null)
   };
 
   /** Definitions for external symbols registered by SymbolService. */
-  private symbolDefs: { [ref: string]: MapIconDef } = {};
+  private symbolDefs: { [ref: string]: MapIconDef } = Object.create(null);
 
   private atonImageDefs: any = {
     virtual: {},
@@ -143,7 +146,7 @@ export class MapImageRegistry {
     if (id.startsWith('default:')) {
       // Forced built-in: strip the reserved prefix and skip override lookup.
       id = id.slice('default:'.length);
-    } else if (id in this.symbolDefs) {
+    } else if (Object.hasOwn(this.symbolDefs, id)) {
       // External override (qualified or unqualified external ref).
       if (!this.icons.symbols[id]) {
         this.buildIcon(this.icons.symbols, this.symbolDefs, id);
@@ -152,6 +155,9 @@ export class MapImageRegistry {
     }
     if (!this.icons.poi[id]) {
       this.buildIcon(this.icons.poi, this.poiImageDefs, id);
+    }
+    if (!this.icons.poi['default']) {
+      this.buildIcon(this.icons.poi, this.poiImageDefs, 'default');
     }
     return this.icons.poi[id] ?? this.icons.poi['default'];
   }
@@ -171,7 +177,7 @@ export class MapImageRegistry {
    * @returns Icon object or null
    */
   getExternalSymbol(id: string): Icon | null {
-    if (!id || !(id in this.symbolDefs)) {
+    if (!id || !Object.hasOwn(this.symbolDefs, id)) {
       return null;
     }
     if (!this.icons.symbols[id]) {
@@ -196,7 +202,7 @@ export class MapImageRegistry {
       if (wid.startsWith('default:')) {
         // Forced built-in: strip the reserved prefix and skip override lookup.
         wid = wid.slice('default:'.length);
-      } else if (wid in this.symbolDefs) {
+      } else if (Object.hasOwn(this.symbolDefs, wid)) {
         if (!this.icons.symbols[wid]) {
           this.buildIcon(this.icons.symbols, this.symbolDefs, wid);
         }
@@ -205,6 +211,12 @@ export class MapImageRegistry {
     }
     if (!this.icons.waypoints[wid]) {
       this.buildIcon(this.icons.waypoints, this.waypointImageDefs, wid);
+    }
+    if (!this.icons.waypoints[type]) {
+      this.buildIcon(this.icons.waypoints, this.waypointImageDefs, type);
+    }
+    if (!this.icons.waypoints['default']) {
+      this.buildIcon(this.icons.waypoints, this.waypointImageDefs, 'default');
     }
     return (
       this.icons.waypoints[wid] ??
@@ -228,7 +240,7 @@ export class MapImageRegistry {
     rotate: boolean = false,
     cacheKey: number | string = id
   ) {
-    if (!iconDef[id]) return;
+    if (!Object.hasOwn(iconDef, id)) return;
     group[cacheKey] = new Icon({
       src: iconDef[id].path,
       scale: iconDef[id].scale,

--- a/src/app/modules/map/ol/lib/resources/layer-notes.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-notes.component.ts
@@ -72,7 +72,7 @@ export class FreeboardNoteLayerComponent extends FBFeatureLayerComponent {
 
   // build note feature style
   buildStyle(note: SKNote | NoteResource): Style {
-    const icon = this.mapImages.getPOI(note.properties.skIcon ?? 'default');
+    const icon = this.mapImages.getSymbol(note.properties.skIcon ?? 'default');
     if (icon) {
       return new Style({
         image: icon,

--- a/src/app/modules/map/ol/lib/resources/layer-notes.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-notes.component.ts
@@ -72,7 +72,7 @@ export class FreeboardNoteLayerComponent extends FBFeatureLayerComponent {
 
   // build note feature style
   buildStyle(note: SKNote | NoteResource): Style {
-    const icon = this.mapImages.getSymbol(note.properties.skIcon ?? 'default');
+    const icon = this.mapImages.getSymbol(note.properties?.skIcon ?? 'default');
     if (icon) {
       return new Style({
         image: icon,

--- a/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
@@ -15,6 +15,12 @@ import { getRhumbLineBearing } from 'geolib';
 import { GeolibInputCoordinates } from 'geolib/es/types';
 import { FBFeatureLayerComponent } from '../sk-feature.component';
 import { FBRoutes } from 'src/app/types';
+import { MapImageRegistry } from '../map-image-registry.service';
+
+/** Symbol ids used to override the default route marker shapes. */
+export const ROUTE_MARKER_START = 'route-start';
+export const ROUTE_MARKER_WAYPOINT = 'route-waypoint';
+export const ROUTE_MARKER_END = 'route-end';
 
 // ** Freeboard resource collection format **
 @Component({
@@ -30,7 +36,8 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
 
   constructor(
     protected override mapComponent: MapComponent,
-    protected override changeDetectorRef: ChangeDetectorRef
+    protected override changeDetectorRef: ChangeDetectorRef,
+    protected mapImages: MapImageRegistry
   ) {
     super(mapComponent, changeDetectorRef);
   }
@@ -115,6 +122,15 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
       });
     }
 
+    // External symbol overrides (null when no provider symbol is registered).
+    // When present, an external symbol replaces the default drawn shape.
+    // Note: external symbols do not inherit the route line colour. The waypoint
+    // symbol is cloned per-segment and rotated to the bearing; start/end symbols
+    // render upright.
+    const startSym = this.mapImages.getExternalSymbol(ROUTE_MARKER_START);
+    const wptSym = this.mapImages.getExternalSymbol(ROUTE_MARKER_WAYPOINT);
+    const endSym = this.mapImages.getExternalSymbol(ROUTE_MARKER_END);
+
     // point styles
     let idx = 0;
     const l = geometry.getCoordinates().length;
@@ -124,18 +140,36 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
         styles.push(
           new Style({
             geometry: new Point(start),
-            image: new Circle({
-              radius: 5,
-              stroke: new Stroke({
-                width: 1,
-                color: 'white'
-              }),
-              fill: ptFill
-            })
+            image:
+              startSym ??
+              new Circle({
+                radius: 5,
+                stroke: new Stroke({
+                  width: 1,
+                  color: 'white'
+                }),
+                fill: ptFill
+              })
           })
         );
       } else {
-        if (isActive) {
+        if (wptSym) {
+          // Clone the cached icon so each segment can carry its own bearing
+          // rotation without mutating the shared instance.
+          const d = getRhumbLineBearing(
+            toLonLat(start) as GeolibInputCoordinates,
+            toLonLat(end) as GeolibInputCoordinates
+          );
+          const img = wptSym.clone();
+          img.setRotation((d * Math.PI) / 180);
+          img.setRotateWithView(true);
+          styles.push(
+            new Style({
+              geometry: new Point(start),
+              image: img
+            })
+          );
+        } else if (isActive) {
           styles.push(
             new Style({
               geometry: new Point(start),
@@ -179,16 +213,18 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
         styles.push(
           new Style({
             geometry: new Point(end),
-            image: new RegularShape({
-              radius: 6,
-              stroke: new Stroke({
-                width: 1,
-                color: 'white'
-              }),
-              fill: ptFill,
-              points: 4,
-              angle: Math.PI / 4
-            })
+            image:
+              endSym ??
+              new RegularShape({
+                radius: 6,
+                stroke: new Stroke({
+                  width: 1,
+                  color: 'white'
+                }),
+                fill: ptFill,
+                points: 4,
+                angle: Math.PI / 4
+              })
           })
         );
       }

--- a/src/app/modules/map/ol/lib/resources/layer-waypoints.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-waypoints.component.ts
@@ -79,7 +79,7 @@ export class FreeboardWaypointLayerComponent extends FBFeatureLayerComponent {
   // build waypoint style
   buildStyle(id: string, wpt: SKWaypoint): Style {
     const icon = this.mapImages.getWaypoint(
-      wpt.type ?? 'default',
+      wpt.type || 'waypoint',
       wpt.feature.properties?.skIcon
     );
     if (icon && typeof this.waypointStyles === 'undefined') {

--- a/src/app/modules/map/ol/lib/sk-feature.component.ts
+++ b/src/app/modules/map/ol/lib/sk-feature.component.ts
@@ -214,6 +214,9 @@ export class FBFeatureLayerComponent implements OnInit, OnDestroy, OnChanges {
     const im = style.getImage();
     if (im) {
       im.setRotation(value ?? 0);
+      // Ensure orientation markers (incl. external symbol overrides, which are
+      // built with rotateWithView=false) rotate with the map view like built-ins.
+      im.setRotateWithView(true);
       style.setImage(im);
     }
     return style;

--- a/src/app/modules/map/ol/lib/vessel/layer-vessel.component.ts
+++ b/src/app/modules/map/ol/lib/vessel/layer-vessel.component.ts
@@ -20,6 +20,10 @@ import { MapComponent } from '../map.component';
 import { Extent, Coordinate } from '../models';
 import { AsyncSubject } from 'rxjs';
 import { Options } from 'ol/style/Icon';
+import { MapImageRegistry } from '../map-image-registry.service';
+
+/** Symbol id used to override the own-vessel marker. */
+export const VESSEL_SELF_MARKER = 'vessel-self';
 
 const vesselIconDef = {
   src: './assets/img/vessels/self.png',
@@ -94,7 +98,8 @@ export class VesselComponent implements OnInit, OnDestroy, OnChanges {
 
   constructor(
     protected changeDetectorRef: ChangeDetectorRef,
-    protected mapComponent: MapComponent
+    protected mapComponent: MapComponent,
+    protected mapImages: MapImageRegistry
   ) {
     this.changeDetectorRef.detach();
   }
@@ -197,9 +202,18 @@ export class VesselComponent implements OnInit, OnDestroy, OnChanges {
     if (this.iconScale) {
       vesselIconDef.scale = Math.abs(this.iconScale);
     }
-    this.selfStyle = new Style({
-      image: new Icon(vesselIconDef as Options)
-    });
+    // External symbol override for the own-vessel marker. Clone the cached icon
+    // so per-render heading rotation does not mutate the shared instance.
+    const ext = this.mapImages.getExternalSymbol(VESSEL_SELF_MARKER);
+    if (ext) {
+      const img = ext.clone();
+      img.setRotateWithView(true);
+      this.selfStyle = new Style({ image: img });
+    } else {
+      this.selfStyle = new Style({
+        image: new Icon(vesselIconDef as Options)
+      });
+    }
   }
 
   // build target style

--- a/src/app/modules/map/ol/lib/vessel/layer-vessel.component.ts
+++ b/src/app/modules/map/ol/lib/vessel/layer-vessel.component.ts
@@ -208,6 +208,9 @@ export class VesselComponent implements OnInit, OnDestroy, OnChanges {
     if (ext) {
       const img = ext.clone();
       img.setRotateWithView(true);
+      if (this.iconScale) {
+        img.setScale(Math.abs(this.iconScale));
+      }
       this.selfStyle = new Style({ image: img });
     } else {
       this.selfStyle = new Style({

--- a/src/app/modules/skresources/components/notes/note-dialog.html
+++ b/src/app/modules/skresources/components/notes/note-dialog.html
@@ -240,6 +240,15 @@
                 }
               </mat-select>
             </mat-form-field>
+            <mat-slide-toggle
+              labelPosition="before"
+              [hideIcon]="true"
+              [checked]="showAllIcons()"
+              (change)="onShowAllToggle($event.checked)"
+              style="font-size: 10pt; margin-left: 8px; vertical-align: middle;"
+            >
+              Show all symbols
+            </mat-slide-toggle>
           </div>
           <div style="padding-left: 10px">
             <mat-form-field style="width: 145px">

--- a/src/app/modules/skresources/components/notes/note-dialog.ts
+++ b/src/app/modules/skresources/components/notes/note-dialog.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CoordsPipe } from 'src/app/lib/pipes';
 import { MatButtonModule } from '@angular/material/button';
@@ -27,6 +27,7 @@ import { AppFacade } from 'src/app/app.facade';
 import {
   AppIconDef,
   getResourceIcon,
+  persistSkIcon,
   selListNoteIcons
 } from 'src/app/modules/icons';
 import { SKNote } from '../../resource-classes';
@@ -123,6 +124,7 @@ export class NoteDialog implements OnInit {
 
   protected icon: AppIconDef;
   protected poiIcons: Array<{ id: string; name: string }> = [];
+  protected showAllIcons = signal(false);
   protected data = inject<DialogData>(MAT_DIALOG_DATA);
   protected app = inject(AppFacade);
   protected dialogRef = inject(MatDialogRef<NoteDialog>);
@@ -140,7 +142,19 @@ export class NoteDialog implements OnInit {
       this.data.editable = false;
     }
     this.icon = this.cleanIconDef(getResourceIcon('notes', this.data.note));
-    this.poiIcons = selListNoteIcons();
+    this.poiIcons = selListNoteIcons(this.showAllIcons());
+    // If the current icon isn't visible in the merged list (a 'default:' pin or
+    // a non-note-role symbol, shown only under "Show all"), start with it on.
+    const sel = this.icon.svgIcon;
+    if (sel && !this.poiIcons.some((i) => i.id === sel)) {
+      this.showAllIcons.set(true);
+      this.poiIcons = selListNoteIcons(true);
+    }
+  }
+
+  onShowAllToggle(checked: boolean) {
+    this.showAllIcons.set(checked);
+    this.poiIcons = selListNoteIcons(checked);
   }
 
   cleanIconDef(icon: AppIconDef) {
@@ -150,7 +164,9 @@ export class NoteDialog implements OnInit {
 
   onIconSelected(e: string) {
     if (e.length) {
-      this.data.note.properties.skIcon = e;
+      // Pin to default:<id> when a bare built-in id has an override, so a future
+      // custom version won't silently replace an explicit built-in choice.
+      this.data.note.properties.skIcon = persistSkIcon(e);
     } else {
       delete this.data.note.properties.skIcon;
     }

--- a/src/app/modules/skresources/components/notes/notelist.html
+++ b/src/app/modules/skresources/components/notes/notelist.html
@@ -79,7 +79,9 @@
             <div style="flex: 1 1 auto; width: 215px; display: flex">
               <div>
                 @if(r[1].properties?.skIcon) {
-                <mat-icon [svgIcon]="r[1].properties?.skIcon"></mat-icon>
+                <mat-icon
+                  [svgIcon]="r[1].properties?.skIcon | resolveSkIcon"
+                ></mat-icon>
                 } @else {
                 <mat-icon class="icon-note icon-accent">local_offer</mat-icon>
                 }

--- a/src/app/modules/skresources/components/notes/notelist.ts
+++ b/src/app/modules/skresources/components/notes/notelist.ts
@@ -20,6 +20,7 @@ import { AppFacade } from 'src/app/app.facade';
 import { Position } from 'src/app/types';
 import { FBNotes, FBNote, FBResourceSelect, SKPosition } from 'src/app/types';
 import { SKResourceService } from '../../resources.service';
+import { ResolveSkIconPipe } from 'src/app/modules/icons';
 
 @Component({
   selector: 'note-list',
@@ -35,7 +36,8 @@ import { SKResourceService } from '../../resources.service';
     MatButtonModule,
     FormsModule,
     MatInputModule,
-    ScrollingModule
+    ScrollingModule,
+    ResolveSkIconPipe
   ]
 })
 export class NoteListComponent {

--- a/src/app/modules/skresources/components/notes/relatednotes-dialog.html
+++ b/src/app/modules/skresources/components/notes/relatednotes-dialog.html
@@ -42,7 +42,7 @@
           <mat-card-title-group>
             <mat-card-title>{{n[1].name}}</mat-card-title>
             @if(n[1].properties?.skIcon) {
-            <mat-icon [svgIcon]="n[1].properties?.skIcon"></mat-icon>
+            <mat-icon [svgIcon]="n[1].properties?.skIcon | resolveSkIcon"></mat-icon>
             } @else {
             <mat-icon class="icon-accent">local_offer</mat-icon>
             }

--- a/src/app/modules/skresources/components/notes/relatednotes-dialog.ts
+++ b/src/app/modules/skresources/components/notes/relatednotes-dialog.ts
@@ -18,6 +18,7 @@ import { AddTargetPipe } from './safe.pipe';
 
 import { AppFacade } from 'src/app/app.facade';
 import { SKNote } from '../../resource-classes';
+import { ResolveSkIconPipe } from 'src/app/modules/icons';
 
 interface DialogData {
   notes: SKNote[];
@@ -38,7 +39,8 @@ interface DialogData {
     MatInputModule,
     MatToolbarModule,
     AddTargetPipe,
-    RemarkModule
+    RemarkModule,
+    ResolveSkIconPipe
   ],
   templateUrl: `relatednotes-dialog.html`,
   styleUrls: ['notes.css']

--- a/src/app/modules/skresources/components/waypoints/waypoint-dialog.ts
+++ b/src/app/modules/skresources/components/waypoints/waypoint-dialog.ts
@@ -16,6 +16,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import {
   MatDialogModule,
   MatDialogRef,
@@ -29,6 +30,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   AppIconDef,
   getResourceIcon,
+  persistSkIcon,
   selListWaypointIcons
 } from 'src/app/modules/icons';
 
@@ -54,7 +56,8 @@ interface DialogData {
     CoordsPipe,
     ReactiveFormsModule,
     MatTooltip,
-    MatChipsModule
+    MatChipsModule,
+    MatSlideToggleModule
   ],
   template: `
     <div class="_ap-waypoint">
@@ -167,21 +170,34 @@ interface DialogData {
             <div style="font-size: 10pt;display:flex;flex-wrap:wrap">
               <div>
                 <div>
-                  <mat-chip-listbox
-                    selectable
-                    (change)="handleWptTypeChange($event.value)"
-                  >
-                    @for (i of iconTypeSelection; track i) {
-                      <mat-chip-option
-                        [value]="i.id"
-                        [selected]="wptType === i.id"
+                  <div style="display:flex;align-items:center;flex-wrap:wrap;gap:4px;">
+                    <mat-chip-listbox
+                      selectable
+                      (change)="handleWptTypeChange($event.value)"
+                    >
+                      @for (i of iconTypeSelection; track i) {
+                        <mat-chip-option
+                          [value]="i.id"
+                          [selected]="wptType === i.id"
+                        >
+                          {{ i.group }}
+                        </mat-chip-option>
+                      }
+                    </mat-chip-listbox>
+                    @if (wptType === 'waypoint') {
+                      <mat-slide-toggle
+                        labelPosition="before"
+                        [hideIcon]="true"
+                        [checked]="showAllIcons()"
+                        (change)="onShowAllToggle($event.checked)"
+                        style="font-size:10pt;margin-left:4px;"
                       >
-                        {{ i.group }}
-                      </mat-chip-option>
+                        Show all symbols
+                      </mat-slide-toggle>
                     }
-                  </mat-chip-listbox>
+                  </div>
                   <div
-                    style="display:flex;flex-wrap:wrap;padding-bottom:10px;height:40px;"
+                    style="display:flex;flex-wrap:wrap;padding-bottom:10px;height:64px;overflow-y:auto;"
                   >
                     @for (i of iconsForSelection(); track i) {
                       <div
@@ -267,23 +283,35 @@ export class WaypointDialog {
   >;
   protected iconTypeSelection: Array<{ id: string; group: string }> = [];
   protected iconsForSelection = signal<AppIconDef[]>([]);
+  protected showAllIcons = signal(false);
 
   constructor() {
     this.dialogIcon = this.data.addMode ? 'add_location' : 'edit_location';
 
     // initialise waypoint icons and selections
-    this.wptOptions = selListWaypointIcons(); // waypoint selection options
+    this.rebuildIconOptions(false);
     const typeKeys = Object.keys(this.wptOptions);
     this.wptType = !typeKeys.includes(this.data.waypoint.type)
       ? 'waypoint'
       : this.data.waypoint.type;
 
-    this.iconTypeSelection = Object.entries(this.wptOptions).map((i) => {
-      return { id: i[0], group: i[1].group };
-    });
-    this.iconsForSelection.set(this.wptOptions[this.wptType].icons);
-
     this.wptIcon.update(() => this.getIconDef(this.data.waypoint));
+
+    // If the current icon isn't visible in the merged Waypoints list (e.g. a
+    // 'default:' pin or a non-waypoint-role symbol, both shown only under
+    // "Show all symbols"), start with the slider on so the selection is shown.
+    if (this.wptType === 'waypoint') {
+      const sel = this.wptIcon().svgIcon;
+      const visible = this.wptOptions['waypoint'].icons.some(
+        (i) => i.svgIcon === sel
+      );
+      if (sel && !visible) {
+        this.showAllIcons.set(true);
+        this.rebuildIconOptions(true);
+      }
+    }
+
+    this.iconsForSelection.set(this.wptOptions[this.wptType]?.icons ?? this.wptOptions['waypoint'].icons);
     this.wptDescription = this.data.waypoint.description ?? '';
     this.wptReadOnly = this.data.waypoint.feature.properties?.readOnly ?? false;
     const coords = this.data.waypoint.feature.geometry.coordinates ?? [0, 0];
@@ -331,7 +359,13 @@ export class WaypointDialog {
         this.inpLon.value,
         this.inpLat.value
       ];
-      this.data.waypoint.feature.properties.skIcon = this.wptIcon().svgIcon;
+      // Only the 'waypoint' category participates in symbol overrides, so only
+      // it gets the bare-vs-default: persistence treatment. Other categories
+      // (start-pin, …) save their icon id verbatim.
+      this.data.waypoint.feature.properties.skIcon =
+        this.wptType === 'waypoint'
+          ? persistSkIcon(this.wptIcon().svgIcon)
+          : this.wptIcon().svgIcon;
     }
     this.dialogRef.close({ save: save, waypoint: this.data.waypoint });
   }
@@ -339,6 +373,22 @@ export class WaypointDialog {
   /** return the waypoint icon definition */
   private getIconDef(wpt?: SKWaypoint): AppIconDef {
     return getResourceIcon('waypoints', wpt ?? this.data.waypoint);
+  }
+
+  protected onShowAllToggle(checked: boolean) {
+    this.showAllIcons.set(checked);
+    this.rebuildIconOptions(checked);
+    // Stay on the current category (only the Waypoints chip shows the toggle).
+    const currentGroup = this.wptOptions[this.wptType] ? this.wptType : 'waypoint';
+    this.iconsForSelection.set(this.wptOptions[currentGroup].icons);
+  }
+
+  private rebuildIconOptions(showAll: boolean) {
+    this.wptOptions = selListWaypointIcons(showAll);
+    this.iconTypeSelection = Object.entries(this.wptOptions).map((i) => ({
+      id: i[0],
+      group: i[1].group
+    }));
   }
 
   protected handleWptTypeChange(value: string) {

--- a/src/app/types/symbols.ts
+++ b/src/app/types/symbols.ts
@@ -1,0 +1,36 @@
+export const SYMBOL_RESOURCE_TYPE = 'symbols' as const;
+
+export type SymbolRole =
+  | 'note'
+  | 'waypoint'
+  | 'region'
+  | 'button'
+  | 'alert'
+  | 'logbook'
+  | 'map-marker'
+  | 'vector-style-icon'
+  | string;
+
+export interface SymbolDefinition {
+  id: string;
+  namespace: string;
+  name: string;
+  description?: string;
+  mediaType: 'image/svg+xml';
+  url: string;
+  roles?: SymbolRole[];
+  tags?: string[];
+  scale?: number;
+  anchor?: [number, number];
+  /** Mapping to a GPX waypoint `<type>` value (GPX import/export). */
+  gpxType?: string;
+  /** Mapping to a GPX waypoint `<sym>` value (GPX import/export). */
+  gpxSym?: string;
+}
+
+export interface SymbolResource extends SymbolDefinition {
+  $source?: string;
+  timestamp?: string;
+}
+
+export type SymbolReference = string; // "namespace:id"

--- a/src/app/types/symbols.ts
+++ b/src/app/types/symbols.ts
@@ -12,8 +12,10 @@ export type SymbolRole =
   | string;
 
 export interface SymbolDefinition {
-  id: string;
-  namespace: string;
+  /** Immutable symbol identifier. */
+  uuid: string;
+  /** One or more canonical "namespace:id" references. */
+  alias: string[];
   name: string;
   description?: string;
   mediaType: 'image/svg+xml';

--- a/src/assets/img/no-such-symbol.svg
+++ b/src/assets/img/no-such-symbol.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <circle cx="24" cy="24" r="22" fill="#e57373" stroke="#c62828" stroke-width="2"/>
+  <text x="24" y="33" text-anchor="middle" font-family="sans-serif" font-size="28" font-weight="bold" fill="white">?</text>
+</svg>


### PR DESCRIPTION
# Add support for custom map symbols in Freeboard-SK

## Summary

This change lets Freeboard-SK display **custom map symbols** supplied by a Signal
K server, in place of or in addition to its built-in icons. Boaters can give
notes, waypoints, vessels, aids to navigation, and route markers their own
artwork - a custom marker for a waypoint or chart note that is personally meaningful to the user,
a custom boat icon for their own vessel, branded buoys, and so on - without rebuilding Freeboard.

Custom symbols are discovered from the server at startup, offered in the note and
waypoint icon pickers, and rendered on the chart. The change also adds symbol
awareness to **GPX import and export** so symbols survive a round trip through
GPX files.

## Requirements

Custom symbols require a **symbol provider plugin** installed on the Signal K
server. Freeboard consumes whatever symbols the server publishes; it does not
create or store them itself. With no provider installed, Freeboard behaves
exactly as before, using only its built-in icons.

The reference symbol provider is [signalk-symbol-manager](https://www.npmjs.com/package/signalk-symbol-manager), which lets you
upload, edit, and organize symbols through its own web app. Any plugin that
publishes symbols in the standard way will work.

## How overriding works

In addition to adding entirely new note and waypoint markers to Freeport, the user can now 
replace an existing marker icon with one of their own liking by "overriding" it.

Each symbol has a short **id** (for example `dive-site`) and belongs to a
**namespace** (for example your personal `custom` namespace), giving every symbol a
unique name like `custom:dive-site`.

There are two ways a symbol takes effect:

1. **Replace a built-in by name.** Create a symbol whose id matches one of
   Freeboard's built-in icons (for example `dive-site`) ***AND*** has the namespace `fsk:`.
   Freeboard then shows your version everywhere that icon is used — on the chart and in the
   pickers — automatically. You don't have to re-edit existing notes or
   waypoints; anything that already used that built-in picks up your version.

2. **Add a brand-new symbol.** Create a symbol with the namespace `custom` and
   a new id and it appears as an additional choice in the icon pickers (subject to its declared usage — see
   below).

When a custom version of a built-in exists, the pickers show **your version in
place of the built-in**, so you see one entry, not two. A **"Show all symbols"**
toggle reveals everything at once — every custom symbol plus the original
built-ins — so you can still choose the original built-in even after you've
created a custom replacement. If you explicitly pick the built-in this way,
Freeboard remembers that choice and won't silently swap in a custom version
later.

Symbols can advertise which contexts they're meant for (for example "note" or
"waypoint"). Freeboard uses that to keep each picker tidy — the note picker
offers note symbols, the waypoint picker offers waypoint symbols — while "Show
all symbols" ignores the filter and offers everything.

## Where custom symbols can be used

| Area | Custom symbols? |
|------|-----------------|
| Note markers | Yes |
| Waypoint markers (the **Waypoints** category) | Yes |
| Own vessel | Yes |
| AIS vessels | Yes |
| Aids to Navigation (AtoNs) | Yes |
| Route start / turn / end markers | Yes |
| Specialized waypoint types (start pin, start boat, sightings, alarms, pseudo-AtoN) | No — keep their built-in icons |
| Region area shading | No |
| Moored-vessel dots | No |

Markers that rotate to a heading or bearing (vessels, AtoNs, route turn markers,
your own vessel) keep rotating correctly when shown with a custom symbol.

## Overridable built-in symbols and their ids

To replace a built-in, create a custom symbol using the namespace `fsk:` and and id
that matches on of FSK's built in icon Ids:

**Note / waypoint icons** (used for notes and as waypoint icons):

```
anchorage   boatramp   bridge      business    dam
dive-site   ferry      hazard      inlet       lock
marina      dock       turning-basin           radio-call-point
transhipment-dock      notice-to-mariners      diver-down
navigation-structure   fuel        tunnel      waterway-guage
```

**Generic waypoint marker:** `waypoint`

**Own vessel:** `vessel-self`

**AIS vessel icons** (by ship class / state):

```
ais_active   ais_highspeed   ais_special   ais_passenger   ais_cargo
ais_tanker   ais_other       ais_inactive  ais_buddy       ais_self
```

(`ais_self` is the *focused* AIS target, not your own boat — that is
`vessel-self`.)

**Aids to Navigation** — each exists as a *real* (physical) and *virtual*
(AIS-only) form, named `real-…` and `virtual-…`:

```
real-north / virtual-north            real-east / virtual-east
real-south / virtual-south            real-west / virtual-west
real-port / virtual-port              real-starboard / virtual-starboard
real-danger / virtual-danger          real-safe / virtual-safe
real-special / virtual-special        real-basestation / virtual-basestation
real-weatherStation / virtual-weatherStation
real-aton / virtual-aton
```

**Route markers:**

```
route-start      route-waypoint      route-end
```

The route markers and the own-vessel, AIS, and AtoN icons are chosen
automatically by Freeboard rather than picked per feature, so they are overridden
globally: create a symbol with the matching id and every marker of that kind uses
it.

## GPX import and export

Symbols can declare the GPX symbol name (the GPX `<sym>` element) and GPX type
(the GPX `<type>` element) they correspond to. Freeboard uses these to preserve
symbol choices across GPX files.

**Import.** For each waypoint in an imported GPX file that carries a symbol name
(`<sym>`), Freeboard tries to match it to one of your symbols, in order:

1. the symbol whose declared GPX symbol name matches the file's `<sym>`; failing
   that,
2. the symbol whose id matches the file's `<sym>`.

If either matches, that symbol becomes the imported waypoint's icon. If neither
matches, the waypoint gets the default waypoint marker, as before. Matching is
exact and case-sensitive, and uses only the `<sym>` value.

**Export.** When a waypoint that uses a custom symbol is exported to GPX,
Freeboard writes that symbol's declared GPX type and GPX symbol name into the
file's `<type>` and `<sym>` elements (whichever the symbol provides). Combined
with import, this lets a symbol survive a full round trip: export to GPX, re-import,
and the same symbol is restored.

## Behavior without a provider

If no symbol provider is installed, or the server publishes no symbols:

- All pickers and the chart use Freeboard's built-in icons, unchanged.
- The "Show all symbols" toggle simply shows the built-ins.
- GPX import falls back to default markers; GPX export writes whatever the
  waypoint already carried.

There is no configuration to enable — Freeboard uses custom symbols automatically
when they are available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added external symbol/icon resolution across the app, including dynamic rendering for routes, and improved support for vessel self markers.
  * Expanded note and waypoint icon pickers with a “Show all symbols” option to reveal additional selections.
  * GPX import/export now preserves and maps waypoint symbol/icon information more accurately.

* **Bug Fixes**
  * Symbol loading now happens before server data is displayed, reducing missing icons.
  * Improved icon fallback and override behavior for notes/waypoints/routes, including safer handling of unresolved symbols.
  * Improved map marker rotation so symbols stay aligned with the view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->