### PR TITLE
feat: Add plotter extension host: widgets, panels, buttons, resource filters & background runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ _Note: The `Signal K Instrument Panel` app will be displayed if no user selectio
 
 ---
 
+### Screen Widgets:
+
+If you have installed any plugins on your Signal K server that provide screen widgets, you can place them directly onto the chart screen.
+
+Widgets sit in the corners and at the centre of the top and bottom edges of the screen _(the top-left corner is reserved for Freeboard's own menu)_.
+
+![widgets](https://raw.githubusercontent.com/joelkoz/signalk-instrument-widgets/refs/heads/main/docs/screenshots/1_freeboard-widget.png)
+
+**To add a widget**, press and hold an empty spot in any of these areas for at least 1.5 seconds (or right-click if you are using a mouse and keyboard). A short list of the widgets that fit there appears — choose one and it is added to your screen. As you add more, widgets stack neatly from the edge inward.
+
+**To change or remove a widget** you have already placed, press and hold the widget itself for 1.5 seconds. This opens its settings, where you can adjust it (if it has any options) or remove it from the screen.
+
+Your layout is remembered, so the widgets you place are still there the next time you open Freeboard-SK.
+
+---
+
 ### S57 Charts
 
 Freeboard-SK is able to display S57 ENC charts that have been converted to vector tiles with [s57-tiler](https://github.com/wdantuma/s57-tiler). _(See the [README](https://github.com/wdantuma/s57-tiler) for instructions how to create the vector tiles from downloaded S57 ENC's.)_

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@signalk/server-api": "^2.24.0",
         "geolib": "^3.3.3",
         "google-protobuf": "^4.0.1",
+        "signalk-plotterext-bus": "^0.5.0",
         "tslib": "^2.0.0",
         "uuid": "^11.1.0"
       },
@@ -10684,6 +10685,12 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/signalk-plotterext-bus": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.5.0.tgz",
+      "integrity": "sha512-i3OsOScXsoE/r9zrqCoYc3bXmN9TtSHGPnEe1/wDW4mQz4awrPZBr3EcF3fTO00ntTZPi96O7PiSprjTGNNSxw==",
+      "license": "MIT"
     },
     "node_modules/sigstore": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@signalk/server-api": "^2.24.0",
     "geolib": "^3.3.3",
     "google-protobuf": "^4.0.1",
-    "signalk-plotterext-bus": "file:../signalk-plotterext-bus",
+    "signalk-plotterext-bus": "^0.5.0",
     "tslib": "^2.0.0",
     "uuid": "^11.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@signalk/server-api": "^2.24.0",
     "geolib": "^3.3.3",
     "google-protobuf": "^4.0.1",
+    "signalk-plotterext-bus": "file:../signalk-plotterext-bus",
     "tslib": "^2.0.0",
     "uuid": "^11.1.0"
   },

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -25,10 +25,18 @@ mat-nav-list {
 	bottom: 0;
     right: 0;
 	left: 0px;
-    overflow: auto;
+    overflow: hidden;
     scrollbar-width: none;
     position: fixed;
 	border-top: silver 0px solid;
+    /* row layout so an open plotter-extension panel pushes the map left */
+    display: flex;
+    flex-direction: row;
+}
+.view .pe-view-main {
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 100%;
 }
 
 .leftMenuPanel {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -275,7 +275,7 @@
 
     <!-- content -->
     <div class="view" theme-main>
-      <mat-sidenav-container hasBackdrop="false">
+      <mat-sidenav-container hasBackdrop="false" class="pe-view-main">
         <!--info-panel-->
         <mat-sidenav
           #sideright
@@ -715,7 +715,10 @@
             }
 
             <!-- Status Bar -->
-            <div class="statusBar">
+            <div
+              class="statusBar"
+              [style.top.px]="20 + plotterExt.toolbarTopOffset()"
+            >
               @if (!wakeLock.enabled() && wakeLock.isAvailable) {
                 <div class="statusBarItem">
                   <mat-icon
@@ -766,7 +769,10 @@
 
             <!-- right button bar -->
             <!-- show/hide  -->
-            <div class="rightTop buttonPanel">
+            <div
+              class="rightTop buttonPanel"
+              [style.top.px]="plotterExt.toolbarTopOffset()"
+            >
               <div class="buttonPanelItem">
                 <button
                   class="button-secondary"
@@ -786,7 +792,10 @@
               </div>
             </div>
             @if (app.uiConfig().toolbarButtons) {
-              <div class="buttonPanel right">
+              <div
+                class="buttonPanel right"
+                [style.top.px]="60 + plotterExt.toolbarTopOffset()"
+              >
                 <!-- instrument sidebar open button -->
                 <div class="instrumentPanelToggle buttonPanelItem">
                   @if (
@@ -966,6 +975,30 @@
                     <br />&nbsp;<br />
                   </div>
                 }
+
+                <!-- plotter extension buttons -->
+                @for (
+                  entry of plotterExt.toolbarButtons();
+                  track entry.extension + '/' + entry.button.id
+                ) {
+                  <div class="buttonPanelItem">
+                    <button
+                      class="button-toolbar"
+                      mat-mini-fab
+                      [matTooltip]="entry.button.title"
+                      matTooltipPosition="before"
+                      (click)="
+                        plotterExt.handleButtonAction(
+                          entry.extension,
+                          entry.button
+                        )
+                      "
+                    >
+                      <mat-icon>{{ entry.button.icon || 'extension' }}</mat-icon>
+                    </button>
+                    <br />&nbsp;<br />
+                  </div>
+                }
               </div>
             }
             <!-- /right button bar -->
@@ -1001,6 +1034,9 @@
             </fb-map>
           </div>
           <!--/map panel-->
+
+          <!-- Plotter extension widget overlay -->
+          <fb-plotterext-overlay></fb-plotterext-overlay>
 
           <!-- North Arrow -->
           <div style="position: absolute; top: 60px; left: 56px; width: 50px">
@@ -1220,6 +1256,12 @@
           }
         </mat-sidenav-content>
       </mat-sidenav-container>
+
+      <!-- Plotter extension panel drawer: pushes the display left when open -->
+      <fb-plotterext-panel-drawer></fb-plotterext-panel-drawer>
+
+      <!-- Plotter extension headless background runtimes (hidden iframes) -->
+      <fb-plotterext-runtimes></fb-plotterext-runtimes>
     </div>
     <!-- /content -->
   </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -104,6 +104,10 @@ import {
   SelectionResultDef
 } from './modules/map/fbmap-interact.service';
 import { RadarAPIService } from './modules/radar/radar-api.service';
+import { PlotterExtensionService } from './modules/plotterext/plotterext.service';
+import { PlotterExtensionOverlay } from './modules/plotterext/widget-overlay.component';
+import { PlotterBackgroundHost } from './modules/plotterext/background-runtime.component';
+import { PlotterPanelDrawer } from './modules/plotterext/panel-drawer.component';
 import {
   RoutePanel,
   SKResourceType,
@@ -165,7 +169,10 @@ interface DrawEndEvent {
     RegionPanel,
     WaypointPanel,
     RoutePanel,
-    RadarPanel
+    RadarPanel,
+    PlotterExtensionOverlay,
+    PlotterBackgroundHost,
+    PlotterPanelDrawer
   ]
 })
 export class AppComponent {
@@ -265,6 +272,7 @@ export class AppComponent {
   protected autopilot = inject(AutopilotService);
   protected radarApi = inject(RadarAPIService);
   private symbols = inject(SymbolService);
+  protected plotterExt = inject(PlotterExtensionService);
 
   constructor() {
     // set self to active vessel
@@ -299,6 +307,15 @@ export class AppComponent {
         if (this.sideright?.opened) {
           this.closeDrawer();
         }
+      }
+    });
+
+    // apply programmatic map move requests (e.g. from plotter extensions)
+    // through Freeboard's own centering path so chart layers refresh.
+    effect(() => {
+      const req = this.app.mapMoveRequest();
+      if (req) {
+        this.centerAndZoom(req.center, req.zoom);
       }
     });
   }
@@ -772,6 +789,9 @@ export class AppComponent {
             })
             .finally(() => {
               this.loadSymbolsThenFetchResources();
+              // after user config is final so persisted widget placements
+              // reflect the server-stored layout, not a stale local copy
+              this.plotterExt.init();
             });
           this.getFeatures();
           this.app.data.server = this.signalk.server.info;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1337,6 +1337,10 @@ export class AppComponent {
               this.app.loadUserConfigfromServer().then((loaded: boolean) => {
                 if (loaded) {
                   this.loadSymbolsThenFetchResources();
+                  // re-run plotter extension discovery now that we are
+                  // authenticated, so auth-gated extensions and the
+                  // server-stored widget layout appear without a page reload
+                  this.plotterExt.init();
                 }
               });
               if (onConnect) {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -301,6 +301,32 @@ export function cleanConfig(
     };
   }
 
+  if (typeof settings.plotterExtensions === 'undefined') {
+    settings.plotterExtensions = {
+      widgets: []
+    };
+  }
+  // migrate early plotterExtensions config shape
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (settings.plotterExtensions as any).enabled;
+  if (!Array.isArray(settings.plotterExtensions.widgets)) {
+    settings.plotterExtensions.widgets = [];
+  }
+  settings.plotterExtensions.widgets = settings.plotterExtensions.widgets
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((w: any) => {
+      // early builds used `corner` with a `tl` option
+      if (w.corner && !w.anchor) {
+        w.anchor = w.corner === 'tl' ? 'tr' : w.corner;
+        delete w.corner;
+      }
+      return w;
+    })
+    .filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (w: any) => ['tr', 'ct', 'cb', 'bl', 'br'].includes(w.anchor)
+    );
+
   if (typeof settings.radars === 'undefined') {
     settings.radars = {
       deviceId: '',
@@ -542,6 +568,9 @@ export function defaultConfig(): IAppConfig {
       opacity: 1
     },
     experiments: false,
+    plotterExtensions: {
+      widgets: []
+    },
     selections: {
       routes: [],
       waypoints: [],

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -301,7 +301,11 @@ export function cleanConfig(
     };
   }
 
-  if (typeof settings.plotterExtensions === 'undefined') {
+  if (
+    !settings.plotterExtensions ||
+    typeof settings.plotterExtensions !== 'object' ||
+    Array.isArray(settings.plotterExtensions)
+  ) {
     settings.plotterExtensions = {
       widgets: []
     };

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -253,6 +253,9 @@ export class AppFacade extends InfoService {
   mapViewTopCenter = signal<Position>([0, 0]); // top-centre of viewport (rotation-aware)
   mapViewRightCenter = signal<Position>([0, 0]); // right-centre of viewport (rotation-aware)
   mapViewRotation = signal<number>(0); // OL view rotation in radians (CCW positive)
+  // programmatic map move request (e.g. from a plotter extension). A new
+  // object reference each time so the consuming effect always reacts.
+  mapMoveRequest = signal<{ center: Position; zoom?: number } | null>(null);
 
   protected signalk = inject(SignalKClient);
   private worker = inject(SKWorkerService);

--- a/src/app/lib/components/mfb-container.component.ts
+++ b/src/app/lib/components/mfb-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, output } from '@angular/core';
+import { Component, computed, inject, input, output } from '@angular/core';
 
 import { AppFacade } from 'src/app/app.facade';
 import { MFBAction } from 'src/app/types';
@@ -7,6 +7,7 @@ import { WptButtonComponent } from './wpt-button.component';
 import { AutopilotButtonComponent } from './autopilot-button.component';
 import { RadarButtonComponent } from './radar-button.component';
 import { RadarAPIService } from 'src/app/modules/radar/radar-api.service';
+import { PlotterExtensionService } from 'src/app/modules/plotterext/plotterext.service';
 
 @Component({
   selector: 'mfb-container',
@@ -18,7 +19,7 @@ import { RadarAPIService } from 'src/app/modules/radar/radar-api.service';
     RadarButtonComponent
   ],
   template: `
-    <div class="mfb-container">
+    <div class="mfb-container" [style.bottom.px]="bottomOffset()">
       @if (action() === 'wpt') {
         <wpt-button
           [position]="app.data.vessels.self.position"
@@ -63,6 +64,13 @@ export class MFBContainerComponent {
 
   protected app = inject(AppFacade);
   protected radarApi = inject(RadarAPIService);
+  private plotterExt = inject(PlotterExtensionService);
+
+  // sit above any plotter-extension widgets in the bottom-right corner
+  protected bottomOffset = computed(() => {
+    const lift = this.plotterExt.actionButtonLift();
+    return lift > 0 ? lift : 23;
+  });
 
   constructor() {}
 }

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -94,7 +94,14 @@
   <!-- Cursor position control -->
   <ol-control>
     <ol-content>
-      <div class="ol-mouse-position">
+      <div
+        class="ol-mouse-position"
+        [style.bottom]="
+          plotterExt.statusBarLift() > 0
+            ? plotterExt.statusBarLift() + 'px'
+            : null
+        "
+      >
         <span
           style="
             background-color: rgba(250, 250, 250, 0.7);
@@ -452,9 +459,9 @@
   >
   </fb-regions>
 
-  <!-- Notes -->
+  <!-- Notes (display-filtered by plotter extensions) -->
   @if (showNoteslayer()) {
-    <fb-notes [notes]="skres.notes()" [zIndex]="450"> </fb-notes>
+    <fb-notes [notes]="plotterExt.visibleNotes()" [zIndex]="450"> </fb-notes>
   }
 
   <!-- Distance & Bearing to -->
@@ -914,6 +921,17 @@
       >
         <mat-icon>info</mat-icon>
         <span>Get Feature Info</span>
+      </button>
+    }
+    @if (addableWidgetCell) {
+      <mat-divider></mat-divider>
+      <button
+        mat-menu-item
+        (click)="onContextMenuAction('add_widget', item)"
+        (contextmenu)="$event.preventDefault()"
+      >
+        <mat-icon>widgets</mat-icon>
+        Add widget here
       </button>
     }
   </ng-template>

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -50,6 +50,7 @@ import { GeoUtils, Angle } from 'src/app/lib/geoutils';
 import { LineString, MultiLineString, Position } from 'src/app/types';
 
 import { AppFacade } from 'src/app/app.facade';
+import { PlotterExtensionService } from 'src/app/modules/plotterext/plotterext.service';
 
 import {
   SKResourceService,
@@ -254,6 +255,11 @@ export class FBMapComponent implements OnInit, OnDestroy {
     xy: null
   };
   contextMenuPosition = { x: '0px', y: '0px' };
+  // Empty widget-anchor cell at the last right-click (or null) — gates and
+  // drives the "Add widget here" context-menu item (desktop).
+  protected addableWidgetCell: ReturnType<
+    PlotterExtensionService['addableCellAt']
+  > = null;
 
   private obsList = [];
 
@@ -264,6 +270,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   protected skstream = inject(SKStreamFacade);
   protected anchor = inject(AnchorService);
   protected notiMgr = inject(NotificationManager);
+  protected plotterExt = inject(PlotterExtensionService);
   protected course = inject(CourseService);
   protected mapInteract = inject(FBMapInteractService);
   protected mapService = inject(MapService);
@@ -557,6 +564,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
       case 'measure':
         this.mapInteract.startMeasuring();
         break;
+      case 'add_widget':
+        if (this.addableWidgetCell) {
+          this.plotterExt.openAddWidgetPicker(
+            this.addableWidgetCell.anchor,
+            this.addableWidgetCell.cell
+          );
+        }
+        break;
       case 'get_feature_info':
         this.getFeatureInfo();
         break;
@@ -699,6 +714,12 @@ export class FBMapComponent implements OnInit, OnDestroy {
     e.preventDefault();
     this.contextMenuPosition.x = e.clientX + 'px';
     this.contextMenuPosition.y = e.clientY + 'px';
+    // Resolve the click to an empty widget-anchor cell (desktop right-click
+    // equivalent of the press-and-hold add gesture). Null when not over one.
+    this.addableWidgetCell = this.plotterExt.addableCellAt(
+      e.clientX,
+      e.clientY
+    );
     this.contextMenu.menuData = { item: this.mouse.coords };
     if (this.mapInteract.isMeasuring()) {
       this.parseClickInMeasureMode(this.mouse.xy.lonlat);

--- a/src/app/modules/plotterext/add-widget-dialog.component.ts
+++ b/src/app/modules/plotterext/add-widget-dialog.component.ts
@@ -1,0 +1,64 @@
+// Widget picker shown after a press-and-hold on an empty anchor cell.
+// Lists every widget (across discovered extensions) that fits at the
+// pressed cell; a single click places it.
+
+import { Component, Inject } from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { ANCHOR_LABELS, AnchorId, WidgetCandidate } from './types';
+
+export interface PlotterAddWidgetDialogData {
+  anchor: AnchorId;
+  candidates: WidgetCandidate[];
+}
+
+@Component({
+  selector: 'fb-plotterext-add-widget',
+  imports: [MatDialogModule, MatButtonModule, MatIconModule, MatListModule],
+  template: `
+    <div mat-dialog-title class="pe-add-title">
+      <mat-icon>widgets</mat-icon>
+      <span>Add widget — {{ anchorLabel }}</span>
+    </div>
+    <mat-dialog-content>
+      <mat-action-list>
+        @for (c of data.candidates; track c.extension + '/' + c.widget.id) {
+          <button mat-list-item (click)="dialogRef.close(c)">
+            <span matListItemTitle>{{ c.widget.title }}</span>
+            <span matListItemLine
+              >{{ c.extensionName }} · {{ c.widget.size }}</span
+            >
+          </button>
+        }
+      </mat-action-list>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="dialogRef.close()">Cancel</button>
+    </mat-dialog-actions>
+  `,
+  styles: [
+    `
+      .pe-add-title {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+    `
+  ]
+})
+export class PlotterAddWidgetDialog {
+  anchorLabel: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<PlotterAddWidgetDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: PlotterAddWidgetDialogData
+  ) {
+    this.anchorLabel = ANCHOR_LABELS[data.anchor];
+  }
+}

--- a/src/app/modules/plotterext/background-runtime.component.ts
+++ b/src/app/modules/plotterext/background-runtime.component.ts
@@ -1,0 +1,107 @@
+// Headless background runtimes: hidden iframes loaded while their providing
+// extension is present in the plotterExtensions collection. No UI — each runs
+// the same bus client as a widget/panel and may call the host API (state,
+// signalk, resources/filters, map). The host element is always mounted (placed
+// once in the app shell) so a runtime's lifecycle follows extension presence,
+// not the visibility of any panel.
+//
+// The sandbox set matches the widget/panel baseline (fault containment, not a
+// security boundary): scripts + same-origin for Signal K API access + forms;
+// navigation/popups/modals deliberately withheld.
+
+import {
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  inject,
+  input
+} from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { PlotterExtensionService } from './plotterext.service';
+import { BackgroundContribution } from './types';
+
+interface RuntimeEntry {
+  key: string;
+  extension: string;
+  extensionName: string;
+  runtime: BackgroundContribution;
+}
+
+// One background runtime iframe. Attaches on init, detaches on destroy — so
+// when its entry leaves backgroundRuntimes() (extension disabled) Angular
+// removes the element and the bus connection is closed.
+@Component({
+  selector: 'fb-plotterext-runtime',
+  imports: [],
+  template: `
+    <iframe
+      #frame
+      [src]="url"
+      sandbox="allow-scripts allow-same-origin allow-forms"
+      [title]="entry().runtime.id"
+      aria-hidden="true"
+    ></iframe>
+  `,
+  styles: [
+    `
+      :host {
+        display: none;
+      }
+    `
+  ]
+})
+export class PlotterBackgroundFrame implements OnInit, OnDestroy {
+  entry = input.required<RuntimeEntry>();
+
+  @ViewChild('frame', { static: true })
+  frame: ElementRef<HTMLIFrameElement>;
+
+  url: SafeResourceUrl;
+  private detach: (() => void) | null = null;
+
+  constructor(
+    private service: PlotterExtensionService,
+    private sanitizer: DomSanitizer
+  ) {}
+
+  ngOnInit() {
+    const { extension, runtime } = this.entry();
+    this.url = this.sanitizer.bypassSecurityTrustResourceUrl(
+      runtime.url ? this.service.resolveAssetUrl(runtime.url) : 'about:blank'
+    );
+    // Attach immediately: the bus handshake tolerates either side being ready
+    // first, so there is no load-order race with the iframe.
+    this.detach = this.service.attachBackground(this.frame.nativeElement, {
+      extension,
+      runtime
+    });
+  }
+
+  ngOnDestroy() {
+    this.detach?.();
+    this.detach = null;
+  }
+}
+
+// Always-mounted host that renders one hidden iframe per background runtime.
+@Component({
+  selector: 'fb-plotterext-runtimes',
+  imports: [PlotterBackgroundFrame],
+  template: `
+    @for (entry of service.backgroundRuntimes(); track entry.key) {
+      <fb-plotterext-runtime [entry]="entry"></fb-plotterext-runtime>
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: none;
+      }
+    `
+  ]
+})
+export class PlotterBackgroundHost {
+  protected service = inject(PlotterExtensionService);
+}

--- a/src/app/modules/plotterext/panel-dialog.component.ts
+++ b/src/app/modules/plotterext/panel-dialog.component.ts
@@ -1,0 +1,146 @@
+// Material dialog hosting an extension panel iframe (used for widget
+// configuration panels in this phase; generic panels reuse it later).
+
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Inject,
+  OnDestroy,
+  OnInit,
+  ViewChild
+} from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { PlotterExtensionService } from './plotterext.service';
+import { PanelContribution } from './types';
+
+export interface PlotterPanelDialogData {
+  extension: string;
+  /** The configuration panel, or null for a widget with no settings. */
+  panel: PanelContribution | null;
+  /** Title shown when there is no panel (e.g. the widget name). */
+  title?: string;
+  targetInstance?: string | null;
+  targetWidget?: string | null;
+}
+
+@Component({
+  selector: 'fb-plotterext-panel-dialog',
+  imports: [MatDialogModule, MatButtonModule, MatIconModule],
+  template: `
+    <div class="pe-panel-header" mat-dialog-title>
+      <span>{{ data.panel ? data.panel.title : data.title }}</span>
+      <button mat-icon-button (click)="dialogRef.close()" aria-label="Close">
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+    @if (data.panel) {
+      <mat-dialog-content class="pe-panel-content">
+        <iframe
+          #frame
+          [src]="url"
+          sandbox="allow-scripts allow-same-origin allow-forms"
+          [title]="data.panel.title"
+        ></iframe>
+      </mat-dialog-content>
+    } @else {
+      <mat-dialog-content class="pe-panel-noconfig">
+        This widget has no settings.
+      </mat-dialog-content>
+    }
+    @if (data.targetInstance) {
+      <mat-dialog-actions class="pe-panel-actions">
+        <button mat-button class="pe-remove" (click)="removeWidget()">
+          <mat-icon>delete</mat-icon> Remove widget
+        </button>
+      </mat-dialog-actions>
+    }
+  `,
+  styles: [
+    `
+      .pe-panel-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-right: 8px;
+      }
+      .pe-panel-content {
+        padding: 0;
+        height: 60vh;
+      }
+      .pe-panel-noconfig {
+        padding: 16px 24px;
+        color: rgba(0, 0, 0, 0.6);
+      }
+      iframe {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border: none;
+      }
+      .pe-panel-actions {
+        justify-content: flex-start;
+      }
+      .pe-remove {
+        color: #d32f2f;
+      }
+    `
+  ]
+})
+export class PlotterPanelDialog implements OnInit, AfterViewInit, OnDestroy {
+  // non-static: the iframe lives inside an @if (data.panel) block, so it is
+  // only available after view init
+  @ViewChild('frame')
+  frame?: ElementRef<HTMLIFrameElement>;
+
+  url: SafeResourceUrl;
+  private detach: (() => void) | null = null;
+
+  constructor(
+    public dialogRef: MatDialogRef<PlotterPanelDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: PlotterPanelDialogData,
+    private service: PlotterExtensionService,
+    private sanitizer: DomSanitizer
+  ) {}
+
+  ngOnInit() {
+    // set the iframe src before first render so it loads with the dialog
+    const panel = this.data.panel;
+    if (!panel) return;
+    this.url = this.sanitizer.bypassSecurityTrustResourceUrl(
+      panel.url ? this.service.resolveAssetUrl(panel.url) : 'about:blank'
+    );
+  }
+
+  ngAfterViewInit() {
+    // No panel -> a settings-less widget; the dialog only offers Remove.
+    const panel = this.data.panel;
+    if (!panel || !this.frame) return;
+    this.detach = this.service.attachPanel(this.frame.nativeElement, {
+      extension: this.data.extension,
+      panel,
+      targetInstance: this.data.targetInstance,
+      targetWidget: this.data.targetWidget,
+      close: () => this.dialogRef.close()
+    });
+  }
+
+  removeWidget() {
+    if (this.data.targetInstance) {
+      this.service.removeWidget(this.data.targetInstance);
+    }
+    this.dialogRef.close();
+  }
+
+  ngOnDestroy() {
+    this.detach?.();
+    this.detach = null;
+  }
+}

--- a/src/app/modules/plotterext/panel-drawer.component.ts
+++ b/src/app/modules/plotterext/panel-drawer.component.ts
@@ -1,0 +1,182 @@
+// Right-side drawer hosting extension panels opened via toolbar buttons or
+// ui.openPanel. keepAlive panels stay loaded when hidden (their iframe
+// element is preserved — reparenting an iframe would reload it); onOpen
+// panels are removed from the registry and destroyed on close.
+
+import {
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  computed,
+  effect,
+  inject,
+  input
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { PlotterExtensionService } from './plotterext.service';
+import { PanelContribution } from './types';
+
+@Component({
+  selector: 'fb-plotterext-panel-frame',
+  imports: [],
+  template: `
+    <iframe
+      #frame
+      [src]="url"
+      sandbox="allow-scripts allow-same-origin allow-forms"
+      [title]="panel().title"
+    ></iframe>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+      iframe {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border: none;
+      }
+    `
+  ]
+})
+export class PlotterPanelFrame implements OnInit, OnDestroy {
+  extension = input.required<string>();
+  panel = input.required<PanelContribution>();
+
+  @ViewChild('frame', { static: true })
+  frame: ElementRef<HTMLIFrameElement>;
+
+  url: SafeResourceUrl;
+  private detach: (() => void) | null = null;
+  private service = inject(PlotterExtensionService);
+  private sanitizer = inject(DomSanitizer);
+
+  ngOnInit() {
+    this.url = this.sanitizer.bypassSecurityTrustResourceUrl(
+      this.panel().url ? this.service.resolveAssetUrl(this.panel().url) : 'about:blank'
+    );
+    this.detach = this.service.attachPanel(this.frame.nativeElement, {
+      extension: this.extension(),
+      panel: this.panel(),
+      close: () => this.service.closeVisiblePanel()
+    });
+  }
+
+  ngOnDestroy() {
+    this.detach?.();
+    this.detach = null;
+  }
+}
+
+@Component({
+  selector: 'fb-plotterext-panel-drawer',
+  imports: [MatButtonModule, MatIconModule, PlotterPanelFrame],
+  host: { '[class.pe-open]': 'isOpen()' },
+  // The drawer is an in-flow flex sibling of the map container (not an
+  // overlay): when open it widens and pushes the display to the left,
+  // mirroring Freeboard's instrument-app sidenav. Panels are kept mounted
+  // while hidden (keepAlive) — only the visible one is shown.
+  template: `
+    <div class="pe-drawer-inner" (transitionend)="onTransitionEnd($event)">
+      @if (service.visiblePanel(); as v) {
+        <div class="pe-drawer-head">
+          <span>{{ v.panel.title }}</span>
+          <button
+            mat-icon-button
+            (click)="service.closeVisiblePanel()"
+            aria-label="Close panel"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
+      }
+      <div class="pe-drawer-bodies">
+        @for (entry of service.openPanels(); track entry.key) {
+          <div class="pe-drawer-body" [class.pe-body-hidden]="!entry.visible">
+            <fb-plotterext-panel-frame
+              [extension]="entry.extension"
+              [panel]="entry.panel"
+            ></fb-plotterext-panel-frame>
+          </div>
+        }
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        flex: 0 0 auto;
+        height: 100%;
+        width: 0;
+        max-width: 92vw;
+        overflow: hidden;
+        background: #1d242b;
+        color: #e8edf2;
+      }
+      :host.pe-open {
+        width: 390px;
+        box-shadow: -2px 0 8px rgba(0, 0, 0, 0.4);
+      }
+      .pe-drawer-inner {
+        width: 390px;
+        max-width: 92vw;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      .pe-drawer-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 4px 4px 4px 14px;
+        font-weight: 600;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+        flex: 0 0 auto;
+      }
+      .pe-drawer-bodies {
+        flex: 1;
+        min-height: 0;
+        position: relative;
+      }
+      .pe-drawer-body {
+        position: absolute;
+        inset: 0;
+      }
+      .pe-body-hidden {
+        visibility: hidden;
+        pointer-events: none;
+      }
+    `
+  ]
+})
+export class PlotterPanelDrawer {
+  protected service = inject(PlotterExtensionService);
+
+  // host width follows the open state (see host binding above)
+  protected isOpen = computed(() => !!this.service.visiblePanel());
+
+  constructor() {
+    // resize the OL map as the drawer width animates so the viewport tracks
+    let first = true;
+    effect(() => {
+      this.isOpen();
+      if (first) {
+        first = false;
+        return;
+      }
+      this.service.pulseMapResize();
+    });
+  }
+
+  onTransitionEnd(ev: TransitionEvent) {
+    if (ev.propertyName === 'width') this.service.pulseMapResize(80);
+  }
+}

--- a/src/app/modules/plotterext/panel-drawer.component.ts
+++ b/src/app/modules/plotterext/panel-drawer.component.ts
@@ -48,6 +48,7 @@ import { PanelContribution } from './types';
   ]
 })
 export class PlotterPanelFrame implements OnInit, OnDestroy {
+  panelKey = input.required<string>();
   extension = input.required<string>();
   panel = input.required<PanelContribution>();
 
@@ -61,12 +62,14 @@ export class PlotterPanelFrame implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.url = this.sanitizer.bypassSecurityTrustResourceUrl(
-      this.panel().url ? this.service.resolveAssetUrl(this.panel().url) : 'about:blank'
+      this.panel().url
+        ? this.service.resolveAssetUrl(this.panel().url)
+        : 'about:blank'
     );
     this.detach = this.service.attachPanel(this.frame.nativeElement, {
       extension: this.extension(),
       panel: this.panel(),
-      close: () => this.service.closeVisiblePanel()
+      close: () => this.service.closePanel(this.panelKey())
     });
   }
 
@@ -102,6 +105,7 @@ export class PlotterPanelFrame implements OnInit, OnDestroy {
         @for (entry of service.openPanels(); track entry.key) {
           <div class="pe-drawer-body" [class.pe-body-hidden]="!entry.visible">
             <fb-plotterext-panel-frame
+              [panelKey]="entry.key"
               [extension]="entry.extension"
               [panel]="entry.panel"
             ></fb-plotterext-panel-frame>

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -1,0 +1,1576 @@
+// Plotter extension host service.
+//
+// Responsibilities (phase 1-2 of the plotterExtensions host implementation —
+// the widget stack):
+//   - discover extension manifests from /signalk/v2/api/resources/plotterExtensions
+//   - widget placement persisted in app config (anchor areas, gravity packing)
+//   - one HostConnection (signalk-plotterext-bus) per live iframe context
+//   - host API methods: state.get/set, signalk.subscribe/unsubscribe/put,
+//     ui.openPanel/togglePanel, ui.openConfigPanel/toggleConfigPanel,
+//     ui.closePanel
+//   - a single multiplexed delta WebSocket relaying subscribed Signal K paths
+//     to widget contexts as sk.<path> events
+//
+// There is deliberately NO host-side enable/disable for extensions: the user
+// already controls extension availability on the Signal K server (plugin
+// install + plugin enable). Presence in the plotterExtensions resource
+// collection is the enablement signal.
+//
+// Map/resource host APIs (buttons, filters, map.*) belong to phase 3.
+
+import { Injectable, computed, isDevMode, signal } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
+import { SignalKClient } from 'signalk-client-angular';
+import { transformExtent } from 'ol/proj';
+
+import { AppFacade } from 'src/app/app.facade';
+import { SKResourceService } from 'src/app/modules/skresources/resources.service';
+import { MapService } from 'src/app/modules/map/ol/lib/map.service';
+import { FBNotes } from 'src/app/types';
+import {
+  HostConnection,
+  MethodHandler,
+  RpcError,
+  RPC_ERRORS,
+  windowPort
+} from 'signalk-plotterext-bus/host';
+import {
+  ANCHOR_COL_ORDER,
+  ANCHOR_GRAVITY,
+  ANCHOR_GRID,
+  AnchorId,
+  BackgroundContribution,
+  ButtonContribution,
+  HOST_API_VERSION,
+  HOST_CAPABILITIES,
+  PanelContribution,
+  PlacedWidget,
+  PlotterExtensionManifest,
+  ResourceFilterCondition,
+  ResourceFilterSpec,
+  WIDGET_CELL_GAP,
+  WidgetCandidate,
+  WidgetContribution,
+  cellHeightPx,
+  parseSize
+} from './types';
+
+const STATE_STORAGE_KEY = 'fb-plotterext-state';
+const SK_PATH_PERIOD = 1000; // default delta period (ms) for relayed paths
+
+interface ExtensionStateStore {
+  [extensionId: string]: {
+    extension?: Record<string, unknown>;
+    instances?: { [instanceId: string]: Record<string, unknown> };
+  };
+}
+
+interface LiveContext {
+  extension: string;
+  conn: HostConnection;
+  /** signalk.subscribe subscriptionId -> paths */
+  skSubs: Map<string, string[]>;
+  skSubSeq: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PlotterExtensionService {
+  // id -> manifest, as discovered from the resources API
+  readonly manifests = signal<Record<string, PlotterExtensionManifest>>({});
+  // placements whose extension is present and compatible (drives the overlay)
+  readonly activeWidgets = signal<PlacedWidget[]>([]);
+  readonly initialized = signal(false);
+
+  /**
+   * Bottom offset (px) for host chrome that normally lives in the
+   * bottom-right corner (Freeboard's action button): 0 when no widgets
+   * occupy the bottom-right anchor, otherwise just above the occupied rows.
+   */
+  readonly actionButtonLift = computed(() => {
+    const br = this.activeWidgets().filter((p) => p.anchor === 'br');
+    if (!br.length) return 0;
+    const rows = br.some((p) => p.row === 0) ? 2 : 1;
+    return rows * cellHeightPx() + (rows - 1) * WIDGET_CELL_GAP + 6;
+  });
+
+  /**
+   * Bottom offset (px) for the Lat/Lon status bar: 0 when no widget occupies
+   * the bottom-center anchor (the bar keeps its default resting position),
+   * otherwise just above the bottom-center widget stack (which sits flush
+   * against the screen bottom). Mirrors actionButtonLift for the bottom-right.
+   */
+  readonly statusBarLift = computed(() => {
+    const cb = this.activeWidgets().filter((p) => p.anchor === 'cb');
+    if (!cb.length) return 0;
+    const rows = cb.some((p) => p.row === 0) ? 2 : 1;
+    return rows * cellHeightPx() + (rows - 1) * WIDGET_CELL_GAP + 4;
+  });
+
+  /**
+   * Top offset (px) for the right-hand toolbar (the Show/Hide Toolbars button
+   * and the expanded toolbar below it): 0 when no widget occupies the
+   * top-right anchor (the toolbar keeps its normal position), otherwise just
+   * below the top-right widget stack (which sits flush against the screen
+   * top). The top-right anchor has top gravity, so the non-gravity row is
+   * row 1. Mirrors actionButtonLift/statusBarLift.
+   */
+  readonly toolbarTopOffset = computed(() => {
+    const tr = this.activeWidgets().filter((p) => p.anchor === 'tr');
+    if (!tr.length) return 0;
+    const rows = tr.some((p) => p.row === 1) ? 2 : 1;
+    return rows * cellHeightPx() + (rows - 1) * WIDGET_CELL_GAP + 4;
+  });
+
+  /** Toolbar buttons contributed by compatible extensions. */
+  readonly toolbarButtons = computed(() => {
+    const result: Array<{
+      extension: string;
+      extensionName: string;
+      button: ButtonContribution;
+    }> = [];
+    for (const [extension, manifest] of Object.entries(this.manifests())) {
+      if (!this.isCompatible(manifest)) continue;
+      for (const button of manifest.buttons ?? []) {
+        if (
+          button.apiVersion !== undefined &&
+          button.apiVersion !== HOST_API_VERSION
+        ) {
+          continue;
+        }
+        result.push({ extension, extensionName: manifest.name, button });
+      }
+    }
+    return result;
+  });
+
+  /**
+   * Headless background runtimes contributed by compatible extensions. Drives
+   * the always-mounted runtime host: a hidden iframe per entry, loaded while
+   * the extension is present in the collection and torn down when it leaves
+   * (the providing plugin was disabled). `key` is stable per (extension,
+   * runtime) so Angular's @for keeps the iframe across unrelated changes.
+   */
+  readonly backgroundRuntimes = computed(() => {
+    const result: Array<{
+      key: string;
+      extension: string;
+      extensionName: string;
+      runtime: BackgroundContribution;
+    }> = [];
+    for (const [extension, manifest] of Object.entries(this.manifests())) {
+      if (!this.isCompatible(manifest)) continue;
+      for (const runtime of manifest.background ?? []) {
+        if (
+          runtime.apiVersion !== undefined &&
+          runtime.apiVersion !== HOST_API_VERSION
+        ) {
+          continue;
+        }
+        if (runtime.type !== 'iframe' || !runtime.url) continue;
+        result.push({
+          key: `${extension}/${runtime.id}`,
+          extension,
+          extensionName: manifest.name,
+          runtime
+        });
+      }
+    }
+    return result;
+  });
+
+  // ---------- extension panels (button-opened, ui.openPanel) ----------
+
+  /**
+   * Open panels live in a right-side drawer. keepAlive panels stay loaded
+   * (hidden) when closed; onOpen panels are destroyed. One panel is visible
+   * at a time.
+   */
+  readonly openPanels = signal<
+    Array<{
+      key: string;
+      extension: string;
+      panel: PanelContribution;
+      visible: boolean;
+    }>
+  >([]);
+
+  readonly visiblePanel = computed(
+    () => this.openPanels().find((p) => p.visible) ?? null
+  );
+
+  openPanel(extension: string, panelId: string): boolean {
+    const manifest = this.manifests()[extension];
+    const panel = manifest?.panels?.find((p) => p.id === panelId);
+    if (!panel || panel.type !== 'iframe' || !panel.url) return false;
+    const key = `${extension}/${panelId}`;
+    this.openPanels.update((panels) => {
+      const existing = panels.find((p) => p.key === key);
+      if (existing) {
+        return panels.map((p) => ({ ...p, visible: p.key === key }));
+      }
+      return [
+        ...panels.map((p) => ({ ...p, visible: false })),
+        { key, extension, panel, visible: true }
+      ];
+    });
+    return true;
+  }
+
+  /** Close the visible drawer panel (hide keepAlive, destroy others). */
+  closeVisiblePanel() {
+    this.openPanels.update((panels) => {
+      const visible = panels.find((p) => p.visible);
+      if (!visible) return panels;
+      if (visible.panel.lifecycle === 'keepAlive') {
+        return panels.map((p) => ({ ...p, visible: false }));
+      }
+      return panels.filter((p) => p.key !== visible.key);
+    });
+  }
+
+  /**
+   * Toggle a drawer panel: if it is the currently visible panel, close it;
+   * otherwise open (or switch to) it. Mirrors Freeboard's instrument-panel
+   * button behavior.
+   */
+  togglePanel(extension: string, panelId: string): boolean {
+    const key = `${extension}/${panelId}`;
+    if (this.visiblePanel()?.key === key) {
+      this.closeVisiblePanel();
+      return true;
+    }
+    return this.openPanel(extension, panelId);
+  }
+
+  /** `ui.openPanel` / `ui.togglePanel` for an extension context. */
+  private uiPanelMethods(extension: string): Record<string, MethodHandler> {
+    const requirePanel = (params: unknown): string => {
+      const panel = (params as { panel?: string } | undefined)?.panel;
+      if (!panel) {
+        throw new RpcError('panel is required', {
+          code: RPC_ERRORS.INVALID_PARAMS,
+          reason: 'UNKNOWN_PANEL'
+        });
+      }
+      return panel;
+    };
+    return {
+      'ui.openPanel': async (params) => {
+        const panel = requirePanel(params);
+        if (!this.openPanel(extension, panel)) {
+          throw new RpcError(`No such panel: ${panel}`, {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'UNKNOWN_PANEL'
+          });
+        }
+        return {};
+      },
+      'ui.togglePanel': async (params) => {
+        const panel = requirePanel(params);
+        if (!this.togglePanel(extension, panel)) {
+          throw new RpcError(`No such panel: ${panel}`, {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'UNKNOWN_PANEL'
+          });
+        }
+        return {};
+      }
+    };
+  }
+
+  handleButtonAction(extension: string, button: ButtonContribution) {
+    const action = button.action;
+    if (!action) return;
+    if (action.type === 'sendMessage') {
+      // Fire-and-forget: publish a custom event onto the bus. Delivery is
+      // subscription-gated (publish() only reaches contexts that subscribed
+      // to the topic), so this reaches the extension's own background runtime
+      // and, by convention with a shared topic, other extensions too.
+      if (action.topic) this.broadcastMessage(action.topic, action.params);
+      return;
+    }
+    const panel = action.panel;
+    if (!panel) return;
+    if (action.type === 'togglePanel') {
+      this.togglePanel(extension, panel);
+    } else if (action.type === 'openPanel') {
+      this.openPanel(extension, panel);
+    }
+  }
+
+  // ---------- resource display filters ----------
+
+  /** type -> extension id -> filter */
+  readonly resourceFilters = signal<
+    Record<string, Record<string, ResourceFilterSpec>>
+  >({});
+
+  /** Notes to display: the resource cache with active filters applied. */
+  readonly visibleNotes = computed<FBNotes>(() => {
+    const notes = this.skres.notes();
+    const filters = this.resourceFilters()['notes'];
+    if (!filters || !Object.keys(filters).length) return notes;
+    const specs = Object.values(filters);
+    return notes.filter(([id, note]) =>
+      specs.every((spec) => this.passesFilter(spec, id, note))
+    );
+  });
+
+  /** Active-filter chips for the host UI. */
+  readonly filterChips = computed(() => {
+    const chips: Array<{
+      type: string;
+      extension: string;
+      label: string;
+    }> = [];
+    for (const [type, byExt] of Object.entries(this.resourceFilters())) {
+      for (const [extension, spec] of Object.entries(byExt)) {
+        chips.push({
+          type,
+          extension,
+          label:
+            spec.label ??
+            `${this.manifests()[extension]?.name ?? extension} filter`
+        });
+      }
+    }
+    return chips;
+  });
+
+  setResourceFilter(
+    extension: string,
+    type: string,
+    filter: ResourceFilterSpec
+  ) {
+    this.resourceFilters.update((all) => ({
+      ...all,
+      [type]: { ...(all[type] ?? {}), [extension]: filter }
+    }));
+    this.publishToExtension(extension, 'filters.changed', {
+      type,
+      active: true
+    });
+  }
+
+  clearResourceFilter(extension: string, type: string) {
+    this.resourceFilters.update((all) => {
+      const byExt = { ...(all[type] ?? {}) };
+      delete byExt[extension];
+      const next = { ...all };
+      if (Object.keys(byExt).length) {
+        next[type] = byExt;
+      } else {
+        delete next[type];
+      }
+      return next;
+    });
+    this.publishToExtension(extension, 'filters.changed', {
+      type,
+      active: false
+    });
+  }
+
+  private passesFilter(
+    spec: ResourceFilterSpec,
+    id: string,
+    resource: unknown
+  ): boolean {
+    let matches = true;
+    if (spec.ids) {
+      matches = spec.ids.includes(id);
+    }
+    if (matches && spec.match) {
+      matches = spec.match.every((cond) =>
+        this.evalCondition(cond, resource)
+      );
+    }
+    return spec.mode === 'exclude' ? !matches : matches;
+  }
+
+  private evalCondition(
+    cond: ResourceFilterCondition,
+    resource: unknown
+  ): boolean {
+    let value: unknown = resource;
+    for (const seg of cond.path.split('.')) {
+      if (value === null || typeof value !== 'object') {
+        value = undefined;
+        break;
+      }
+      value = (value as Record<string, unknown>)[seg];
+    }
+    switch (cond.op) {
+      case 'exists':
+        return value !== undefined;
+      case 'eq':
+        return this.refEquals(value, cond.value, cond.exact);
+      case 'ne':
+        return !this.refEquals(value, cond.value, cond.exact);
+      case 'lt':
+        return typeof value === 'number' && value < (cond.value as number);
+      case 'lte':
+        return typeof value === 'number' && value <= (cond.value as number);
+      case 'gt':
+        return typeof value === 'number' && value > (cond.value as number);
+      case 'gte':
+        return typeof value === 'number' && value >= (cond.value as number);
+      case 'in':
+        return (
+          Array.isArray(cond.value) &&
+          cond.value.some((v) => this.refEquals(value, v, cond.exact))
+        );
+      case 'contains':
+        if (typeof value === 'string') {
+          return value
+            .toLowerCase()
+            .includes(String(cond.value).toLowerCase());
+        }
+        return Array.isArray(value) && value.includes(cond.value);
+      case 'regex': {
+        if (typeof value !== 'string' || typeof cond.value !== 'string') {
+          return false;
+        }
+        const re = this.compileRegex(cond.value);
+        return re ? re.test(value) : false;
+      }
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Local id of a symbol-style `namespace:id` reference, or null when the
+   * value is not one. The grammar follows the Symbols API alias form: a
+   * single colon, `namespace` matching `[A-Za-z0-9_-]+`, and an `id` with no
+   * further colon. Multi-colon strings (e.g. `urn:mrn:...`) are NOT symbol
+   * references and return null, so URN-like fields keep exact-match semantics.
+   */
+  private symbolLocalId(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const m = /^[A-Za-z0-9_-]+:([^:]+)$/.exec(value);
+    return m ? m[1] : null;
+  }
+
+  /**
+   * Equality used by eq/ne/in. Exact match first; then namespace-tolerant
+   * matching for symbol references so a filter written against a bare symbol
+   * id (`anchorage`) still matches once the host has persisted a
+   * fully-qualified alias (`default:anchorage`), and vice versa. Differing
+   * namespaces (`custom:x` vs `fsk:x`) never match. Only single-colon
+   * `namespace:id` values participate; everything else compares strictly.
+   * `exact` opts out of the tolerance and compares strictly.
+   */
+  private refEquals(stored: unknown, target: unknown, exact?: boolean): boolean {
+    if (stored === target) return true;
+    if (exact) return false;
+    // bare target id vs qualified stored reference
+    if (typeof target === 'string' && !target.includes(':')) {
+      if (this.symbolLocalId(stored) === target) return true;
+    }
+    // qualified target reference vs bare stored id
+    if (typeof stored === 'string' && !stored.includes(':')) {
+      if (this.symbolLocalId(target) === stored) return true;
+    }
+    return false;
+  }
+
+  /** Compile a filter regex; invalid patterns make the condition false. */
+  private compileRegex(pattern: string): RegExp | null {
+    try {
+      return new RegExp(pattern);
+    } catch {
+      return null;
+    }
+  }
+
+  private contexts = new Set<LiveContext>();
+
+  // ---- Signal K delta relay (one WS for all widget contexts) ----
+  private ws: WebSocket | null = null;
+  private wsReady = false;
+  private pathRefs = new Map<string, number>();
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private app: AppFacade,
+    private signalk: SignalKClient,
+    private dialog: MatDialog,
+    private skres: SKResourceService,
+    private mapService: MapService
+  ) {
+    if (isDevMode()) {
+      // console handle for exercising the host API during development
+      (window as unknown as Record<string, unknown>)['fbPlotterExt'] = this;
+    }
+  }
+
+  /** Fetch manifests. Called after the server connection is established. */
+  async init(): Promise<void> {
+    try {
+      const response = await firstValueFrom(
+        this.signalk.api.get(this.app.skApiVersion, '/resources/plotterExtensions')
+      );
+      const manifests: Record<string, PlotterExtensionManifest> = {};
+      if (response && typeof response === 'object') {
+        for (const [id, value] of Object.entries(
+          response as Record<string, unknown>
+        )) {
+          if (this.isManifest(value)) {
+            manifests[id] = value as PlotterExtensionManifest;
+          }
+        }
+      }
+      this.manifests.set(manifests);
+    } catch {
+      // No provider installed (404) or fetch failed: extensions unavailable.
+      this.manifests.set({});
+    }
+    this.refreshActiveWidgets();
+    this.initialized.set(true);
+  }
+
+  // ---------- discovery ----------
+
+  private isCompatible(manifest: PlotterExtensionManifest): boolean {
+    if (manifest.apiVersion !== HOST_API_VERSION) return false;
+    return (manifest.requires ?? []).every((cap) =>
+      HOST_CAPABILITIES.includes(cap)
+    );
+  }
+
+  private isManifest(value: unknown): boolean {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as PlotterExtensionManifest).name === 'string' &&
+      typeof (value as PlotterExtensionManifest).apiVersion === 'string'
+    );
+  }
+
+  // ---------- widget placement ----------
+
+  widgetDef(extension: string, widget: string): WidgetContribution | null {
+    const manifest = this.manifests()[extension];
+    return manifest?.widgets?.find((w) => w.id === widget) ?? null;
+  }
+
+  placements(): PlacedWidget[] {
+    return this.app.config.plotterExtensions.widgets;
+  }
+
+  /** Occupancy map of an anchor area (sized per ANCHOR_GRID): occupied[row][col]. */
+  private occupancy(anchor: AnchorId): boolean[][] {
+    const { cols, rows } = ANCHOR_GRID[anchor];
+    const occupied = Array.from({ length: rows }, () =>
+      Array.from({ length: cols }, () => false)
+    );
+    for (const placed of this.placements()) {
+      if (placed.anchor !== anchor) continue;
+      const def = this.widgetDef(placed.extension, placed.widget);
+      const size = parseSize(def?.size ?? '1x1');
+      for (let r = placed.row; r < placed.row + size.rows && r < rows; r++) {
+        for (let c = placed.col; c < placed.col + size.cols && c < cols; c++) {
+          occupied[r][c] = true;
+        }
+      }
+    }
+    return occupied;
+  }
+
+  /** Whether a cell of an anchor area is occupied by a placed widget. */
+  cellOccupied(anchor: AnchorId, cell: { col: number; row: number }): boolean {
+    return this.occupancy(anchor)[cell.row]?.[cell.col] ?? true;
+  }
+
+  /**
+   * A placement is valid when every needed cell is free and the widget does
+   * not "float": widgets pack from the anchor's screen edge inward, so a
+   * widget not touching the gravity row needs the cells between it and the
+   * gravity edge occupied.
+   */
+  private isValidOrigin(
+    anchor: AnchorId,
+    size: { cols: number; rows: number },
+    origin: { col: number; row: number },
+    occupied: boolean[][]
+  ): boolean {
+    const { cols, rows } = ANCHOR_GRID[anchor];
+    if (origin.col + size.cols > cols || origin.row + size.rows > rows) {
+      return false;
+    }
+    for (let r = origin.row; r < origin.row + size.rows; r++) {
+      for (let c = origin.col; c < origin.col + size.cols; c++) {
+        if (occupied[r][c]) return false;
+      }
+    }
+    if (size.rows === 1) {
+      const gravityRow = ANCHOR_GRAVITY[anchor] === 'bottom' ? rows - 1 : 0;
+      if (origin.row !== gravityRow) {
+        // floating row: require support toward the gravity edge
+        for (let c = origin.col; c < origin.col + size.cols; c++) {
+          if (!occupied[gravityRow][c]) return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /** Candidate origins for an anchor, most-preferred (gravity/corner) first. */
+  private originOrder(anchor: AnchorId): Array<{ col: number; row: number }> {
+    const rowCount = ANCHOR_GRID[anchor].rows;
+    const ascending = Array.from({ length: rowCount }, (_, i) => i);
+    const rows =
+      ANCHOR_GRAVITY[anchor] === 'bottom' ? [...ascending].reverse() : ascending;
+    const cols = ANCHOR_COL_ORDER[anchor];
+    const order: Array<{ col: number; row: number }> = [];
+    for (const row of rows) {
+      for (const col of cols) {
+        order.push({ col, row });
+      }
+    }
+    return order;
+  }
+
+  /**
+   * Best valid origin for a widget at an anchor. When a pressed cell is
+   * given, only placements covering that cell are considered, so the user's
+   * press location disambiguates (e.g. stacking on top of an existing
+   * widget vs. filling the rest of the gravity row).
+   */
+  private findOrigin(
+    anchor: AnchorId,
+    widget: WidgetContribution,
+    pressedCell?: { col: number; row: number }
+  ): { col: number; row: number } | null {
+    const size = parseSize(widget.size);
+    const occupied = this.occupancy(anchor);
+    for (const origin of this.originOrder(anchor)) {
+      if (!this.isValidOrigin(anchor, size, origin, occupied)) continue;
+      if (
+        pressedCell &&
+        !(
+          pressedCell.col >= origin.col &&
+          pressedCell.col < origin.col + size.cols &&
+          pressedCell.row >= origin.row &&
+          pressedCell.row < origin.row + size.rows
+        )
+      ) {
+        continue;
+      }
+      return origin;
+    }
+    return null;
+  }
+
+  /**
+   * All widgets (across compatible extensions) that could be added at the
+   * pressed cell of an anchor area, each with its computed origin.
+   */
+  addableWidgets(
+    anchor: AnchorId,
+    pressedCell: { col: number; row: number }
+  ): WidgetCandidate[] {
+    const result: WidgetCandidate[] = [];
+    for (const [extension, manifest] of Object.entries(this.manifests())) {
+      if (!this.isCompatible(manifest)) continue;
+      for (const widget of manifest.widgets ?? []) {
+        if (widget.type !== 'iframe') continue;
+        if (
+          widget.apiVersion !== undefined &&
+          widget.apiVersion !== HOST_API_VERSION
+        ) {
+          continue;
+        }
+        const origin = this.findOrigin(anchor, widget, pressedCell);
+        if (origin) {
+          result.push({
+            extension,
+            extensionName: manifest.name,
+            widget,
+            origin
+          });
+        }
+      }
+    }
+    return result;
+  }
+
+  // Screen-coordinate hit testing is owned by the overlay (it has the anchor
+  // DOM). The overlay registers its tester here so other entry points — the
+  // desktop right-click menu — can resolve a point to an anchor cell without a
+  // direct component reference.
+  private hitTester:
+    | ((
+        x: number,
+        y: number
+      ) => { anchor: AnchorId; cell: { col: number; row: number } } | null)
+    | null = null;
+
+  registerHitTester(
+    fn: (
+      x: number,
+      y: number
+    ) => { anchor: AnchorId; cell: { col: number; row: number } } | null
+  ): () => void {
+    this.hitTester = fn;
+    return () => {
+      if (this.hitTester === fn) this.hitTester = null;
+    };
+  }
+
+  /**
+   * Resolve screen coordinates to an EMPTY anchor cell that can accept at least
+   * one widget, or null. Used to gate and trigger the right-click "Add widget
+   * here" menu item.
+   */
+  addableCellAt(
+    x: number,
+    y: number
+  ): { anchor: AnchorId; cell: { col: number; row: number } } | null {
+    const hit = this.hitTester?.(x, y);
+    if (!hit) return null;
+    if (this.cellOccupied(hit.anchor, hit.cell)) return null;
+    if (!this.addableWidgets(hit.anchor, hit.cell).length) return null;
+    return hit;
+  }
+
+  /**
+   * Open the Add Widget picker for an empty anchor cell. Shared by the
+   * press-and-hold gesture (touch) and the right-click menu (desktop); on a
+   * choice it places the widget and opens its config panel if it has one.
+   */
+  async openAddWidgetPicker(
+    anchor: AnchorId,
+    cell: { col: number; row: number }
+  ) {
+    const candidates = this.addableWidgets(anchor, cell);
+    if (!candidates.length) return;
+    const { PlotterAddWidgetDialog } = await import(
+      './add-widget-dialog.component'
+    );
+    this.dialog
+      .open(PlotterAddWidgetDialog, {
+        data: { anchor, candidates },
+        width: '340px'
+      })
+      .afterClosed()
+      .subscribe((choice) => {
+        if (!choice) return;
+        const placed = this.placeWidget(
+          choice.extension,
+          choice.widget,
+          anchor,
+          choice.origin
+        );
+        if (this.widgetHasConfigPanel(placed)) {
+          this.openConfigPanel(placed);
+        }
+      });
+  }
+
+  /** Place a widget at a previously computed origin (see addableWidgets). */
+  placeWidget(
+    extension: string,
+    widget: WidgetContribution,
+    anchor: AnchorId,
+    origin: { col: number; row: number }
+  ): PlacedWidget {
+    const placed: PlacedWidget = {
+      instanceId: crypto.randomUUID(),
+      extension,
+      widget: widget.id,
+      anchor,
+      col: origin.col,
+      row: origin.row
+    };
+    this.app.config.plotterExtensions.widgets.push(placed);
+    this.app.saveConfig();
+    this.refreshActiveWidgets();
+    return placed;
+  }
+
+  removeWidget(instanceId: string) {
+    const widgets = this.app.config.plotterExtensions.widgets;
+    const idx = widgets.findIndex((w) => w.instanceId === instanceId);
+    if (idx !== -1) {
+      const [removed] = widgets.splice(idx, 1);
+      this.clearInstanceState(removed.extension, instanceId);
+      this.app.saveConfig();
+      this.refreshActiveWidgets();
+    }
+  }
+
+  private refreshActiveWidgets() {
+    const manifests = this.manifests();
+    this.activeWidgets.set(
+      this.placements().filter((p) => {
+        const manifest = manifests[p.extension];
+        return (
+          manifest &&
+          this.isCompatible(manifest) &&
+          manifest.widgets?.some((w) => w.id === p.widget)
+        );
+      })
+    );
+  }
+
+  // ---------- live contexts (one per iframe) ----------
+
+  /**
+   * Manifest asset URLs are server-relative; resolve them against the
+   * Signal K server origin (which differs from the app origin when running
+   * the Angular dev server).
+   */
+  resolveAssetUrl(url: string): string {
+    const base = this.app.hostDef?.url || window.location.origin;
+    try {
+      return new URL(url, base).toString();
+    } catch {
+      return url;
+    }
+  }
+
+  private assetOrigin(url: string): string {
+    try {
+      return new URL(this.resolveAssetUrl(url)).origin;
+    } catch {
+      return '*';
+    }
+  }
+
+  /**
+   * Attach a widget iframe to the host. Returns a detach function.
+   * Call once the iframe element exists (the connection handles the
+   * extension's bus.ready retries, so load-order does not matter).
+   */
+  attachWidget(iframe: HTMLIFrameElement, placed: PlacedWidget): () => void {
+    const ctx: LiveContext = {
+      extension: placed.extension,
+      conn: null as unknown as HostConnection,
+      skSubs: new Map(),
+      skSubSeq: 0
+    };
+    const widgetUrl = this.widgetDef(placed.extension, placed.widget)?.url ?? '';
+    ctx.conn = new HostConnection({
+      port: windowPort(iframe.contentWindow as Window, {
+        origin: this.assetOrigin(widgetUrl)
+      }),
+      hostInfo: this.hostInfo(),
+      context: {
+        kind: 'widget',
+        id: placed.widget,
+        instanceId: placed.instanceId,
+        targetInstance: null
+      },
+      methods: {
+        ...this.stateMethods(placed.extension, placed.instanceId),
+        ...this.signalkMethods(ctx),
+        ...this.unitsMethods(),
+        ...this.resourcesMethods(placed.extension),
+        ...this.mapMethods(),
+        ...this.uiPanelMethods(placed.extension),
+        'ui.openConfigPanel': async () => {
+          this.openConfigPanel(placed);
+          return {};
+        },
+        'ui.toggleConfigPanel': async () => {
+          this.toggleConfigPanel(placed);
+          return {};
+        }
+      },
+      onError: (err) => console.warn('plotterext widget error', err)
+    });
+    this.contexts.add(ctx);
+    return () => this.detach(ctx);
+  }
+
+  /**
+   * Attach a panel iframe (e.g. a widget configuration panel). targetInstance
+   * scopes the panel's instance state to the widget being configured.
+   */
+  attachPanel(
+    iframe: HTMLIFrameElement,
+    opts: {
+      extension: string;
+      panel: PanelContribution;
+      targetInstance?: string | null;
+      targetWidget?: string | null;
+      close: () => void;
+    }
+  ): () => void {
+    const ctx: LiveContext = {
+      extension: opts.extension,
+      conn: null as unknown as HostConnection,
+      skSubs: new Map(),
+      skSubSeq: 0
+    };
+    ctx.conn = new HostConnection({
+      port: windowPort(iframe.contentWindow as Window, {
+        origin: this.assetOrigin(opts.panel.url ?? '')
+      }),
+      hostInfo: this.hostInfo(),
+      context: {
+        kind: 'panel',
+        id: opts.panel.id,
+        instanceId: null,
+        targetInstance: opts.targetInstance ?? null,
+        targetWidget: opts.targetWidget ?? null
+      },
+      methods: {
+        ...this.stateMethods(opts.extension, opts.targetInstance ?? null),
+        ...this.signalkMethods(ctx),
+        ...this.unitsMethods(),
+        ...this.resourcesMethods(opts.extension),
+        ...this.mapMethods(),
+        ...this.uiPanelMethods(opts.extension),
+        'ui.closePanel': async () => {
+          opts.close();
+          return {};
+        }
+      },
+      onError: (err) => console.warn('plotterext panel error', err)
+    });
+    this.contexts.add(ctx);
+    return () => this.detach(ctx);
+  }
+
+  /**
+   * Attach a headless background-runtime iframe. No UI: same host API surface
+   * as a panel minus the panel/config-only methods (no ui.closePanel /
+   * ui.*ConfigPanel). State defaults to the extension scope (no instance).
+   * Returns a detach function called when the runtime leaves the collection.
+   */
+  attachBackground(
+    iframe: HTMLIFrameElement,
+    opts: { extension: string; runtime: BackgroundContribution }
+  ): () => void {
+    const ctx: LiveContext = {
+      extension: opts.extension,
+      conn: null as unknown as HostConnection,
+      skSubs: new Map(),
+      skSubSeq: 0
+    };
+    ctx.conn = new HostConnection({
+      port: windowPort(iframe.contentWindow as Window, {
+        origin: this.assetOrigin(opts.runtime.url)
+      }),
+      hostInfo: this.hostInfo(),
+      context: {
+        kind: 'background',
+        id: opts.runtime.id,
+        instanceId: null
+      },
+      methods: {
+        ...this.stateMethods(opts.extension, null),
+        ...this.signalkMethods(ctx),
+        ...this.unitsMethods(),
+        ...this.resourcesMethods(opts.extension),
+        ...this.mapMethods(),
+        ...this.uiPanelMethods(opts.extension)
+      },
+      onError: (err) => console.warn('plotterext background error', err)
+    });
+    this.contexts.add(ctx);
+    return () => this.detach(ctx);
+  }
+
+  private detach(ctx: LiveContext) {
+    if (!this.contexts.has(ctx)) return;
+    this.contexts.delete(ctx);
+    for (const [, paths] of ctx.skSubs) {
+      this.releasePaths(paths);
+    }
+    ctx.skSubs.clear();
+    ctx.conn.close();
+  }
+
+  private hostInfo() {
+    return {
+      host: 'freeboard-sk',
+      hostVersion: this.app.data?.server?.version ?? 'dev',
+      apiVersion: HOST_API_VERSION,
+      capabilities: HOST_CAPABILITIES
+    };
+  }
+
+  // ---------- configuration panels ----------
+
+  // the currently open widget-configuration dialog, if any
+  private configDialogRef: MatDialogRef<unknown> | null = null;
+  private configDialogInstance: string | null = null;
+
+  /** Whether a placed widget has a usable iframe configuration panel. */
+  widgetHasConfigPanel(placed: PlacedWidget): boolean {
+    const manifest = this.manifests()[placed.extension];
+    const widget = this.widgetDef(placed.extension, placed.widget);
+    const found = manifest?.panels?.find((p) => p.id === widget?.configPanel);
+    return !!(found && found.type === 'iframe' && found.url);
+  }
+
+  openConfigPanel(placed: PlacedWidget) {
+    const manifest = this.manifests()[placed.extension];
+    const widget = this.widgetDef(placed.extension, placed.widget);
+    const found = manifest?.panels?.find((p) => p.id === widget?.configPanel);
+    // A widget with no usable config panel still gets a dialog so it can be
+    // removed (long-press affordance applies to every placed widget).
+    const panel =
+      found && found.type === 'iframe' && found.url ? found : null;
+    // Deferred import avoids a service->component->service import cycle.
+    import('./panel-dialog.component').then(({ PlotterPanelDialog }) => {
+      const ref = this.dialog.open(PlotterPanelDialog, {
+        data: {
+          extension: placed.extension,
+          panel,
+          title: widget?.title ?? placed.widget,
+          targetInstance: placed.instanceId,
+          targetWidget: placed.widget
+        },
+        width: '440px',
+        maxHeight: '85vh'
+      });
+      this.configDialogRef = ref;
+      this.configDialogInstance = placed.instanceId;
+      ref.afterClosed().subscribe(() => {
+        if (this.configDialogRef === ref) {
+          this.configDialogRef = null;
+          this.configDialogInstance = null;
+        }
+      });
+    });
+  }
+
+  /**
+   * Toggle a widget instance's configuration panel: close it if it is already
+   * open for that instance, otherwise open it.
+   */
+  toggleConfigPanel(placed: PlacedWidget) {
+    if (this.configDialogRef && this.configDialogInstance === placed.instanceId) {
+      this.configDialogRef.close();
+      return;
+    }
+    this.openConfigPanel(placed);
+  }
+
+  // ---------- state storage ----------
+  //
+  // v0 persistence is browser localStorage. TODO(phase 2 follow-up): persist
+  // through the server's applicationData so widget config follows the user
+  // across devices, mirroring how Freeboard persists its own config.
+
+  private loadStore(): ExtensionStateStore {
+    try {
+      return JSON.parse(localStorage.getItem(STATE_STORAGE_KEY) ?? '{}');
+    } catch {
+      return {};
+    }
+  }
+
+  private saveStore(store: ExtensionStateStore) {
+    localStorage.setItem(STATE_STORAGE_KEY, JSON.stringify(store));
+  }
+
+  private clearInstanceState(extension: string, instanceId: string) {
+    const store = this.loadStore();
+    if (store[extension]?.instances?.[instanceId]) {
+      delete store[extension].instances![instanceId];
+      this.saveStore(store);
+    }
+  }
+
+  private stateMethods(
+    extension: string,
+    instanceId: string | null
+  ): Record<string, MethodHandler> {
+    const resolve = (
+      store: ExtensionStateStore,
+      scope: string | undefined
+    ): Record<string, unknown> => {
+      const extStore = (store[extension] = store[extension] ?? {});
+      const useInstance = (scope ?? (instanceId ? 'instance' : 'extension')) === 'instance';
+      if (useInstance) {
+        if (!instanceId) {
+          throw new RpcError('No widget instance in scope', {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'NO_INSTANCE'
+          });
+        }
+        extStore.instances = extStore.instances ?? {};
+        return (extStore.instances[instanceId] =
+          extStore.instances[instanceId] ?? {});
+      }
+      return (extStore.extension = extStore.extension ?? {});
+    };
+
+    return {
+      'state.get': async (params) => {
+        const { scope, keys } = (params ?? {}) as {
+          scope?: string;
+          keys?: string[];
+        };
+        const values = resolve(this.loadStore(), scope);
+        if (!keys) return { values };
+        const filtered: Record<string, unknown> = {};
+        for (const key of keys) {
+          if (key in values) filtered[key] = values[key];
+        }
+        return { values: filtered };
+      },
+      'state.set': async (params) => {
+        const { scope, values } = (params ?? {}) as {
+          scope?: string;
+          values?: Record<string, unknown>;
+        };
+        if (!values || typeof values !== 'object') {
+          throw new RpcError('state.set requires a values object', {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'INVALID_VALUES'
+          });
+        }
+        const store = this.loadStore();
+        const target = resolve(store, scope);
+        Object.assign(target, values);
+        this.saveStore(store);
+        const useInstance =
+          (scope ?? (instanceId ? 'instance' : 'extension')) === 'instance';
+        this.publishToExtension(extension, 'state.changed', {
+          scope: useInstance ? 'instance' : 'extension',
+          instanceId: useInstance ? instanceId : null,
+          keys: Object.keys(values)
+        });
+        return {};
+      }
+    };
+  }
+
+  private publishToExtension(extension: string, event: string, params: unknown) {
+    for (const ctx of this.contexts) {
+      if (ctx.extension === extension) {
+        ctx.conn.publish(event, params);
+      }
+    }
+  }
+
+  /**
+   * Broadcast a custom event to every live extension context (any extension).
+   * Like publishToExtension, delivery is subscription-gated — publish() only
+   * reaches a context that subscribed to the topic — so this is a shared,
+   * opt-in message bus, not a spam channel. Used by `sendMessage` buttons; the
+   * cross-extension reach is what lets a federation of plugins talk over
+   * namespaced topics.
+   */
+  private broadcastMessage(event: string, params: unknown) {
+    for (const ctx of this.contexts) {
+      ctx.conn.publish(event, params);
+    }
+  }
+
+  // ---------- resources host API ----------
+
+  private resourcesMethods(extension: string): Record<string, MethodHandler> {
+    return {
+      'resources.list': async (params) => {
+        const { type, query } = (params ?? {}) as {
+          type?: string;
+          query?: Record<string, unknown>;
+        };
+        if (typeof type !== 'string' || !/^[A-Za-z][A-Za-z0-9_-]*$/.test(type)) {
+          throw new RpcError('resources.list requires a resource type', {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'INVALID_TYPE'
+          });
+        }
+        const qs = this.serializeQuery(query);
+        try {
+          const result = await firstValueFrom(
+            this.signalk.api.get(
+              this.app.skApiVersion,
+              `/resources/${type}${qs}`
+            )
+          );
+          return result ?? {};
+        } catch (err) {
+          throw new RpcError(`resources.list ${type} failed`, {
+            reason: 'LIST_FAILED',
+            data: { message: (err as Error)?.message }
+          });
+        }
+      },
+      'resources.setFilter': async (params) => {
+        const { type, filter } = (params ?? {}) as {
+          type?: string;
+          filter?: ResourceFilterSpec;
+        };
+        if (
+          typeof type !== 'string' ||
+          !filter ||
+          (filter.mode !== 'include' && filter.mode !== 'exclude') ||
+          (filter.ids === undefined && filter.match === undefined) ||
+          (filter.ids !== undefined &&
+            (!Array.isArray(filter.ids) ||
+              !filter.ids.every((id) => typeof id === 'string'))) ||
+          (filter.match !== undefined && !Array.isArray(filter.match))
+        ) {
+          throw new RpcError(
+            'resources.setFilter requires a type and a filter with mode plus ids and/or match',
+            { code: RPC_ERRORS.INVALID_PARAMS, reason: 'INVALID_FILTER' }
+          );
+        }
+        this.setResourceFilter(extension, type, filter);
+        return {};
+      },
+      'resources.clearFilter': async (params) => {
+        const { type } = (params ?? {}) as { type?: string };
+        if (typeof type !== 'string') {
+          throw new RpcError('resources.clearFilter requires a type', {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'INVALID_TYPE'
+          });
+        }
+        this.clearResourceFilter(extension, type);
+        return {};
+      }
+    };
+  }
+
+  private serializeQuery(query?: Record<string, unknown>): string {
+    if (!query || typeof query !== 'object') return '';
+    const parts: string[] = [];
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      const serialized = Array.isArray(value)
+        ? JSON.stringify(value)
+        : String(value);
+      parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(serialized)}`);
+    }
+    return parts.length ? `?${parts.join('&')}` : '';
+  }
+
+  // ---------- map host API ----------
+  //
+  // Map moves are routed through the host's own centering path
+  // (AppFacade.mapMoveRequest -> AppComponent effect -> centerAndZoom), not
+  // by reaching into the OpenLayers view directly. Driving the OL view
+  // directly bypasses Freeboard's mapCenter/mapZoom signal flow, so chart
+  // and resource layers do not refresh after the move.
+
+  private mapMethods(): Record<string, MethodHandler> {
+    return {
+      'map.getView': async () => {
+        return {
+          center: this.app.config.map.center,
+          zoom: this.app.config.map.zoomLevel,
+          bounds: this.app.mapExtent()
+        };
+      },
+      'map.center': async (params) => {
+        const { position, zoom } = (params ?? {}) as {
+          position?: [number, number];
+          zoom?: number;
+        };
+        if (
+          !Array.isArray(position) ||
+          position.length !== 2 ||
+          !position.every((v) => typeof v === 'number')
+        ) {
+          throw new RpcError('map.center requires position [lon, lat]', {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'INVALID_POSITION'
+          });
+        }
+        this.app.mapMoveRequest.set({
+          center: position as [number, number],
+          ...(typeof zoom === 'number' ? { zoom } : {})
+        });
+        return {};
+      },
+      'map.fitBounds': async (params) => {
+        const { bounds } = (params ?? {}) as { bounds?: number[] };
+        if (
+          !Array.isArray(bounds) ||
+          bounds.length !== 4 ||
+          !bounds.every((v) => typeof v === 'number')
+        ) {
+          throw new RpcError(
+            'map.fitBounds requires bounds [minLon, minLat, maxLon, maxLat]',
+            { code: RPC_ERRORS.INVALID_PARAMS, reason: 'INVALID_BOUNDS' }
+          );
+        }
+        const [minLon, minLat, maxLon, maxLat] = bounds as number[];
+        const center: [number, number] = [
+          (minLon + maxLon) / 2,
+          (minLat + maxLat) / 2
+        ];
+        this.app.mapMoveRequest.set({
+          center,
+          zoom: this.zoomForBounds(bounds as number[])
+        });
+        return {};
+      }
+    };
+  }
+
+  /**
+   * Compute a zoom level that frames a lon/lat bounding box in the current
+   * viewport (read-only use of the OL view). Falls back to a reasonable
+   * zoom when the map is unavailable.
+   */
+  private zoomForBounds(bounds: number[]): number {
+    const map = this.mapService.getMaps()[0];
+    const size = map?.getSize();
+    if (!map || !size) return 12;
+    const view = map.getView();
+    const ext = transformExtent(bounds, 'EPSG:4326', 'EPSG:3857');
+    // pad by shrinking the usable size ~15% so markers aren't at the edge
+    const padded: [number, number] = [size[0] * 0.85, size[1] * 0.85];
+    const resolution = view.getResolutionForExtent(ext, padded);
+    const zoom = view.getZoomForResolution(resolution) ?? 12;
+    const maxZoom = this.app.MAP_ZOOM_EXTENT?.max ?? 18;
+    return Math.min(zoom, maxZoom);
+  }
+
+  /**
+   * Pulse OL map.updateSize() across a layout transition (the panel drawer
+   * push), so the map tracks the changing container width smoothly.
+   */
+  pulseMapResize(durationMs = 320) {
+    let elapsed = 0;
+    const step = () => {
+      this.mapService.updateSize();
+      elapsed += 16;
+      if (elapsed < durationMs) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }
+
+  // ---------- unit preferences ----------
+
+  /**
+   * Host API method exposing the user's preferred display units (Freeboard's
+   * Settings -> Units tab) so extensions can pick sensible conversions.
+   * Vocabulary follows Freeboard's settings values:
+   *   speed: 'kn' | 'm/s' | 'km/h' | 'mph'
+   *   distance: 'kilometer' | 'naut-mile'
+   *   depth / length: 'm' | 'foot'
+   *   temperature: 'C' | 'F'
+   */
+  private unitsMethods(): Record<string, MethodHandler> {
+    return {
+      'units.get': async () => {
+        const u = this.app.config.units;
+        return {
+          units: {
+            speed: u.speed,
+            distance: u.distance,
+            depth: u.depth,
+            length: u.length,
+            temperature: u.temperature
+          }
+        };
+      }
+    };
+  }
+
+  // ---------- Signal K relay ----------
+
+  private signalkMethods(ctx: LiveContext): Record<string, MethodHandler> {
+    return {
+      'signalk.subscribe': async (params) => {
+        const { paths } = (params ?? {}) as { paths?: unknown };
+        if (
+          !Array.isArray(paths) ||
+          paths.length === 0 ||
+          !paths.every(
+            (p) => typeof p === 'string' && p.length > 0 && !p.includes('*')
+          )
+        ) {
+          throw new RpcError(
+            'signalk.subscribe requires an array of literal Signal K paths',
+            { code: RPC_ERRORS.INVALID_PARAMS, reason: 'INVALID_PATHS' }
+          );
+        }
+        const subscriptionId = `sk-${++ctx.skSubSeq}`;
+        ctx.skSubs.set(subscriptionId, paths as string[]);
+        this.acquirePaths(paths as string[]);
+        return { subscriptionId };
+      },
+      'signalk.unsubscribe': async (params) => {
+        const { subscriptionId } = (params ?? {}) as {
+          subscriptionId?: string;
+        };
+        const paths = subscriptionId ? ctx.skSubs.get(subscriptionId) : null;
+        if (!paths) {
+          throw new RpcError('Unknown subscriptionId', {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'UNKNOWN_SUBSCRIPTION'
+          });
+        }
+        ctx.skSubs.delete(subscriptionId as string);
+        this.releasePaths(paths);
+        return {};
+      },
+      'signalk.put': async (params) => {
+        const { path, value } = (params ?? {}) as {
+          path?: string;
+          value?: unknown;
+        };
+        if (typeof path !== 'string' || !path.length) {
+          throw new RpcError('signalk.put requires a path', {
+            code: RPC_ERRORS.INVALID_PARAMS,
+            reason: 'INVALID_PATH'
+          });
+        }
+        try {
+          const result = await firstValueFrom(
+            this.signalk.api.put(
+              1,
+              `vessels/self/${path.split('.').join('/')}`,
+              value
+            )
+          );
+          return result ?? {};
+        } catch (err) {
+          throw new RpcError(`PUT ${path} failed`, {
+            reason: 'PUT_FAILED',
+            data: { message: (err as Error)?.message }
+          });
+        }
+      }
+    };
+  }
+
+  private acquirePaths(paths: string[]) {
+    const fresh: string[] = [];
+    for (const path of paths) {
+      const count = this.pathRefs.get(path) ?? 0;
+      this.pathRefs.set(path, count + 1);
+      if (count === 0) fresh.push(path);
+    }
+    if (fresh.length) {
+      this.ensureSocket();
+      this.sendSubscribe(fresh);
+    }
+  }
+
+  private releasePaths(paths: string[]) {
+    const gone: string[] = [];
+    for (const path of paths) {
+      const count = this.pathRefs.get(path) ?? 0;
+      if (count <= 1) {
+        this.pathRefs.delete(path);
+        gone.push(path);
+      } else {
+        this.pathRefs.set(path, count - 1);
+      }
+    }
+    if (gone.length && this.wsReady) {
+      this.wsSend({
+        context: 'vessels.self',
+        unsubscribe: gone.map((path) => ({ path }))
+      });
+    }
+    if (this.pathRefs.size === 0) {
+      this.closeSocket();
+    }
+  }
+
+  private ensureSocket() {
+    if (this.ws) return;
+    const endpoint = this.app.data?.server
+      ? this.signalk.server?.endpoints?.['v1']?.['signalk-ws']
+      : null;
+    if (!endpoint) {
+      console.warn('plotterext: no signalk-ws endpoint available');
+      return;
+    }
+    let url = `${endpoint}?subscribe=none`;
+    const token = this.app.getFBToken();
+    if (token) {
+      url += `&token=${token}`;
+    }
+    const ws = new WebSocket(url);
+    this.ws = ws;
+    ws.onopen = () => {
+      this.wsReady = true;
+      const paths = [...this.pathRefs.keys()];
+      if (paths.length) this.sendSubscribe(paths);
+    };
+    ws.onmessage = (ev) => this.handleDelta(ev.data);
+    ws.onclose = () => {
+      if (this.ws !== ws) return;
+      this.ws = null;
+      this.wsReady = false;
+      if (this.pathRefs.size && !this.reconnectTimer) {
+        this.reconnectTimer = setTimeout(() => {
+          this.reconnectTimer = null;
+          this.ensureSocket();
+        }, 3000);
+      }
+    };
+    ws.onerror = () => {
+      // onclose follows; reconnection handled there.
+    };
+  }
+
+  private closeSocket() {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    const ws = this.ws;
+    this.ws = null;
+    this.wsReady = false;
+    ws?.close();
+  }
+
+  private sendSubscribe(paths: string[]) {
+    if (!this.wsReady) return;
+    this.wsSend({
+      context: 'vessels.self',
+      subscribe: paths.map((path) => ({
+        path,
+        period: SK_PATH_PERIOD,
+        policy: 'instant',
+        minPeriod: 200
+      }))
+    });
+  }
+
+  private wsSend(msg: unknown) {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  private handleDelta(raw: unknown) {
+    let delta: {
+      updates?: Array<{
+        timestamp?: string;
+        $source?: string;
+        source?: { label?: string };
+        values?: Array<{ path: string; value: unknown }>;
+      }>;
+    };
+    try {
+      delta = JSON.parse(raw as string);
+    } catch {
+      return;
+    }
+    if (!Array.isArray(delta.updates)) return;
+    for (const update of delta.updates) {
+      if (!Array.isArray(update.values)) continue;
+      for (const pv of update.values) {
+        if (!pv?.path || !this.pathRefs.has(pv.path)) continue;
+        const event = {
+          path: pv.path,
+          value: pv.value,
+          timestamp: update.timestamp,
+          $source: update.$source ?? update.source?.label
+        };
+        for (const ctx of this.contexts) {
+          ctx.conn.publish(`sk.${pv.path}`, event);
+        }
+      }
+    }
+  }
+}

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -23,6 +23,7 @@ import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { firstValueFrom } from 'rxjs';
 import { SignalKClient } from 'signalk-client-angular';
 import { transformExtent } from 'ol/proj';
+import * as uuid from 'uuid';
 
 import { AppFacade } from 'src/app/app.facade';
 import { SKResourceService } from 'src/app/modules/skresources/resources.service';
@@ -59,6 +60,30 @@ import {
 const STATE_STORAGE_KEY = 'fb-plotterext-state';
 const SK_PATH_PERIOD = 1000; // default delta period (ms) for relayed paths
 
+// Recognised resources.setFilter condition operators (see ResourceFilterCondition).
+const FILTER_OPS = new Set([
+  'eq',
+  'ne',
+  'lt',
+  'lte',
+  'gt',
+  'gte',
+  'in',
+  'contains',
+  'regex',
+  'exists'
+]);
+
+// A match condition is only safe to store/evaluate if it has a string path and
+// a known operator; evalCondition() does `cond.path.split('.')`, so a malformed
+// entry (e.g. {}) would throw during change detection.
+const isValidFilterCondition = (c: unknown): boolean =>
+  !!c &&
+  typeof c === 'object' &&
+  typeof (c as { path?: unknown }).path === 'string' &&
+  (c as { path: string }).path.length > 0 &&
+  FILTER_OPS.has((c as { op?: unknown }).op as string);
+
 interface ExtensionStateStore {
   [extensionId: string]: {
     extension?: Record<string, unknown>;
@@ -82,12 +107,18 @@ export class PlotterExtensionService {
   readonly activeWidgets = signal<PlacedWidget[]>([]);
   readonly initialized = signal(false);
 
+  // Bumped on window resize so the size-derived offset computeds below — which
+  // call cellHeightPx() (reads window.innerWidth) — re-evaluate after an
+  // orientation/viewport change, not only when widget state changes.
+  private readonly viewportTick = signal(0);
+
   /**
    * Bottom offset (px) for host chrome that normally lives in the
    * bottom-right corner (Freeboard's action button): 0 when no widgets
    * occupy the bottom-right anchor, otherwise just above the occupied rows.
    */
   readonly actionButtonLift = computed(() => {
+    this.viewportTick();
     const br = this.activeWidgets().filter((p) => p.anchor === 'br');
     if (!br.length) return 0;
     const rows = br.some((p) => p.row === 0) ? 2 : 1;
@@ -101,6 +132,7 @@ export class PlotterExtensionService {
    * against the screen bottom). Mirrors actionButtonLift for the bottom-right.
    */
   readonly statusBarLift = computed(() => {
+    this.viewportTick();
     const cb = this.activeWidgets().filter((p) => p.anchor === 'cb');
     if (!cb.length) return 0;
     const rows = cb.some((p) => p.row === 0) ? 2 : 1;
@@ -116,6 +148,7 @@ export class PlotterExtensionService {
    * row 1. Mirrors actionButtonLift/statusBarLift.
    */
   readonly toolbarTopOffset = computed(() => {
+    this.viewportTick();
     const tr = this.activeWidgets().filter((p) => p.anchor === 'tr');
     if (!tr.length) return 0;
     const rows = tr.some((p) => p.row === 1) ? 2 : 1;
@@ -203,29 +236,50 @@ export class PlotterExtensionService {
     const manifest = this.manifests()[extension];
     const panel = manifest?.panels?.find((p) => p.id === panelId);
     if (!panel || panel.type !== 'iframe' || !panel.url) return false;
+    // Skip a contribution that targets a newer host API than we implement.
+    if (
+      panel.apiVersion !== undefined &&
+      panel.apiVersion !== HOST_API_VERSION
+    ) {
+      return false;
+    }
     const key = `${extension}/${panelId}`;
     this.openPanels.update((panels) => {
-      const existing = panels.find((p) => p.key === key);
-      if (existing) {
-        return panels.map((p) => ({ ...p, visible: p.key === key }));
+      // Keep the target plus any keepAlive panels; drop non-keepAlive panels
+      // that are being hidden so their iframe/timers/subscriptions are torn
+      // down (matches the documented panel lifecycle).
+      const retained = panels
+        .filter((p) => p.key === key || p.panel.lifecycle === 'keepAlive')
+        .map((p) => ({ ...p, visible: p.key === key }));
+      if (retained.some((p) => p.key === key)) {
+        return retained;
       }
-      return [
-        ...panels.map((p) => ({ ...p, visible: false })),
-        { key, extension, panel, visible: true }
-      ];
+      return [...retained, { key, extension, panel, visible: true }];
     });
     return true;
   }
 
   /** Close the visible drawer panel (hide keepAlive, destroy others). */
   closeVisiblePanel() {
+    const visible = this.openPanels().find((p) => p.visible);
+    if (visible) this.closePanel(visible.key);
+  }
+
+  /**
+   * Close a specific drawer panel by key (hide if keepAlive, destroy
+   * otherwise). Used by `ui.closePanel` so a panel — including a hidden
+   * keepAlive one — closes itself rather than whichever panel is visible.
+   */
+  closePanel(key: string) {
     this.openPanels.update((panels) => {
-      const visible = panels.find((p) => p.visible);
-      if (!visible) return panels;
-      if (visible.panel.lifecycle === 'keepAlive') {
-        return panels.map((p) => ({ ...p, visible: false }));
+      const target = panels.find((p) => p.key === key);
+      if (!target) return panels;
+      if (target.panel.lifecycle === 'keepAlive') {
+        return panels.map((p) =>
+          p.key === key ? { ...p, visible: false } : p
+        );
       }
-      return panels.filter((p) => p.key !== visible.key);
+      return panels.filter((p) => p.key !== key);
     });
   }
 
@@ -381,9 +435,7 @@ export class PlotterExtensionService {
       matches = spec.ids.includes(id);
     }
     if (matches && spec.match) {
-      matches = spec.match.every((cond) =>
-        this.evalCondition(cond, resource)
-      );
+      matches = spec.match.every((cond) => this.evalCondition(cond, resource));
     }
     return spec.mode === 'exclude' ? !matches : matches;
   }
@@ -422,15 +474,16 @@ export class PlotterExtensionService {
         );
       case 'contains':
         if (typeof value === 'string') {
-          return value
-            .toLowerCase()
-            .includes(String(cond.value).toLowerCase());
+          return value.toLowerCase().includes(String(cond.value).toLowerCase());
         }
         return Array.isArray(value) && value.includes(cond.value);
       case 'regex': {
         if (typeof value !== 'string' || typeof cond.value !== 'string') {
           return false;
         }
+        // Bound tested input length as a second ReDoS safeguard (resource
+        // fields are short; anything larger is not worth matching here).
+        if (value.length > 2000) return false;
         const re = this.compileRegex(cond.value);
         return re ? re.test(value) : false;
       }
@@ -461,7 +514,11 @@ export class PlotterExtensionService {
    * `namespace:id` values participate; everything else compares strictly.
    * `exact` opts out of the tolerance and compares strictly.
    */
-  private refEquals(stored: unknown, target: unknown, exact?: boolean): boolean {
+  private refEquals(
+    stored: unknown,
+    target: unknown,
+    exact?: boolean
+  ): boolean {
     if (stored === target) return true;
     if (exact) return false;
     // bare target id vs qualified stored reference
@@ -475,8 +532,14 @@ export class PlotterExtensionService {
     return false;
   }
 
-  /** Compile a filter regex; invalid patterns make the condition false. */
+  /**
+   * Compile a filter regex; invalid or oversized patterns make the condition
+   * false. Patterns come from extension filter specs and run synchronously in
+   * the visibleNotes computed during change detection, so the length bound
+   * limits ReDoS exposure (paired with an input-length bound at the call site).
+   */
   private compileRegex(pattern: string): RegExp | null {
+    if (pattern.length > 200) return null;
     try {
       return new RegExp(pattern);
     } catch {
@@ -503,13 +566,22 @@ export class PlotterExtensionService {
       // console handle for exercising the host API during development
       (window as unknown as Record<string, unknown>)['fbPlotterExt'] = this;
     }
+    // Recompute size-derived widget offsets on viewport/orientation changes.
+    // The service is an app-lifetime root singleton, so this listener lives for
+    // the session by design.
+    window.addEventListener('resize', () =>
+      this.viewportTick.update((n) => n + 1)
+    );
   }
 
   /** Fetch manifests. Called after the server connection is established. */
   async init(): Promise<void> {
     try {
       const response = await firstValueFrom(
-        this.signalk.api.get(this.app.skApiVersion, '/resources/plotterExtensions')
+        this.signalk.api.get(
+          this.app.skApiVersion,
+          '/resources/plotterExtensions'
+        )
       );
       const manifests: Record<string, PlotterExtensionManifest> = {};
       if (response && typeof response === 'object') {
@@ -621,7 +693,9 @@ export class PlotterExtensionService {
     const rowCount = ANCHOR_GRID[anchor].rows;
     const ascending = Array.from({ length: rowCount }, (_, i) => i);
     const rows =
-      ANCHOR_GRAVITY[anchor] === 'bottom' ? [...ascending].reverse() : ascending;
+      ANCHOR_GRAVITY[anchor] === 'bottom'
+        ? [...ascending].reverse()
+        : ascending;
     const cols = ANCHOR_COL_ORDER[anchor];
     const order: Array<{ col: number; row: number }> = [];
     for (const row of rows) {
@@ -746,9 +820,8 @@ export class PlotterExtensionService {
   ) {
     const candidates = this.addableWidgets(anchor, cell);
     if (!candidates.length) return;
-    const { PlotterAddWidgetDialog } = await import(
-      './add-widget-dialog.component'
-    );
+    const { PlotterAddWidgetDialog } =
+      await import('./add-widget-dialog.component');
     this.dialog
       .open(PlotterAddWidgetDialog, {
         data: { anchor, candidates },
@@ -777,7 +850,10 @@ export class PlotterExtensionService {
     origin: { col: number; row: number }
   ): PlacedWidget {
     const placed: PlacedWidget = {
-      instanceId: crypto.randomUUID(),
+      // uuid.v4() (not crypto.randomUUID) so placement works on plain-HTTP
+      // origins too — crypto.randomUUID is secure-context only (boat LANs
+      // are often http://<ip>).
+      instanceId: uuid.v4(),
       extension,
       widget: widget.id,
       anchor,
@@ -809,7 +885,11 @@ export class PlotterExtensionService {
         return (
           manifest &&
           this.isCompatible(manifest) &&
-          manifest.widgets?.some((w) => w.id === p.widget)
+          manifest.widgets?.some(
+            (w) =>
+              w.id === p.widget &&
+              (w.apiVersion === undefined || w.apiVersion === HOST_API_VERSION)
+          )
         );
       })
     );
@@ -825,9 +905,22 @@ export class PlotterExtensionService {
   resolveAssetUrl(url: string): string {
     const base = this.app.hostDef?.url || window.location.origin;
     try {
-      return new URL(url, base).toString();
+      const baseUrl = new URL(base);
+      const resolved = new URL(url, base);
+      // The result feeds bypassSecurityTrustResourceUrl() in the iframe hosts,
+      // so only trust http(s) assets — reject javascript:, data:, blob:, etc.
+      if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
+        return 'about:blank';
+      }
+      // Manifest assets are server-relative; reject anything that resolves to a
+      // different origin so a manifest cannot point the host (and its trusted
+      // RPC surface) at an external server.
+      if (resolved.origin !== baseUrl.origin) {
+        return 'about:blank';
+      }
+      return resolved.toString();
     } catch {
-      return url;
+      return 'about:blank';
     }
   }
 
@@ -851,7 +944,8 @@ export class PlotterExtensionService {
       skSubs: new Map(),
       skSubSeq: 0
     };
-    const widgetUrl = this.widgetDef(placed.extension, placed.widget)?.url ?? '';
+    const widgetUrl =
+      this.widgetDef(placed.extension, placed.widget)?.url ?? '';
     ctx.conn = new HostConnection({
       port: windowPort(iframe.contentWindow as Window, {
         origin: this.assetOrigin(widgetUrl)
@@ -1013,9 +1107,15 @@ export class PlotterExtensionService {
     const widget = this.widgetDef(placed.extension, placed.widget);
     const found = manifest?.panels?.find((p) => p.id === widget?.configPanel);
     // A widget with no usable config panel still gets a dialog so it can be
-    // removed (long-press affordance applies to every placed widget).
+    // removed (long-press affordance applies to every placed widget). A panel
+    // targeting a newer host API is treated as absent so it is not loaded.
     const panel =
-      found && found.type === 'iframe' && found.url ? found : null;
+      found &&
+      found.type === 'iframe' &&
+      found.url &&
+      (found.apiVersion === undefined || found.apiVersion === HOST_API_VERSION)
+        ? found
+        : null;
     // Deferred import avoids a service->component->service import cycle.
     import('./panel-dialog.component').then(({ PlotterPanelDialog }) => {
       const ref = this.dialog.open(PlotterPanelDialog, {
@@ -1045,7 +1145,10 @@ export class PlotterExtensionService {
    * open for that instance, otherwise open it.
    */
   toggleConfigPanel(placed: PlacedWidget) {
-    if (this.configDialogRef && this.configDialogInstance === placed.instanceId) {
+    if (
+      this.configDialogRef &&
+      this.configDialogInstance === placed.instanceId
+    ) {
       this.configDialogRef.close();
       return;
     }
@@ -1087,7 +1190,8 @@ export class PlotterExtensionService {
       scope: string | undefined
     ): Record<string, unknown> => {
       const extStore = (store[extension] = store[extension] ?? {});
-      const useInstance = (scope ?? (instanceId ? 'instance' : 'extension')) === 'instance';
+      const useInstance =
+        (scope ?? (instanceId ? 'instance' : 'extension')) === 'instance';
       if (useInstance) {
         if (!instanceId) {
           throw new RpcError('No widget instance in scope', {
@@ -1143,7 +1247,11 @@ export class PlotterExtensionService {
     };
   }
 
-  private publishToExtension(extension: string, event: string, params: unknown) {
+  private publishToExtension(
+    extension: string,
+    event: string,
+    params: unknown
+  ) {
     for (const ctx of this.contexts) {
       if (ctx.extension === extension) {
         ctx.conn.publish(event, params);
@@ -1174,7 +1282,10 @@ export class PlotterExtensionService {
           type?: string;
           query?: Record<string, unknown>;
         };
-        if (typeof type !== 'string' || !/^[A-Za-z][A-Za-z0-9_-]*$/.test(type)) {
+        if (
+          typeof type !== 'string' ||
+          !/^[A-Za-z][A-Za-z0-9_-]*$/.test(type)
+        ) {
           throw new RpcError('resources.list requires a resource type', {
             code: RPC_ERRORS.INVALID_PARAMS,
             reason: 'INVALID_TYPE'
@@ -1209,7 +1320,9 @@ export class PlotterExtensionService {
           (filter.ids !== undefined &&
             (!Array.isArray(filter.ids) ||
               !filter.ids.every((id) => typeof id === 'string'))) ||
-          (filter.match !== undefined && !Array.isArray(filter.match))
+          (filter.match !== undefined &&
+            (!Array.isArray(filter.match) ||
+              !filter.match.every(isValidFilterCondition)))
         ) {
           throw new RpcError(
             'resources.setFilter requires a type and a filter with mode plus ids and/or match',
@@ -1241,7 +1354,9 @@ export class PlotterExtensionService {
       const serialized = Array.isArray(value)
         ? JSON.stringify(value)
         : String(value);
-      parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(serialized)}`);
+      parts.push(
+        `${encodeURIComponent(key)}=${encodeURIComponent(serialized)}`
+      );
     }
     return parts.length ? `?${parts.join('&')}` : '';
   }

--- a/src/app/modules/plotterext/types.ts
+++ b/src/app/modules/plotterext/types.ts
@@ -1,0 +1,227 @@
+// Types for the plotter extension host (plotterExtensions resource type).
+// Mirrors the plotter extension provider specification. Declared locally so
+// the branch does not depend on a server-api release.
+
+export const PLOTTER_EXTENSIONS_RESOURCE = 'plotterExtensions';
+
+/** Host API major version implemented by this Freeboard build. */
+export const HOST_API_VERSION = '1';
+
+/** Capabilities advertised by this host build. */
+export const HOST_CAPABILITIES = [
+  'widgets',
+  'panels.iframe',
+  'buttons',
+  'signalk.stream',
+  'signalk.put',
+  'units',
+  'map',
+  'resources',
+  'resources.filter',
+  'background.iframe',
+  'ui'
+];
+
+export type WidgetSize = '1x1' | '2x1' | '1x2' | '2x2';
+
+/**
+ * Widget anchor areas. The upper-left corner is deliberately not offered —
+ * Freeboard's own controls live there.
+ */
+export type AnchorId = 'tr' | 'ct' | 'cb' | 'bl' | 'br';
+
+export const ANCHORS: AnchorId[] = ['tr', 'ct', 'cb', 'bl', 'br'];
+
+export const ANCHOR_LABELS: Record<AnchorId, string> = {
+  tr: 'Top right',
+  ct: 'Top center',
+  cb: 'Bottom center',
+  bl: 'Bottom left',
+  br: 'Bottom right'
+};
+
+/**
+ * Vertical packing direction: widgets build from the screen edge of their
+ * anchor inward ("bottom up" for bottom anchors, top down for top anchors).
+ * The gravity row must fill before a widget may sit in the other row.
+ */
+export const ANCHOR_GRAVITY: Record<AnchorId, 'top' | 'bottom'> = {
+  tr: 'top',
+  ct: 'top',
+  cb: 'bottom',
+  bl: 'bottom',
+  br: 'bottom'
+};
+
+/**
+ * Per-anchor grid dimensions (cols x rows). Corners are 4 wide so up to eight
+ * 1x1 (or four 2x1) widgets can stack there; the center anchors stay 2 wide.
+ * Rows are 2 everywhere — widgets are never taller than the gravity stack.
+ */
+export const ANCHOR_GRID: Record<AnchorId, { cols: number; rows: number }> = {
+  tr: { cols: 4, rows: 2 },
+  ct: { cols: 2, rows: 2 },
+  cb: { cols: 2, rows: 2 },
+  bl: { cols: 4, rows: 2 },
+  br: { cols: 4, rows: 2 }
+};
+
+/** Horizontal packing direction per anchor (toward the screen corner first). */
+const ANCHOR_COL_FILL: Record<AnchorId, 'left' | 'right'> = {
+  tr: 'right',
+  ct: 'left',
+  cb: 'left',
+  bl: 'left',
+  br: 'right'
+};
+
+/**
+ * Preferred column fill order per anchor (toward the screen corner first),
+ * derived from the anchor's width and packing direction.
+ */
+export const ANCHOR_COL_ORDER: Record<AnchorId, number[]> = ANCHORS.reduce(
+  (acc, anchor) => {
+    const cols = Array.from({ length: ANCHOR_GRID[anchor].cols }, (_, i) => i);
+    acc[anchor] = ANCHOR_COL_FILL[anchor] === 'right' ? cols.reverse() : cols;
+    return acc;
+  },
+  {} as Record<AnchorId, number[]>
+);
+
+export interface WidgetContribution {
+  id: string;
+  title: string;
+  type: 'iframe';
+  url: string;
+  size: WidgetSize;
+  configPanel?: string;
+  lifecycle?: string;
+  apiVersion?: string;
+}
+
+export interface ButtonContribution {
+  id: string;
+  title: string;
+  slot?: string;
+  /** Material icon name rendered by this host (generic `symbol` refs TBD). */
+  icon?: string;
+  symbol?: string;
+  /**
+   * Button action. `openPanel`/`togglePanel` target a `panel` from the same
+   * manifest. `sendMessage` publishes `topic` (with optional `params`) onto
+   * the host message bus, delivered to every live extension context
+   * subscribed to that topic (typically the extension's own background
+   * runtime).
+   */
+  action?: { type: string; panel?: string; topic?: string; params?: unknown };
+  apiVersion?: string;
+}
+
+export interface ResourceFilterCondition {
+  path: string;
+  op:
+    | 'eq'
+    | 'ne'
+    | 'lt'
+    | 'lte'
+    | 'gt'
+    | 'gte'
+    | 'in'
+    | 'contains'
+    | 'regex'
+    | 'exists';
+  value?: unknown;
+  /**
+   * For eq/ne/in: when true, compare strictly and skip the namespace-tolerant
+   * symbol-reference matching (so `anchorage` will NOT match `default:anchorage`).
+   * Absent/false keeps the tolerant default. Ignored by other ops.
+   */
+  exact?: boolean;
+}
+
+export interface ResourceFilterSpec {
+  mode: 'include' | 'exclude';
+  ids?: string[];
+  match?: ResourceFilterCondition[];
+  label?: string;
+}
+
+/**
+ * A headless background runtime: a hidden iframe loaded while the extension is
+ * present, with no UI. It runs the same bus client as widgets/panels and may
+ * call the host API (state, signalk, resources, filters, map), letting a panel
+ * close itself while a client-side service keeps state and work alive.
+ */
+export interface BackgroundContribution {
+  id: string;
+  title?: string;
+  type: 'iframe';
+  url: string;
+  lifecycle?: string;
+  apiVersion?: string;
+}
+
+export interface PanelContribution {
+  id: string;
+  title: string;
+  type: 'iframe' | 'customElement';
+  url?: string;
+  moduleUrl?: string;
+  tagName?: string;
+  lifecycle?: string;
+  apiVersion?: string;
+}
+
+export interface PlotterExtensionManifest {
+  name: string;
+  description?: string;
+  version?: string;
+  apiVersion: string;
+  requires?: string[];
+  optional?: string[];
+  widgets?: WidgetContribution[];
+  panels?: PanelContribution[];
+  buttons?: ButtonContribution[];
+  background?: BackgroundContribution[];
+  // Future contribution sections (buttons, background, resourceFilters) are
+  // tolerated but not consumed by this build.
+  [key: string]: unknown;
+}
+
+/** A widget placement persisted in app config (see IAppConfig). */
+export interface PlacedWidget {
+  instanceId: string;
+  extension: string;
+  widget: string;
+  anchor: AnchorId;
+  col: number;
+  row: number;
+}
+
+/** A widget that could be added at a pressed anchor cell. */
+export interface WidgetCandidate {
+  extension: string;
+  extensionName: string;
+  widget: WidgetContribution;
+  origin: { col: number; row: number };
+}
+
+/** Grid gap in px. Keep in sync with --pe-gap in the overlay component. */
+export const WIDGET_CELL_GAP = 6;
+
+/**
+ * Widget cell height in px for the current viewport. Keep in sync with
+ * --pe-cell-h (clamp(84px, 9.5vw, 124px)) in the overlay component.
+ */
+export function cellHeightPx(): number {
+  return Math.min(124, Math.max(84, 0.095 * window.innerWidth));
+}
+
+export function parseSize(size: WidgetSize | string): {
+  cols: number;
+  rows: number;
+} {
+  const m = /^([12])x([12])$/.exec(size ?? '');
+  if (!m) return { cols: 1, rows: 1 };
+  return { cols: Number(m[1]), rows: Number(m[2]) };
+}

--- a/src/app/modules/plotterext/widget-frame.component.ts
+++ b/src/app/modules/plotterext/widget-frame.component.ts
@@ -1,0 +1,85 @@
+// One placed widget instance: a sandboxed iframe wired to a HostConnection.
+// The sandbox set follows the spec baseline (fault containment, not a
+// security boundary): scripts + same-origin for Signal K API access + forms;
+// navigation/popups/modals deliberately withheld.
+
+import {
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  input
+} from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { PlotterExtensionService } from './plotterext.service';
+import { PlacedWidget } from './types';
+
+@Component({
+  selector: 'fb-plotterext-widget',
+  imports: [],
+  template: `
+    <iframe
+      #frame
+      [src]="url"
+      sandbox="allow-scripts allow-same-origin allow-forms"
+      [title]="placed().widget"
+      (load)="onFrameLoad()"
+    ></iframe>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+      iframe {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border: none;
+        background: transparent;
+      }
+    `
+  ]
+})
+export class PlotterWidgetFrame implements OnInit, OnDestroy {
+  placed = input.required<PlacedWidget>();
+
+  @ViewChild('frame', { static: true })
+  frame: ElementRef<HTMLIFrameElement>;
+
+  url: SafeResourceUrl;
+  private detach: (() => void) | null = null;
+
+  constructor(
+    private service: PlotterExtensionService,
+    private sanitizer: DomSanitizer
+  ) {}
+
+  ngOnInit() {
+    const def = this.service.widgetDef(
+      this.placed().extension,
+      this.placed().widget
+    );
+    this.url = this.sanitizer.bypassSecurityTrustResourceUrl(
+      def?.url ? this.service.resolveAssetUrl(def.url) : 'about:blank'
+    );
+    // Attach immediately: the bus handshake tolerates either side being
+    // ready first, so there is no load-order race with the iframe.
+    this.detach = this.service.attachWidget(
+      this.frame.nativeElement,
+      this.placed()
+    );
+  }
+
+  onFrameLoad() {
+    // No-op: connection already attached; extension retries bus.ready.
+  }
+
+  ngOnDestroy() {
+    this.detach?.();
+    this.detach = null;
+  }
+}

--- a/src/app/modules/plotterext/widget-overlay.component.ts
+++ b/src/app/modules/plotterext/widget-overlay.component.ts
@@ -1,0 +1,341 @@
+// Widget overlay: a full-map-size layer with a 2x2 widget grid at each
+// anchor position (top-right, top-center, bottom-center, bottom-left,
+// bottom-right — top-left is reserved for Freeboard's own controls).
+//
+// The overlay itself never intercepts pointer events; only placed widget
+// frames do. Adding a widget is a press-and-hold on an EMPTY anchor cell:
+// a document-level capture listener watches presses that geometrically fall
+// inside an anchor area (map interaction underneath is unaffected — the
+// gesture only fires after the pointer stays put for the hold duration).
+
+import {
+  Component,
+  ElementRef,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject
+} from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { PlotterExtensionService } from './plotterext.service';
+import { PlotterWidgetFrame } from './widget-frame.component';
+import { ANCHOR_GRID, ANCHORS, AnchorId, PlacedWidget, parseSize } from './types';
+
+const HOLD_MS = 1500;
+const MOVE_SLOP_PX = 8;
+
+interface CellStyle {
+  [key: string]: string;
+}
+
+@Component({
+  selector: 'fb-plotterext-overlay',
+  imports: [PlotterWidgetFrame, MatIconModule],
+  template: `
+    @if (service.filterChips().length) {
+      <div
+        class="pe-chips"
+        [class.pe-chips-low]="(byAnchor()['ct'] ?? []).length > 0"
+      >
+        @for (chip of service.filterChips(); track chip.type + chip.extension) {
+          <div class="pe-chip">
+            <mat-icon class="pe-chip-icon">filter_alt</mat-icon>
+            <span class="pe-chip-label">{{ chip.label }}</span>
+            <button
+              class="pe-chip-clear"
+              (click)="clearChip(chip)"
+              aria-label="Clear filter"
+            >
+              <mat-icon>close</mat-icon>
+            </button>
+          </div>
+        }
+      </div>
+    }
+    @for (anchor of anchors; track anchor) {
+      <div
+        class="pe-anchor"
+        [class]="'pe-' + anchor"
+        [attr.data-anchor]="anchor"
+        [style]="anchorStyle(anchor)"
+      >
+        @for (placed of byAnchor()[anchor]; track placed.instanceId) {
+          <div class="pe-cell" [style]="cellStyle(placed)">
+            <fb-plotterext-widget [placed]="placed"></fb-plotterext-widget>
+          </div>
+        }
+      </div>
+    }
+  `,
+  styles: [
+    `
+      :host {
+        position: absolute;
+        inset: 0;
+        z-index: 2000;
+        pointer-events: none;
+        /* keep in sync with cellHeightPx()/WIDGET_CELL_GAP in types.ts */
+        --pe-cell-w: clamp(96px, 11vw, 150px);
+        --pe-cell-h: clamp(84px, 9.5vw, 124px);
+        --pe-gap: 6px;
+        --pe-margin: 10px;
+      }
+      .pe-anchor {
+        position: absolute;
+        display: grid;
+        /* grid-template-columns is set per-anchor (see anchorStyle) so corners
+           can be wider than the center anchors */
+        grid-template-rows: repeat(2, var(--pe-cell-h));
+        gap: var(--pe-gap);
+        pointer-events: none;
+      }
+      /* corner areas sit flush against the screen sides; vertical offsets
+         keep clear of Freeboard's top icon row and bottom status bar */
+      .pe-tr {
+        /* flush against the screen top; the right-hand toolbar pushes down to
+           sit below this widget stack (see toolbarTopOffset) */
+        top: 0;
+        right: 0;
+      }
+      .pe-ct {
+        top: 0;
+        left: 50%;
+        transform: translateX(calc(-50% + var(--pe-center-shift, 0px)));
+      }
+      .pe-cb {
+        /* flush against the screen bottom; the Lat/Lon status bar lifts to
+           sit above this widget stack (see statusBarLift) */
+        bottom: 0;
+        left: 50%;
+        transform: translateX(calc(-50% + var(--pe-center-shift, 0px)));
+      }
+      .pe-bl {
+        bottom: 0;
+        left: 0;
+      }
+      .pe-br {
+        bottom: 0;
+        right: 0;
+      }
+      .pe-cell {
+        pointer-events: auto;
+        overflow: hidden;
+        border-radius: 10px;
+        box-shadow: 0 1px 5px rgba(0, 0, 0, 0.35);
+      }
+      /* active resource-filter chips */
+      .pe-chips {
+        position: absolute;
+        top: 8px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        gap: 6px;
+        pointer-events: auto;
+        z-index: 1;
+      }
+      .pe-chips-low {
+        top: calc(2 * var(--pe-cell-h) + var(--pe-gap) + 10px);
+      }
+      .pe-chip {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        background: rgba(20, 26, 32, 0.85);
+        color: #e8edf2;
+        border-radius: 16px;
+        padding: 3px 6px 3px 10px;
+        font-size: 12px;
+        max-width: 320px;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+      }
+      .pe-chip-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+        color: #29b6f6;
+      }
+      .pe-chip-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .pe-chip-clear {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        background: rgba(255, 255, 255, 0.15);
+        color: #e8edf2;
+        border-radius: 50%;
+        width: 20px;
+        height: 20px;
+        padding: 0;
+        cursor: pointer;
+      }
+      .pe-chip-clear mat-icon {
+        font-size: 14px;
+        width: 14px;
+        height: 14px;
+      }
+    `
+  ]
+})
+export class PlotterExtensionOverlay implements OnInit, OnDestroy {
+  anchors = ANCHORS;
+
+  byAnchor = computed(() => {
+    const result: Record<string, PlacedWidget[]> = {};
+    for (const anchor of ANCHORS) result[anchor] = [];
+    for (const placed of this.service.activeWidgets()) {
+      result[placed.anchor]?.push(placed);
+    }
+    return result;
+  });
+
+  protected service = inject(PlotterExtensionService);
+  private zone = inject(NgZone);
+  private host = inject(ElementRef<HTMLElement>);
+
+  private holdTimer: ReturnType<typeof setTimeout> | null = null;
+  private downPoint: { x: number; y: number } | null = null;
+  private onPointerDown = (e: PointerEvent) => this.pointerDown(e);
+  private onPointerMove = (e: PointerEvent) => this.pointerMove(e);
+  private onPointerEnd = () => this.cancelHold();
+  private unregisterHitTester: (() => void) | null = null;
+
+  ngOnInit() {
+    // Expose this overlay's screen->cell hit test to the host service so the
+    // desktop right-click menu can resolve a point to an anchor cell.
+    this.unregisterHitTester = this.service.registerHitTester((x, y) =>
+      this.hitTest(x, y)
+    );
+    // Outside Angular: these fire for every map interaction.
+    this.zone.runOutsideAngular(() => {
+      document.addEventListener('pointerdown', this.onPointerDown, true);
+      document.addEventListener('pointermove', this.onPointerMove, true);
+      document.addEventListener('pointerup', this.onPointerEnd, true);
+      document.addEventListener('pointercancel', this.onPointerEnd, true);
+    });
+  }
+
+  ngOnDestroy() {
+    this.cancelHold();
+    this.unregisterHitTester?.();
+    this.unregisterHitTester = null;
+    document.removeEventListener('pointerdown', this.onPointerDown, true);
+    document.removeEventListener('pointermove', this.onPointerMove, true);
+    document.removeEventListener('pointerup', this.onPointerEnd, true);
+    document.removeEventListener('pointercancel', this.onPointerEnd, true);
+  }
+
+  /**
+   * Center anchors (ct/cb) center their *content* as a unit: when the
+   * placed widgets only use one grid column, the area shifts by half a
+   * column so a lone 1x1 widget sits dead-center, while a 2x1 (or a pair)
+   * is centered as a whole.
+   */
+  anchorStyle(anchor: AnchorId): CellStyle {
+    const style: CellStyle = {
+      'grid-template-columns': `repeat(${ANCHOR_GRID[anchor].cols}, var(--pe-cell-w))`
+    };
+    if (anchor !== 'ct' && anchor !== 'cb') return style;
+    const used = new Set<number>();
+    for (const placed of this.byAnchor()[anchor] ?? []) {
+      const def = this.service.widgetDef(placed.extension, placed.widget);
+      const { cols } = parseSize(def?.size ?? '1x1');
+      for (let c = placed.col; c < placed.col + cols && c < 2; c++) {
+        used.add(c);
+      }
+    }
+    let shift = '0px';
+    if (used.size === 1) {
+      shift = used.has(0)
+        ? 'calc((var(--pe-cell-w) + var(--pe-gap)) / 2)'
+        : 'calc((var(--pe-cell-w) + var(--pe-gap)) / -2)';
+    }
+    style['--pe-center-shift'] = shift;
+    return style;
+  }
+
+  cellStyle(placed: PlacedWidget): CellStyle {
+    const def = this.service.widgetDef(placed.extension, placed.widget);
+    const { cols, rows } = parseSize(def?.size ?? '1x1');
+    return {
+      'grid-column': `${placed.col + 1} / span ${cols}`,
+      'grid-row': `${placed.row + 1} / span ${rows}`
+    };
+  }
+
+  clearChip(chip: { type: string; extension: string }) {
+    this.service.clearResourceFilter(chip.extension, chip.type);
+  }
+
+  // ---------- press-and-hold to add ----------
+
+  private pointerDown(e: PointerEvent) {
+    this.cancelHold();
+    if (!e.isPrimary || (e.pointerType === 'mouse' && e.button !== 0)) return;
+    // Ignore presses on dialogs, menus, or other app chrome — only presses
+    // that reach the map (or empty overlay space) count.
+    const target = e.target as HTMLElement | null;
+    if (
+      target?.closest(
+        '.cdk-overlay-container, mat-dialog-container, button, mat-toolbar, .pe-cell'
+      )
+    ) {
+      return;
+    }
+    const hit = this.hitTest(e.clientX, e.clientY);
+    if (!hit) return;
+    if (this.service.cellOccupied(hit.anchor, hit.cell)) return;
+    this.downPoint = { x: e.clientX, y: e.clientY };
+    this.holdTimer = setTimeout(() => {
+      this.holdTimer = null;
+      this.zone.run(() =>
+        this.service.openAddWidgetPicker(hit.anchor, hit.cell)
+      );
+    }, HOLD_MS);
+  }
+
+  private pointerMove(e: PointerEvent) {
+    if (!this.holdTimer || !this.downPoint) return;
+    const dx = e.clientX - this.downPoint.x;
+    const dy = e.clientY - this.downPoint.y;
+    if (dx * dx + dy * dy > MOVE_SLOP_PX * MOVE_SLOP_PX) this.cancelHold();
+  }
+
+  private cancelHold() {
+    if (this.holdTimer) clearTimeout(this.holdTimer);
+    this.holdTimer = null;
+    this.downPoint = null;
+  }
+
+  private hitTest(
+    x: number,
+    y: number
+  ): { anchor: AnchorId; cell: { col: number; row: number } } | null {
+    const areas = (this.host.nativeElement as HTMLElement).querySelectorAll(
+      '.pe-anchor'
+    );
+    for (const area of Array.from(areas)) {
+      const rect = area.getBoundingClientRect();
+      if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom) {
+        continue;
+      }
+      const anchor = (area as HTMLElement).dataset['anchor'] as AnchorId;
+      const { cols, rows } = ANCHOR_GRID[anchor];
+      const col = Math.min(
+        cols - 1,
+        Math.max(0, Math.floor(((x - rect.left) / rect.width) * cols))
+      );
+      const row = Math.min(
+        rows - 1,
+        Math.max(0, Math.floor(((y - rect.top) / rect.height) * rows))
+      );
+      return { anchor, cell: { col, row } };
+    }
+    return null;
+  }
+}

--- a/src/app/modules/plotterext/widget-overlay.component.ts
+++ b/src/app/modules/plotterext/widget-overlay.component.ts
@@ -20,7 +20,13 @@ import {
 import { MatIconModule } from '@angular/material/icon';
 import { PlotterExtensionService } from './plotterext.service';
 import { PlotterWidgetFrame } from './widget-frame.component';
-import { ANCHOR_GRID, ANCHORS, AnchorId, PlacedWidget, parseSize } from './types';
+import {
+  ANCHOR_GRID,
+  ANCHORS,
+  AnchorId,
+  PlacedWidget,
+  parseSize
+} from './types';
 
 const HOLD_MS = 1500;
 const MOVE_SLOP_PX = 8;
@@ -278,11 +284,13 @@ export class PlotterExtensionOverlay implements OnInit, OnDestroy {
     this.cancelHold();
     if (!e.isPrimary || (e.pointerType === 'mouse' && e.button !== 0)) return;
     // Ignore presses on dialogs, menus, or other app chrome — only presses
-    // that reach the map (or empty overlay space) count.
+    // that reach the map (or empty overlay space) count. This includes the
+    // overlay's own chrome: placed widget cells (.pe-cell) and the filter-chip
+    // bar (.pe-chips, which covers the chip body, label and clear button).
     const target = e.target as HTMLElement | null;
     if (
       target?.closest(
-        '.cdk-overlay-container, mat-dialog-container, button, mat-toolbar, .pe-cell'
+        '.cdk-overlay-container, mat-dialog-container, button, mat-toolbar, .pe-cell, .pe-chips'
       )
     ) {
       return;

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -197,6 +197,19 @@ export interface IAppConfig {
     opacity: number;
   };
   experiments: boolean;
+  plotterExtensions: {
+    // ** plotter extension host (plotterExtensions resource type).
+    // No enabled list: extension availability is controlled on the server
+    // (plugin install/enable); presence in the resources response = enabled.
+    widgets: Array<{
+      instanceId: string; // host-assigned GUID for this placement
+      extension: string; // extension (resource) id
+      widget: string; // manifest-local widget id
+      anchor: 'tr' | 'ct' | 'cb' | 'bl' | 'br';
+      col: number; // origin cell column (0 | 1)
+      row: number; // origin cell row (0 | 1)
+    }>;
+  };
   anchor: {
     radius: number; // most recent anchor radius setting
     setRadius: boolean; // checks inital anchor radius setting


### PR DESCRIPTION
## Summary

Adds **plotter extension** support to Freeboard-SK: a chartplotter-agnostic mechanism that lets Signal K server plugins contribute UI and behavior to the chart screen — on-chart **widgets**, slide-in **panels**, toolbar **buttons**, **resource filters**, and headless **background runtimes** — without Freeboard needing to know anything about the specific plugin.

Extensions are discovered at runtime from a `plotterExtensions` resource provider and run sandboxed in iframes, communicating with the host over a small JSON-RPC-over-`postMessage` bus. **The feature is fully opt-in: with no extension plugins installed, Freeboard behaves exactly as before.**

The API is proposed upstream in **SignalK/signalk-server#2773**.

## How it works

- **Discovery** — the host reads extension manifests from the `plotterExtensions` resource type via the authenticated Signal K resources API. No server upgrade required (works on current servers as a custom resource type).
- **Isolation** — each widget/panel/background runs in a sandboxed iframe; all host interaction goes through the bus (`signalk.stream`, `signalk.put`, `state.*`, `resources.setFilter`, `units.get`, map centering, panel control). A plugin can never reach into Freeboard's DOM.
- **Host surface** — a 5-area on-chart widget grid (corners + top/bottom centre; top-left reserved for Freeboard's menu), a panel drawer, toolbar buttons, and user-clearable resource-filter chips.

## User-facing changes

A new **Screen Widgets** section (see README): press-and-hold (or right-click) an empty anchor area to add a widget; press-and-hold a placed widget to configure or remove it. Layout is persisted. When no extensions are installed, none of this is visible.

![widgets](https://raw.githubusercontent.com/joelkoz/signalk-instrument-widgets/refs/heads/main/docs/screenshots/1_freeboard-widget.png)

## Companion projects

- **Specification:** SignalK/signalk-server#2773 (proposed API doc).
- **Protocol:** [`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus) — the host/extension bus (JSON-RPC 2.0 over postMessage).
- **Reference extensions:** [`signalk-instrument-widgets`](https://github.com/joelkoz/signalk-instrument-widgets) (widget surface) and [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search) (panel + resource-filter surface).

## Compatibility

Additive and opt-in. New code is isolated in `src/app/modules/plotterext/`; touch-points in existing files are minimal (`app.component`, `fb-map.component`, app config). No existing behavior changes when no extension is present.

## Testing

Verified end-to-end against a local Signal K dev server with the two reference extensions installed: widget add/configure/remove, panel open/close, toolbar buttons, resource-filter chips, background runtime, and programmatic map centering. Build and typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chart screen widgets with placement in corner and center anchor areas.
  * Users can add widgets via right-click context menu or press-and-hold on an empty anchor spot.
  * Added extension UI: per-widget configuration panels in a right-side drawer, plus extension toolbar buttons.
* **Bug Fixes**
  * Improved chart layout so overlays and controls resize/offset correctly when extension panels are shown.
  * Widget layouts persist across app launches (including config migration).
* **Documentation**
  * Updated README with “Screen Widgets” setup and usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->