### PR TITLE
fix(radar): guard OffscreenCanvas access for non-WebGL environments

### DIFF
--- a/src/app/modules/radar/radar-api.service.ts
+++ b/src/app/modules/radar/radar-api.service.ts
@@ -115,6 +115,10 @@ export class RadarAPIService {
   }
 
   private testForWebGL(): boolean {
+    if (typeof OffscreenCanvas === 'undefined') {
+      console.warn('[FreeBoardSK] OffscreenCanvas not available — WebGL radar display disabled');
+      return false;
+    }
     let gl = new OffscreenCanvas(10, 10).getContext('webgl2');
     const result = gl ? true : false;
     if (gl) {


### PR DESCRIPTION
Closes #399.

## Summary

`RadarAPIService.testForWebGL()` called `new OffscreenCanvas(10, 10)` unconditionally. In environments where the API is absent the constructor threw a `ReferenceError` that propagated through Angular DI and prevented the app from starting.

- Add a `typeof` guard so `testForWebGL()` returns `false` cleanly when `OffscreenCanvas` is unavailable
- Emit a single `console.warn` as a breadcrumb for users and contributors diagnosing an inactive radar panel

## How it was found

The new `ci.yml` plugin-ci workflow runs `npm test` for the first time (previous `main.yaml` only ran the build). The radar service was introduced in `2.24.0` so this had not been caught before.

## Test plan
- [x] `npm test` passes locally with the guard in place (32/33 → 33/33)
- [ ] CI green on all platforms