### PR TITLE
test: extend vitest timeout for emulated armv7 (Cerbo GX) CI

### DIFF
--- a/vitest-base.config.ts
+++ b/vitest-base.config.ts
@@ -2,8 +2,15 @@
 
 import { defineConfig } from 'vitest/config';
 
+// The armv7 (Cerbo GX) CI job runs the suite under QEMU emulation, which is
+// ~10-20x slower than native and pushes the AppComponent bootstrap test past
+// the 5s default. Only 32-bit ARM (process.arch === 'arm') gets the larger
+// budget; native platforms keep the strict default so real hangs still surface.
+const TEST_TIMEOUT_MS = process.arch === 'arm' ? 20_000 : 5_000;
+
 export default defineConfig({
   test: {
+    testTimeout: TEST_TIMEOUT_MS,
     setupFiles: [
       'vitest-setup.js',
       '@vitest/web-worker'


### PR DESCRIPTION
## Problem

The `armv7 (Cerbo GX) / Node 20` CI job fails on one test:

```
FAIL  src/app/app.component.spec.ts > AppComponent > should create the app
Error: Test timed out in 5000ms.
Test Files  1 failed | 2 passed (3)
Tests       1 failed | 32 passed (33)
```

This is not a device incompatibility. The armv7 job runs the suite under QEMU emulation (~10–20× slower than native — the run reports 27s transform / 39s import / 20s environment setup), so the `AppComponent` bootstrap test exceeds vitest's 5s default. 32 of 33 tests pass.

The job is `continue-on-error` (advisory/non-blocking), so it doesn't block merges — but it shows a red ✗ on every run, which is misleading now that this CI runs on every PR.

## Solution

Raise `testTimeout` to 20s **only** when `process.arch === 'arm'` (32-bit ARM = the emulated armv7/Cerbo job). The armv7 suite runs inside the `linux/arm/v7` container, so vitest sees `process.arch === 'arm'` there and nowhere else. Native platforms (`x64`, `arm64` incl. Raspberry Pi 4/5) keep the strict 5s default, so the timeout still catches genuine hangs where timing is meaningful.

## Verification

- 33/33 tests pass locally (`npm test`) on the native path.
- The emulated armv7 timing can only be confirmed on CI — the `armv7 (Cerbo GX)` step outcome should go green on this PR's run.