### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      angular:
+        patterns:
+          - '@angular/*'
+          - '@angular-devkit/*'
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable automated dependency updates, bringing Freeboard-SK in line with other SK projects.

**npm** — weekly, with two groups:
- `angular` — bundles all `@angular/*` and `@angular-devkit/*` packages together (they release in lockstep, so without grouping each Angular release would generate ~12 individual PRs)
- `minor-and-patch` — bundles all other minor and patch updates into one PR per cycle
- Major bumps (including `@types/node`) remain as individual PRs for explicit review

**github-actions** — weekly, minor/patch grouped