### PR TITLE
ci: add release and npm publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC publish (no NPM_TOKEN needed)
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish
+        # prepack in package.json runs build:all automatically before packing
+        run: |
+          if [[ "${{ github.ref_name }}" == *-beta.* ]] || [[ "${{ github.ref_name }}" == *-rc.* ]]; then
+            npm publish --provenance --access public --tag beta
+          else
+            npm publish --provenance --access public
+          fi


### PR DESCRIPTION
Adds `.github/workflows/release.yml`, triggered on `v*` tag push.

**Two jobs:**
- `release` — creates a GitHub Release with auto-generated notes from PR titles (uses `GITHUB_TOKEN`, no PAT required)
- `publish` — publishes to npm via OIDC provenance; no `NPM_TOKEN` needed

**Modelled on n2k-signalk** with two simplifications: single workflow file (avoids needing `RELEASE_PAT` to chain two separate workflows), and `softprops/action-gh-release` instead of the deprecated `actions/create-release`.

FSK's `prepack` script (`npm run build:all`) fires automatically during `npm publish`, so no separate build step is needed in CI.

Beta/RC tags (`v*-beta.*`, `v*-rc.*`) publish with `--tag beta`; stable tags go to `latest`.

**Before this workflow can publish:** a trusted publisher must be configured on npmjs.com for `@signalk/freeboard-sk`, linking it to the `SignalK/freeboard-sk` GitHub repo and this workflow file (`release.yml`). No npm token or other secrets are required once that is done.