### PR TITLE
ci(deps): include major versions in angular dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
         patterns:
           - '@angular/*'
           - '@angular-devkit/*'
+        update-types:
+          - major
+          - minor
+          - patch
       minor-and-patch:
         update-types:
           - minor


### PR DESCRIPTION
Dependabot excludes major version bumps from groups by default, even when `update-types` is not specified. This caused four individual `@angular/*` PRs (#408, #409, #411, and the `@angular/build` bump) to be opened separately, each failing CI with an `ERESOLVE` peer dependency conflict — because bumping one Angular package to v22 while the others stay at v21 is never installable.

Explicitly adding `major` to the angular group's `update-types` means all `@angular/*` and `@angular-devkit/*` packages will move together in a single PR, which may actually pass CI (or at least be one thing to evaluate or close).

Closes the broken individual PRs: #408, #409, #411.