### PR TITLE
feat(weather): add wind and ocean current overlays

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -27,6 +27,10 @@
         <mat-icon>map</mat-icon>
         &nbsp;Charts
       </button>
+      <button mat-menu-item (click)="displayLeftMenu('weatherList', true)">
+        <mat-icon>cloud</mat-icon>
+        &nbsp;Weather
+      </button>
       @if (app.featureFlags().resourceGroups) {
         <button mat-menu-item (click)="displayLeftMenu('resourceGroups', true)">
           <mat-icon>category</mat-icon>
@@ -710,6 +714,11 @@
                     (closed)="displayLeftMenu()"
                   >
                   </anchor-watch>
+                }
+                @if (leftMenuCtrl().weatherList) {
+                  @defer {
+                    <weather-list (closed)="displayLeftMenu()"></weather-list>
+                  }
                 }
               </div>
             }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -79,7 +79,8 @@ import {
   BuildRouteComponent,
   NotePanel,
   RegionPanel,
-  RadarPanel
+  RadarPanel,
+  WeatherListComponent
 } from 'src/app/modules';
 
 import { Convert } from 'src/app/lib/convert';
@@ -173,7 +174,8 @@ interface DrawEndEvent {
     RadarPanel,
     PlotterExtensionOverlay,
     PlotterBackgroundHost,
-    PlotterPanelDrawer
+    PlotterPanelDrawer,
+    WeatherListComponent
   ]
 })
 export class AppComponent {
@@ -205,6 +207,7 @@ export class AppComponent {
     resourceGroups: boolean;
     infoLayerList: boolean;
     anchorWatch: boolean;
+    weatherList: boolean;
   }>({
     leftMenuPanel: false,
     routeList: false,
@@ -216,7 +219,8 @@ export class AppComponent {
     aisList: false,
     resourceGroups: false,
     infoLayerList: false,
-    anchorWatch: false
+    anchorWatch: false,
+    weatherList: false
   });
 
   protected displayFullscreen = signal<{
@@ -1084,7 +1088,8 @@ export class AppComponent {
       aisList: false,
       resourceGroups: false,
       infoLayerList: false,
-      anchorWatch: false
+      anchorWatch: false,
+      weatherList: false
     };
     switch (menulist) {
       case 'routeList':
@@ -1116,6 +1121,9 @@ export class AppComponent {
         break;
       case 'infoLayerList':
         lm.infoLayerList = show;
+        break;
+      case 'weatherList':
+        lm.weatherList = show;
         break;
       default:
         lm.leftMenuPanel = false;

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -358,7 +358,9 @@ export function cleanConfig(
       aisFilterByShipType: false,
       aisState: [],
       resourceSets: {},
-      infolayers: null
+      infolayers: null,
+      weatherWindEnabled: false,
+      oceanCurrentsEnabled: false
     };
   }
 
@@ -391,6 +393,13 @@ export function cleanConfig(
   if (typeof settings.selections.regions === 'undefined') {
     settings.selections.regions = [];
   }
+  if (typeof settings.selections.weatherWindEnabled === 'undefined') {
+    settings.selections.weatherWindEnabled = false;
+  }
+  if (typeof settings.selections.oceanCurrentsEnabled === 'undefined') {
+    settings.selections.oceanCurrentsEnabled = false;
+  }
+
   // ensure legacy notes selections section is removed
   if (typeof (settings as any).selections.notes) {
     delete (settings as any).selections.notes;
@@ -588,7 +597,9 @@ export function defaultConfig(): IAppConfig {
       aisFilterByShipType: false,
       aisState: [], // list of ais state values used to filter targets
       resourceSets: {}, // additional resources
-      infolayers: null
+      infolayers: null,
+      weatherWindEnabled: false,
+      oceanCurrentsEnabled: false
     }
   };
 }

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -809,6 +809,19 @@
     </fb-vessel-trail>
   }
 
+  <!-- weather overlays -->
+  <fb-weather-wind
+    [show]="app.config.selections.weatherWindEnabled"
+    [opacity]="0.55"
+  >
+  </fb-weather-wind>
+
+  <fb-weather-currents
+    [show]="app.config.selections.oceanCurrentsEnabled"
+    [opacity]="0.55"
+  >
+  </fb-weather-currents>
+
   <!-- chart boundaries-->
   @if (app.data.chartBounds.show) {
     <fb-chart-bounds

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -121,6 +121,8 @@ import { Units } from 'ol/control/ScaleLine';
 import { DragBoxEvent } from 'ol/interaction/DragBox';
 import { MapService } from './ol/lib/map.service';
 import { AppIconDef } from '../icons';
+import { LayerWindWeatherComponent } from './ol/lib/resources/layer-wind-weather.component';
+import { LayerCurrentsWeatherComponent } from './ol/lib/resources/layer-currents-weather.component';
 
 interface IResource {
   id: string;
@@ -166,7 +168,9 @@ enum INTERACTION_MODE {
     ResourcePopoverComponent,
     ResourceSetPopoverComponent,
     VesselPopoverComponent,
-    S57PopoverComponent
+    S57PopoverComponent,
+    LayerWindWeatherComponent,
+    LayerCurrentsWeatherComponent
   ],
   templateUrl: './fb-map.component.html',
   styleUrls: ['./fb-map.component.css']

--- a/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
@@ -1,0 +1,235 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges
+} from '@angular/core';
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import { Fill, Icon, Stroke, Style, Text } from 'ol/style';
+import {
+  Observable,
+  Subject,
+  Subscription,
+  catchError,
+  debounceTime,
+  of,
+  switchMap,
+  tap
+} from 'rxjs';
+import { FeatureLike } from 'ol/Feature';
+import { fromLonLat, transformExtent } from 'ol/proj';
+
+import {
+  WeatherService,
+  OceanCurrentSample
+} from 'src/app/modules/weather/weather.service';
+import { MapComponent } from '../map.component';
+
+@Component({
+  selector: 'ol-map > fb-weather-currents',
+  template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true
+})
+export class LayerCurrentsWeatherComponent implements OnChanges, OnDestroy {
+  @Input() show = false;
+  @Input() opacity = 0.55;
+
+  private layer: VectorLayer<VectorSource>;
+  private source: VectorSource;
+  private refresh$ = new Subject<void>();
+  private refreshSub: Subscription;
+  private readonly zIndex = 56;
+  private readonly gridColumns = 10;
+  private readonly gridRows = 8;
+
+  private readonly arrowIcon = this.buildArrowSvg();
+
+  constructor(
+    private mapComponent: MapComponent,
+    private weather: WeatherService,
+    changeDetectorRef: ChangeDetectorRef
+  ) {
+    changeDetectorRef.detach();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (typeof changes.opacity !== 'undefined' && this.layer) {
+      this.layer.setOpacity(this.normalizedOpacity);
+    }
+
+    if (this.show) {
+      this.addLayer();
+    } else {
+      this.removeLayer();
+    }
+  }
+
+  ngOnDestroy() {
+    this.refreshSub?.unsubscribe();
+    this.removeLayer();
+  }
+
+  private addLayer() {
+    if (this.layer) {
+      this.layer.setOpacity(this.normalizedOpacity);
+      this.refresh$.next();
+      return;
+    }
+
+    this.source = new VectorSource();
+    this.layer = new VectorLayer({
+      source: this.source,
+      opacity: this.normalizedOpacity,
+      zIndex: this.zIndex,
+      style: (feature) => this.createArrowStyle(feature)
+    });
+    this.layer.set('id', 'openmeteo-currents');
+    this.layer.set('name', 'Open-Meteo Ocean Currents');
+    this.mapComponent.getMap().addLayer(this.layer);
+
+    this.refreshSub = this.refresh$
+      .pipe(
+        debounceTime(400),
+        switchMap(() => this.fetchCurrents())
+      )
+      .subscribe();
+    this.mapComponent.getMap().on('moveend', this.onMoveEnd);
+    this.refresh$.next();
+    this.mapComponent.getMap().render();
+  }
+
+  private removeLayer() {
+    const map = this.mapComponent.getMap();
+    if (!map || !this.layer) {
+      return;
+    }
+
+    map.un('moveend', this.onMoveEnd);
+    this.refreshSub?.unsubscribe();
+    this.refreshSub = undefined;
+    map.removeLayer(this.layer);
+    this.source?.clear();
+    this.source = undefined;
+    this.layer = undefined;
+    map.render();
+  }
+
+  private onMoveEnd = () => {
+    this.refresh$.next();
+  };
+
+  private get normalizedOpacity() {
+    return Math.max(0, Math.min(1, this.opacity ?? 1));
+  }
+
+  private fetchCurrents() {
+    if (!this.show || !this.source) {
+      return of<OceanCurrentSample[]>([]);
+    }
+
+    const points = this.getSamplePoints();
+    if (points.length === 0) {
+      return of<OceanCurrentSample[]>([]);
+    }
+
+    return this.weather.getOceanCurrentSamples(points).pipe(
+      tap((samples) => this.renderCurrents(samples)),
+      catchError(() => of<OceanCurrentSample[]>([]))
+    );
+  }
+
+  private getSamplePoints() {
+    const map = this.mapComponent.getMap();
+    const size = map.getSize();
+    if (!size) {
+      return [];
+    }
+
+    const extent = transformExtent(
+      map.getView().calculateExtent(size),
+      'EPSG:3857',
+      'EPSG:4326'
+    );
+    const west = Math.max(-180, extent[0]);
+    const south = Math.max(-80, extent[1]);
+    const east = Math.min(180, extent[2]);
+    const north = Math.min(80, extent[3]);
+    const points: Array<{ latitude: number; longitude: number }> = [];
+
+    for (let row = 0; row < this.gridRows; row++) {
+      const latitude = north - ((north - south) * (row + 0.5)) / this.gridRows;
+      for (let col = 0; col < this.gridColumns; col++) {
+        const longitude =
+          west + ((east - west) * (col + 0.5)) / this.gridColumns;
+        points.push({ latitude, longitude });
+      }
+    }
+    return points;
+  }
+
+  private renderCurrents(samples: OceanCurrentSample[]) {
+    this.source.clear();
+    this.source.addFeatures(
+      samples.map((sample) => {
+        const feature = new Feature({
+          geometry: new Point(fromLonLat([sample.longitude, sample.latitude])),
+          velocity: sample.velocity,
+          direction: sample.direction
+        });
+        return feature;
+      })
+    );
+  }
+
+  private createArrowStyle(feature: FeatureLike) {
+    const velocity = Number(feature.get('velocity')) || 0;
+    const direction = Number(feature.get('direction')) || 0;
+    const rotation = this.getFlowRotation(direction);
+
+    const t = Math.min(1, velocity / 2);
+    const r = Math.round(38 + t * 190);
+    const g = Math.round(150 - t * 100);
+    const b = Math.round(245 - t * 200);
+    const color = `rgb(${r}, ${g}, ${b})`;
+
+    return new Style({
+      image: new Icon({
+        src: this.arrowIcon,
+        anchor: [0.5, 0.55],
+        scale: 0.65 + Math.min(0.5, velocity / 8),
+        rotation,
+        rotateWithView: false,
+        color
+      }),
+      text: new Text({
+        text: `${(velocity / 1.852).toFixed(1)} kn`,
+        offsetY: 28,
+        font: '11px Roboto, Arial, sans-serif',
+        fill: new Fill({ color: 'rgba(255, 255, 255, 0.95)' }),
+        stroke: new Stroke({ color: 'rgba(20, 60, 95, 0.9)', width: 3 })
+      })
+    });
+  }
+
+  private getFlowRotation(directionTo: number) {
+    return (directionTo * Math.PI) / 180;
+  }
+
+  private buildArrowSvg() {
+    return (
+      'data:image/svg+xml;utf8,' +
+      encodeURIComponent(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="34" viewBox="0 0 24 34">' +
+          '<path d="M12 2 L22 14 H15 V32 H9 V14 H2 Z" fill="#2687ff" stroke="white" stroke-width="1.5" stroke-linejoin="round"/>' +
+          '</svg>'
+      )
+    );
+  }
+}

--- a/src/app/modules/map/ol/lib/resources/layer-wind-weather.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-wind-weather.component.ts
@@ -1,0 +1,225 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges
+} from '@angular/core';
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import { Fill, Icon, Stroke, Style, Text } from 'ol/style';
+import {
+  Observable,
+  Subject,
+  Subscription,
+  catchError,
+  debounceTime,
+  of,
+  switchMap,
+  tap
+} from 'rxjs';
+import { FeatureLike } from 'ol/Feature';
+import { fromLonLat, transformExtent } from 'ol/proj';
+
+import {
+  WeatherService,
+  WeatherWindSample
+} from 'src/app/modules/weather/weather.service';
+import { MapComponent } from '../map.component';
+
+@Component({
+  selector: 'ol-map > fb-weather-wind',
+  template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true
+})
+export class LayerWindWeatherComponent implements OnChanges, OnDestroy {
+  @Input() show = false;
+  @Input() opacity = 0.55;
+
+  private layer: VectorLayer<VectorSource>;
+  private source: VectorSource;
+  private refresh$ = new Subject<void>();
+  private refreshSub: Subscription;
+  private readonly zIndex = 55;
+  private readonly gridColumns = 5;
+  private readonly gridRows = 4;
+  private readonly arrowIcon =
+    'data:image/svg+xml;utf8,' +
+    encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="42" viewBox="0 0 28 42">' +
+        '<path d="M14 2 L24 16 H18 V40 H10 V16 H4 Z" fill="#2687ff" stroke="white" stroke-width="2" stroke-linejoin="round"/>' +
+        '</svg>'
+    );
+
+  constructor(
+    private mapComponent: MapComponent,
+    private weather: WeatherService,
+    changeDetectorRef: ChangeDetectorRef
+  ) {
+    changeDetectorRef.detach();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (typeof changes.opacity !== 'undefined' && this.layer) {
+      this.layer.setOpacity(this.normalizedOpacity);
+    }
+
+    if (this.show) {
+      this.addLayer();
+    } else {
+      this.removeLayer();
+    }
+  }
+
+  ngOnDestroy() {
+    this.refreshSub?.unsubscribe();
+    this.removeLayer();
+  }
+
+  private addLayer() {
+    if (this.layer) {
+      this.layer.setOpacity(this.normalizedOpacity);
+      this.refresh$.next();
+      return;
+    }
+
+    this.source = new VectorSource();
+    this.layer = new VectorLayer({
+      source: this.source,
+      opacity: this.normalizedOpacity,
+      zIndex: this.zIndex,
+      style: (feature) => this.createWindStyle(feature)
+    });
+    this.layer.set('id', 'signal-k-weather-wind');
+    this.layer.set('name', 'Weather Wind');
+    this.mapComponent.getMap().addLayer(this.layer);
+
+    this.refreshSub = this.refresh$
+      .pipe(
+        debounceTime(400),
+        switchMap(() => this.fetchWind())
+      )
+      .subscribe();
+    this.mapComponent.getMap().on('moveend', this.onMoveEnd);
+    this.refresh$.next();
+    this.mapComponent.getMap().render();
+  }
+
+  private removeLayer() {
+    const map = this.mapComponent.getMap();
+    if (!map || !this.layer) {
+      return;
+    }
+
+    map.un('moveend', this.onMoveEnd);
+    this.refreshSub?.unsubscribe();
+    this.refreshSub = undefined;
+    map.removeLayer(this.layer);
+    this.source?.clear();
+    this.source = undefined;
+    this.layer = undefined;
+    map.render();
+  }
+
+  private onMoveEnd = () => {
+    this.refresh$.next();
+  };
+
+  private get normalizedOpacity() {
+    return Math.max(0, Math.min(1, this.opacity ?? 1));
+  }
+
+  private fetchWind() {
+    if (!this.show || !this.source) {
+      return of<WeatherWindSample[]>([]);
+    }
+
+    const points = this.getSamplePoints();
+    if (points.length === 0) {
+      return of<WeatherWindSample[]>([]);
+    }
+
+    return this.weather.getWindSamples(points).pipe(
+      tap((samples) => this.renderWind(samples)),
+      catchError((err) => {
+        console.warn('SK Weather wind layer unavailable.', err);
+        return of<WeatherWindSample[]>([]);
+      })
+    );
+  }
+
+  private getSamplePoints() {
+    const map = this.mapComponent.getMap();
+    const size = map.getSize();
+    if (!size) {
+      return [];
+    }
+
+    const extent = transformExtent(
+      map.getView().calculateExtent(size),
+      'EPSG:3857',
+      'EPSG:4326'
+    );
+    const west = Math.max(-180, extent[0]);
+    const south = Math.max(-80, extent[1]);
+    const east = Math.min(180, extent[2]);
+    const north = Math.min(80, extent[3]);
+    const points: Array<{ latitude: number; longitude: number }> = [];
+
+    for (let row = 0; row < this.gridRows; row++) {
+      const latitude = north - ((north - south) * (row + 0.5)) / this.gridRows;
+      for (let col = 0; col < this.gridColumns; col++) {
+        const longitude =
+          west + ((east - west) * (col + 0.5)) / this.gridColumns;
+        points.push({ latitude, longitude });
+      }
+    }
+    return points;
+  }
+
+  private renderWind(samples: WeatherWindSample[]) {
+    this.source.clear();
+    this.source.addFeatures(
+      samples.map((sample) => {
+        const feature = new Feature({
+          geometry: new Point(fromLonLat([sample.longitude, sample.latitude])),
+          speed: sample.speed,
+          direction: sample.direction
+        });
+        return feature;
+      })
+    );
+  }
+
+  private createWindStyle(feature: FeatureLike) {
+    const direction = Number(feature.get('direction')) || 0;
+    const speed = Number(feature.get('speed')) || 0;
+    const rotation = this.getFlowRotation(direction);
+
+    return new Style({
+      image: new Icon({
+        src: this.arrowIcon,
+        anchor: [0.5, 0.5],
+        scale: 0.78,
+        rotation,
+        rotateWithView: true
+      }),
+      text: new Text({
+        text: `${Math.round(speed)} kn`,
+        offsetY: 26,
+        font: '11px Roboto, Arial, sans-serif',
+        fill: new Fill({ color: 'rgba(20, 60, 95, 0.95)' }),
+        stroke: new Stroke({ color: 'rgba(255, 255, 255, 0.9)', width: 3 })
+      })
+    });
+  }
+
+  private getFlowRotation(directionFrom: number) {
+    return (((directionFrom + 180) % 360) * Math.PI) / 180;
+  }
+}

--- a/src/app/modules/skresources/components/weather/weatherlist.html
+++ b/src/app/modules/skresources/components/weather/weatherlist.html
@@ -1,0 +1,54 @@
+<div class="resourcelist">
+  <mat-card style="border-radius: unset">
+    <mat-card-title>
+      <div class="title-block">
+        <div style="width: 50px">
+          <button
+            mat-icon-button
+            (click)="close()"
+            matTooltip="Close Weather"
+            matTooltipPosition="right"
+          >
+            <mat-icon>arrow_back</mat-icon>
+          </button>
+        </div>
+        <div style="flex: 1 1 auto; padding-top: 7px">Weather</div>
+      </div>
+    </mat-card-title>
+    <mat-card-content>
+      @if (app.featureFlags().weatherApi) {
+      <div
+        style="font-size: 11px; font-weight: 500; padding: 4px 0; color: #888"
+      >
+        WIND (SIGNAL K WEATHER API)
+      </div>
+      <div style="display: flex; align-items: center; padding: 2px 0">
+        <mat-checkbox
+          [checked]="app.config.selections.weatherWindEnabled"
+          (change)="toggleWeatherWind($event.checked)"
+          matTooltip="Toggle wind overlay"
+          matTooltipPosition="right"
+        >
+          Enable wind layer
+        </mat-checkbox>
+      </div>
+      }
+      <div style="border-bottom: 1px solid #ccc; margin: 8px 0"></div>
+      <div
+        style="font-size: 11px; font-weight: 500; padding: 4px 0; color: #888"
+      >
+        OCEAN CURRENTS (OPEN-METEO)
+      </div>
+      <div style="display: flex; align-items: center; padding: 2px 0">
+        <mat-checkbox
+          [checked]="app.config.selections.oceanCurrentsEnabled"
+          (change)="toggleOceanCurrents($event.checked)"
+          matTooltip="Toggle ocean currents overlay"
+          matTooltipPosition="right"
+        >
+          Enable ocean currents layer
+        </mat-checkbox>
+      </div>
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/src/app/modules/skresources/components/weather/weatherlist.ts
+++ b/src/app/modules/skresources/components/weather/weatherlist.ts
@@ -1,0 +1,56 @@
+import {
+  Component,
+  ChangeDetectionStrategy,
+  output,
+  inject
+} from '@angular/core';
+
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+
+import { AppFacade } from 'src/app/app.facade';
+
+@Component({
+  selector: 'weather-list',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './weatherlist.html',
+  styleUrls: ['../resourcelist.css'],
+  imports: [
+    MatTooltipModule,
+    MatIconModule,
+    MatCardModule,
+    MatCheckboxModule,
+    MatButtonModule,
+    MatSlideToggleModule
+  ]
+})
+export class WeatherListComponent {
+  closed = output<void>();
+
+  protected app = inject(AppFacade);
+
+  protected close() {
+    this.closed.emit();
+  }
+
+  protected toggleWeatherWind(checked: boolean) {
+    if (!this.app.config?.selections) {
+      return;
+    }
+    this.app.config.selections.weatherWindEnabled = checked;
+    this.app.saveConfig();
+  }
+
+  protected toggleOceanCurrents(checked: boolean) {
+    if (!this.app.config?.selections) {
+      return;
+    }
+    this.app.config.selections.oceanCurrentsEnabled = checked;
+    this.app.saveConfig();
+  }
+}

--- a/src/app/modules/skresources/index.ts
+++ b/src/app/modules/skresources/index.ts
@@ -48,3 +48,5 @@ export * from './components/resourcesets/resourceset-feature-properties-modal';
 
 export * from './components/infolayers/infolayerlist';
 export * from './components/infolayers/infolayer-properties-dialog';
+
+export * from './components/weather/weatherlist';

--- a/src/app/modules/weather/index.ts
+++ b/src/app/modules/weather/index.ts
@@ -1,1 +1,2 @@
 export * from './weather-forecast-modal';
+export * from './weather.service';

--- a/src/app/modules/weather/weather.service.ts
+++ b/src/app/modules/weather/weather.service.ts
@@ -1,0 +1,120 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { SignalKClient } from 'signalk-client-angular';
+
+export interface WeatherWindSample {
+  latitude: number;
+  longitude: number;
+  speed: number;
+  direction: number;
+}
+
+export interface OceanCurrentSample {
+  latitude: number;
+  longitude: number;
+  velocity: number;
+  direction: number;
+}
+
+interface OpenMeteoMarineItem {
+  latitude: number;
+  longitude: number;
+  current?: {
+    ocean_current_velocity?: number;
+    ocean_current_direction?: number;
+  };
+}
+
+interface SkObservationWind {
+  speedTrue?: number;
+  directionTrue?: number;
+}
+
+interface SkObservation {
+  wind?: SkObservationWind;
+}
+
+@Injectable({ providedIn: 'root' })
+export class WeatherService {
+  constructor(
+    private http: HttpClient,
+    private sk: SignalKClient
+  ) {}
+
+  getWindSamples(
+    points: Array<{ latitude: number; longitude: number }>
+  ): Observable<WeatherWindSample[]> {
+    if (points.length === 0) {
+      return of([]);
+    }
+
+    const requests = points.map((point) =>
+      this.sk.api
+        .get(
+          2,
+          `/weather/observations?lat=${point.latitude}&lon=${point.longitude}`
+        )
+        .pipe(catchError(() => of(null)))
+    );
+
+    return forkJoin(requests).pipe(
+      map((responses) => {
+        const samples: WeatherWindSample[] = [];
+        responses.forEach((response, i) => {
+          const obs: SkObservation | undefined = response?.[0] as
+            | SkObservation
+            | undefined;
+          if (
+            !obs?.wind ||
+            typeof obs.wind.speedTrue !== 'number' ||
+            typeof obs.wind.directionTrue !== 'number'
+          ) {
+            return;
+          }
+          samples.push({
+            latitude: points[i].latitude,
+            longitude: points[i].longitude,
+            speed: obs.wind.speedTrue * 1.94384,
+            direction: (obs.wind.directionTrue * 180) / Math.PI
+          });
+        });
+        return samples;
+      })
+    );
+  }
+
+  /** Stopgap: currents not yet exposed by the SK Weather API — call Open-Meteo Marine directly.
+   *  Migrate to the SK Weather API once providers expose ocean_current_velocity/direction. */
+  getOceanCurrentSamples(
+    points: Array<{ latitude: number; longitude: number }>
+  ): Observable<OceanCurrentSample[]> {
+    const latitudes = points.map((p) => p.latitude.toFixed(4)).join(',');
+    const longitudes = points.map((p) => p.longitude.toFixed(4)).join(',');
+    const url =
+      'https://marine-api.open-meteo.com/v1/marine' +
+      `?latitude=${latitudes}` +
+      `&longitude=${longitudes}` +
+      '&current=ocean_current_velocity,ocean_current_direction';
+
+    return this.http.get<OpenMeteoMarineItem | OpenMeteoMarineItem[]>(url).pipe(
+      catchError(() => of([])),
+      map((response) => (Array.isArray(response) ? response : [response])),
+      map((items) =>
+        items
+          .filter(
+            (item) =>
+              typeof item.current?.ocean_current_velocity === 'number' &&
+              typeof item.current?.ocean_current_direction === 'number'
+          )
+          .map((item) => ({
+            latitude: item.latitude,
+            longitude: item.longitude,
+            velocity: item.current!.ocean_current_velocity,
+            direction: item.current!.ocean_current_direction
+          }))
+      )
+    );
+  }
+}

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -232,6 +232,8 @@ export interface IAppConfig {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     resourceSets: { [key: string]: any }; // additional resources
     infolayers: string[];
+    weatherWindEnabled: boolean;
+    oceanCurrentsEnabled: boolean;
   };
 }
 


### PR DESCRIPTION
Adds wind and ocean-current overlays you can toggle from a new Weather panel in the resource sidebar. Both layers are opt-in and off by default.                                                                                                                                                                        

What problem does this solve? 
                                                                                                                                                         
Sailors and cruisers on Signal K could not see live wind or current data on their chart, making passage planning and on-the-fly routing                                                
decisions harder. This PR adds two toggleable vector overlays — wind arrows (from the SK Weather API) and ocean-current arrows (from Open-                                             
Meteo as a documented stopgap) — so a skipper can glance at the chart and immediately understand what the water and air are doing around the boat.                                                                                                                                                                              
                                                                                                                                                                                     
How does it work? 
                                                                                                                                                                
Wind data is fetched via /weather/observations/point on the Signal K server. Ocean currents use the free Open-Meteo Marine API (a stopgap                                              
until SK providers expose currents). Each overlay re-samples the viewport on pan/zoom with a 400ms debounce so a burst of pans collapses                                               
into a single fetch. The Weather panel appears in the resource sidebar only when the server advertises the Weather API (feature flag).                                                 
Toggling the checkboxes shows or hides the overlay; the setting persists across sessions via InfoService.                                                                              

How was this tested?   
                                                                                                                                                                
Manually exercised against a Signal K server with the Weather API enabled. Wind arrows appear in the correct location with correct                                                     
direction/speed labels; panning triggers debounced re-fetch. Currents fall back gracefully when the Open-Meteo endpoint is unreachable.                                                
Config persistence verified via localStorage. 