### PR TITLE
fix(radar): remove duplicate radar id from control PUT path

### DIFF
--- a/src/app/modules/radar/radar-api.service.ts
+++ b/src/app/modules/radar/radar-api.service.ts
@@ -306,7 +306,7 @@ export class RadarAPIService {
       this.signalk.api
         .put(
           this.app.skApiVersion,
-          `${this.getPath(radarId)}/controls/${radarId}/${controlId}`,
+          `${this.getPath(radarId)}/controls/${controlId}`,
           { value: value }
         )
         .subscribe({


### PR DESCRIPTION
## Motivation

Setting any radar control (e.g. power on/off) from the Radar panel failed with **404 Not Found**. The browser console showed the PUT going to:

```
/signalk/v2/api/vessels/self/radars/fur6424A/controls/fur6424A/power
```

The radar id appears twice. The Signal K server radar API only registers `PUT /radars/:id/controls/:controlId`, so the extra `fur6424A/` segment never matches a route and the request 404s — controls cannot be set.

## Solution

`getPath(radarId)` already appends the radar id, so the additional `${radarId}/` in `setControl()`'s path was redundant. Removing it yields the correct path:

```
/signalk/v2/api/vessels/self/radars/fur6424A/controls/power
```

This matches the pattern already used by the GET methods in the same service.

## Tested

- `npm run build:all` and `npm test` (33 passing) succeed.
- Confirmed the corrected path matches the route registered by the Signal K server radar API (`PUT /radars/:id/controls/:controlId`) and the GET methods in the same service.

Reported by a user running the mayara radar provider, whose browser console showed the duplicated-id 404.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the endpoint used when updating radar control values, helping control changes reach the intended server path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->