### PR TITLE
fix(build): exit production build when ng build does not terminate

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "format:helper": "prettier --ignore-path .gitignore --write \"helper/**/*.+(ts|html)\"",
     "format:all": "npm run format && npm run format:helper",
     "build:helper": "tsc -p tsconfig-helper.json",
-    "build:web": "ng build -c production --output-hashing all",
+    "build:web": "node scripts/build-web.mjs",
     "build:sit": "ng build -c development --aot",
     "build:all": "npm run build:helper && npm run build:web",
     "build:prod": "npm run build:all",

--- a/scripts/build-web.mjs
+++ b/scripts/build-web.mjs
@@ -1,0 +1,102 @@
+// Production build wrapper.
+//
+// Works around an Angular `@angular/build:application` (esbuild) behaviour
+// where, for some dependency graphs, `ng build` finishes a SUCCESSFUL build
+// — it prints "Application bundle generation complete" and writes the output
+// — but the process then fails to terminate (a lingering esbuild service
+// keeps the event loop alive). In CI that hangs the build step until the job
+// timeout and reports a false failure, even though the bundle is correct.
+//
+// This wrapper runs the exact same `ng build` and:
+//   - if ng exits on its own, it forwards ng's exit code unchanged;
+//   - if ng reports failure, it exits non-zero;
+//   - if ng reports success but then does not exit within a short grace
+//     window, it VERIFIES the output exists and exits 0 (it never declares
+//     success on a timeout alone, so a genuinely stalled/broken build still
+//     fails).
+//
+// Used by `npm run build:web`. Behaviour is identical for a normally-exiting
+// build; it only changes the non-exit case.
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const ngBin = require.resolve('@angular/cli/bin/ng.js');
+const NG_ARGS = ['build', '-c', 'production', '--output-hashing', 'all'];
+
+const OUTPUT_INDEX = join(process.cwd(), 'public', 'index.html');
+const COMPLETE = 'Application bundle generation complete';
+const FAILED = 'Application bundle generation failed';
+const GRACE_MS = 10_000; // let ng exit on its own before we force it
+const HARD_TIMEOUT_MS = 10 * 60 * 1000; // backstop if "complete" never prints
+
+const child = spawn(process.execPath, [ngBin, ...NG_ARGS], {
+  stdio: ['inherit', 'pipe', 'pipe']
+});
+
+let settled = false;
+let graceTimer = null;
+let hardTimer = null;
+
+const finish = (code, reason) => {
+  if (settled) return;
+  settled = true;
+  clearTimeout(graceTimer);
+  clearTimeout(hardTimer);
+  if (reason) console.log(`\n[build-web] ${reason}`);
+  child.kill('SIGTERM');
+  // Give the kill a moment to propagate, then exit deterministically.
+  setTimeout(() => process.exit(code), 500);
+};
+
+const scan = (text) => {
+  if (settled) return;
+  if (text.includes(FAILED)) {
+    finish(1, 'ng build reported failure.');
+  } else if (text.includes(COMPLETE)) {
+    graceTimer = setTimeout(() => {
+      if (existsSync(OUTPUT_INDEX)) {
+        finish(
+          0,
+          `Build complete and output verified (${OUTPUT_INDEX}); ng build did not exit, forcing success.`
+        );
+      } else {
+        finish(
+          1,
+          `Build reported complete but output is missing (${OUTPUT_INDEX}).`
+        );
+      }
+    }, GRACE_MS);
+  }
+};
+
+child.stdout.on('data', (b) => {
+  process.stdout.write(b);
+  scan(b.toString());
+});
+child.stderr.on('data', (b) => {
+  process.stderr.write(b);
+  scan(b.toString());
+});
+
+// ng exited by itself — forward its result verbatim.
+child.on('exit', (code, signal) => {
+  if (settled) return;
+  if (signal) finish(1, `ng build terminated by signal ${signal}.`);
+  else finish(code ?? 1, `ng build exited with code ${code}.`);
+});
+child.on('error', (err) =>
+  finish(1, `Failed to start ng build: ${err.message}`)
+);
+
+hardTimer = setTimeout(
+  () =>
+    finish(
+      1,
+      `Hard timeout (${HARD_TIMEOUT_MS / 1000}s) — build never completed.`
+    ),
+  HARD_TIMEOUT_MS
+);


### PR DESCRIPTION
The `@angular/build:application` (esbuild) builder can finish a **successful** production build — it prints `Application bundle generation complete` and writes the output — but then **fail to terminate** (a lingering esbuild service keeps the event loop alive). In CI this hangs the build step until the job timeout and reports a false failure, even though the bundle is correct.

## Fix

`build:web` now runs through a small wrapper (`scripts/build-web.mjs`) that runs the exact same `ng build`:

- if `ng build` exits on its own → its exit code is forwarded unchanged;
- if it reports failure → non-zero exit;
- if it reports success but does not terminate within a short grace window → the wrapper **verifies the output bundle exists** (`public/index.html`) and exits `0`.

It never treats a bare timeout as success, so a genuinely stalled or broken build still fails. Behaviour is identical for a normally-exiting build; only the non-exit case changes. No CI-workflow change is needed — `build:all` picks it up automatically.

## Why

Surfaced on a feature branch whose dependency graph reliably triggered the non-exit; every matrix job hit the 15-minute timeout despite the build completing in seconds. This is a defensive guard for that class of Angular esbuild-builder hang.