### PR TITLE
ci: exit unit-test run when ng test does not terminate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,4 @@ jobs:
     uses: SignalK/signalk-server/.github/workflows/plugin-ci.yml@master
     with:
       build-command: 'npm run build:all'
+      test-command: 'npm run test:ci'

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "build:sit": "ng build -c development --aot",
     "build:all": "npm run build:helper && npm run build:web",
     "build:prod": "npm run build:all",
-    "prepack": "npm run build:all"
+    "prepack": "npm run build:all",
+    "test:ci": "node scripts/test-ci.mjs"
   },
   "author": "AdrianP",
   "contributors": [

--- a/scripts/test-ci.mjs
+++ b/scripts/test-ci.mjs
@@ -1,0 +1,92 @@
+// CI unit-test wrapper.
+//
+// Same Angular `@angular/build` (esbuild) non-exit issue as
+// scripts/build-web.mjs, but for `ng test`: the test bundle builds, vitest
+// runs and prints its summary, but the process then fails to terminate (a
+// lingering esbuild service keeps the event loop alive). In CI that hangs the
+// test step until the job timeout even though every test passed.
+//
+// This wrapper runs `ng test` and:
+//   - forwards ng's exit code if it exits on its own;
+//   - reads vitest's final "Test Files" summary — any "failed" -> exit 1;
+//   - on an all-passed summary that does not terminate within a grace window,
+//     force-exits 0.
+// It only exits 0 after seeing a passing summary, so a crash with no summary
+// still fails (via the hard timeout). Used by `npm run test:ci`; plain
+// `npm test` is left as the normal (watch) command for local development.
+
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ngBin = require.resolve('@angular/cli/bin/ng.js');
+const NG_ARGS = ['test'];
+
+// Matches vitest's final summary line, e.g. "Test Files  3 passed (3)" or
+// "Test Files  1 failed | 2 passed (3)".
+const SUMMARY = /Test Files\s+\d+\s+(?:failed|passed)/;
+const GRACE_MS = 10_000; // let ng exit on its own before we force it
+const HARD_TIMEOUT_MS = 15 * 60 * 1000; // backstop if no summary ever prints
+
+const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+const child = spawn(process.execPath, [ngBin, ...NG_ARGS], {
+  stdio: ['inherit', 'pipe', 'pipe']
+});
+
+let settled = false;
+let graceTimer = null;
+let hardTimer = null;
+
+const finish = (code, reason) => {
+  if (settled) return;
+  settled = true;
+  clearTimeout(graceTimer);
+  clearTimeout(hardTimer);
+  if (reason) console.log(`\n[test-ci] ${reason}`);
+  child.kill('SIGTERM');
+  setTimeout(() => process.exit(code), 500);
+};
+
+const scan = (chunk) => {
+  if (settled) return;
+  for (const line of stripAnsi(chunk.toString()).split('\n')) {
+    if (!SUMMARY.test(line)) continue;
+    if (/failed/.test(line)) {
+      finish(1, 'Tests failed.');
+    } else {
+      graceTimer = setTimeout(
+        () => finish(0, 'Tests passed; ng test did not exit, forcing success.'),
+        GRACE_MS
+      );
+    }
+    return;
+  }
+};
+
+child.stdout.on('data', (b) => {
+  process.stdout.write(b);
+  scan(b);
+});
+child.stderr.on('data', (b) => {
+  process.stderr.write(b);
+  scan(b);
+});
+
+child.on('exit', (code, signal) => {
+  if (settled) return;
+  if (signal) finish(1, `ng test terminated by signal ${signal}.`);
+  else finish(code ?? 1, `ng test exited with code ${code}.`);
+});
+child.on('error', (err) =>
+  finish(1, `Failed to start ng test: ${err.message}`)
+);
+
+hardTimer = setTimeout(
+  () =>
+    finish(
+      1,
+      `Hard timeout (${HARD_TIMEOUT_MS / 1000}s) — tests never completed.`
+    ),
+  HARD_TIMEOUT_MS
+);


### PR DESCRIPTION
Follow-up to #424 (which fixed the same hang for the production build). The `@angular/build` (esbuild) test builder exhibits the identical non-exit: the test bundle builds, **vitest runs and all tests pass**, but `ng test` then fails to terminate (lingering esbuild service), so the CI test step hangs until the job timeout and reports a false failure.

## Fix

- `scripts/test-ci.mjs` — wraps `ng test`: forwards its exit code if it exits; reads vitest's final `Test Files …` summary (any `failed` → exit 1); on an all-passed summary that does not terminate within a grace window, force-exits `0`. It only exits 0 after seeing a passing summary, so a crash with no summary still fails (hard-timeout).
- `package.json` — adds `test:ci` → the wrapper. Plain `npm test` is left untouched as the normal watch command for local dev.
- `.github/workflows/ci.yml` — sets `test-command: npm run test:ci` so the shared Plugin-CI runs the wrapper. No change to the shared workflow.

Mirrors the build-side fix in #424. Behaviour is identical for a normally-exiting `ng test`; only the non-exit case changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a CI-safe test command to make automated test runs complete more reliably.
  * Updated the shared CI workflow to use the new test command during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->