### PR TITLE
fix(build): surface ng build errors when the production build fails

### DIFF
--- a/scripts/build-web.mjs
+++ b/scripts/build-web.mjs
@@ -40,12 +40,14 @@ const child = spawn(process.execPath, [ngBin, ...NG_ARGS], {
 let settled = false;
 let graceTimer = null;
 let hardTimer = null;
+let failTimer = null;
 
 const finish = (code, reason) => {
   if (settled) return;
   settled = true;
   clearTimeout(graceTimer);
   clearTimeout(hardTimer);
+  clearTimeout(failTimer);
   if (reason) console.log(`\n[build-web] ${reason}`);
   child.kill('SIGTERM');
   // Give the kill a moment to propagate, then exit deterministically.
@@ -55,7 +57,20 @@ const finish = (code, reason) => {
 const scan = (text) => {
   if (settled) return;
   if (text.includes(FAILED)) {
-    finish(1, 'ng build reported failure.');
+    // ng build prints its detailed errors AFTER this summary line and then
+    // hangs. Wait briefly so those errors flush to the console before exiting,
+    // otherwise the developer only sees "failed" with no cause.
+    if (!failTimer) {
+      failTimer = setTimeout(
+        () =>
+          finish(
+            1,
+            'ng build failed — see the errors above. A "Could not resolve" / ' +
+              '"Cannot find module" usually means a missing dependency (try `npm install`).'
+          ),
+        3000
+      );
+    }
   } else if (text.includes(COMPLETE)) {
     graceTimer = setTimeout(() => {
       if (existsSync(OUTPUT_INDEX)) {


### PR DESCRIPTION
Follow-up to #424. The `scripts/build-web.mjs` wrapper detects the builder's `Application bundle generation failed` line and exits — but Angular prints that summary **before** the detailed `✘ [ERROR] …` lines, so the wrapper killed `ng build` before they flushed. A failing build therefore showed only:

```
Application bundle generation failed.
[build-web] ng build reported failure.
```

…with no cause — e.g. a missing dependency gave no hint that `npm install` was needed.

## Fix

On detecting failure, wait briefly (3s) so `ng build`'s error detail flushes to the console, then exit 1 with a short hint. Now the same failure shows:

```
✘ [ERROR] Could not resolve "signalk-plotterext-bus/host"
    src/app/modules/plotterext/plotterext.service.ts:30:80
✘ [ERROR] TS2307: Cannot find module "signalk-plotterext-bus/host" ...
[build-web] ng build failed — see the errors above. A "Could not resolve" /
"Cannot find module" usually means a missing dependency (try `npm install`).
```

Validated both paths locally: a failing build prints the real esbuild errors and exits 1; a successful build is unchanged (exits 0 after output verification). `test-ci.mjs` (#425) does not need this — vitest prints failing-test detail before its summary, so nothing is truncated there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build output handling so failure messages are allowed to fully appear before the process exits.
  * Reduced cases where Angular build errors could be cut off, making troubleshooting easier and more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->