### PR TITLE
fix(map): keep route waypoint markers in sync while editing a route

### DIFF
--- a/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-routes.component.ts
@@ -77,7 +77,11 @@ export class FreeboardRouteLayerComponent extends FBFeatureLayerComponent {
         });
         f.setId('route.' + r[0]);
         f.set('pointMetadata', r[1].feature.properties.coordinatesMeta ?? null);
-        f.setStyle(this.buildStyle(f));
+        // Style FUNCTION (not a static array) so the per-vertex markers, whose
+        // geometries are derived from the line in buildStyle, re-evaluate as the
+        // geometry changes during a Modify drag — otherwise they stay frozen at
+        // the original vertex positions until the edit finishes.
+        f.setStyle((feat) => this.buildStyle(feat as Feature));
         fa.push(f);
       }
     }


### PR DESCRIPTION
While editing a route, the per-vertex waypoint markers stayed frozen at their original positions until the edit finished — the route feature used a static style array, but the markers' geometries are derived from the line in `buildStyle`, so they need to re-evaluate as the geometry changes during a Modify drag.

This switches the route feature to a style **function** so the markers follow the line live as vertices are dragged.

CodeRabbit review already performed at my fork. @coderabbitai ignore