### PR TITLE
fix(map): prevent FINISH button clipping and measure-panel overlap during route edit

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -125,11 +125,9 @@ mat-nav-list {
 }
 
 .measurePanel {
-    position: absolute;
-    top: 60px;
-    left: 50px;
-    width: 150px;
-    border: black 1px solid;
+    /* Flows in-line inside the positioned ._ap_interact_help container; was
+       position:absolute, which lifted it out of flow and overlapped the
+       measurement readout shown alongside it during a route modify. */
     font-family: roboto;
     font-size: 10pt;
 }

--- a/src/app/lib/components/interact-help.component.ts
+++ b/src/app/lib/components/interact-help.component.ts
@@ -55,7 +55,7 @@ import { Measurements } from './measurements.component';
             }
           </div>
 
-          <div style="text-align: center">
+          <div style="text-align: center; padding: 6px 0 8px">
             <!-- cancel Draw button -->
             <a
               class="icon-warn"


### PR DESCRIPTION
Two layout glitches in the route-edit (Modify) help bar:

- The **FINISH** button was clipped at the edge of its container — add spacing around it.
- The **measurement panel** used `position: absolute`, which lifted it out of flow so it overlapped the measurement readout shown alongside it during a route modify — let it flow in-line inside the positioned help container instead.

CodeRabbit review already performed at my fork. @coderabbitai ignore