### PR TITLE
fix(routes): re-enable route list controls when route editing ends

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1783,6 +1783,10 @@ export class AppComponent {
   /** Handle feature DrawEnded event and prompt to save */
   protected handleDrawEnded(e: DrawFeatureInfo) {
     this.mapInteract.isDrawing();
+    // A completed draw is no longer being edited — clear the marker (set on
+    // modify drags during the draw, otherwise never reset) so resource-list
+    // visibility checkboxes don't stay disabled.
+    this.app.data.editingId = '';
     switch (this.mapInteract.draw.resourceType) {
       case 'note':
         const params = { position: e.coordinates };
@@ -1809,6 +1813,10 @@ export class AppComponent {
 
   /** End interaction mode */
   protected closeInteraction() {
+    // No feature is being edited once an interaction ends — clear the marker
+    // (it is set on every modify drag and otherwise never reset), so dependent
+    // UI such as the route-list visibility checkboxes re-enables.
+    this.app.data.editingId = '';
     if (this.mapInteract.isBoxSelecting()) {
       this.mapInteract.stopBoxSelection();
     }

--- a/src/app/modules/skresources/components/routes/routelist.html
+++ b/src/app/modules/skresources/components/routes/routelist.html
@@ -37,7 +37,7 @@
         <div>
           <button
             mat-icon-button
-            [disabled]="disableRefresh"
+            [disabled]="disableRefresh()"
             (click)="initItems()"
             matTooltip="Reload Routes"
             matTooltipPosition="below"
@@ -48,7 +48,7 @@
         <div>
           <mat-checkbox
             #selall
-            [disabled]="fullList.length === 0 || disableRefresh"
+            [disabled]="fullList.length === 0 || disableRefresh()"
             [checked]="allSel"
             [indeterminate]="someSel"
             (change)="toggleAll($event.checked)"
@@ -108,7 +108,7 @@
             <div style="text-align: right">
               <mat-checkbox
                 [checked]="r[2]"
-                [disabled]="r[0] === activeRoute() || disableRefresh"
+                [disabled]="r[0] === activeRoute() || disableRefresh()"
                 (change)="itemSelect($event.checked, r[0])"
                 matTooltip="Show on Map"
                 matTooltipPosition="left"
@@ -123,7 +123,7 @@
               <button
                 mat-icon-button
                 (click)="itemDelete(r[0])"
-                [disabled]="r[0] === activeRoute() || disableRefresh"
+                [disabled]="r[0] === activeRoute() || disableRefresh()"
                 matTooltip="Delete Route"
                 matTooltipPosition="above"
               >
@@ -139,7 +139,7 @@
               </button>
               <button
                 mat-icon-button
-                [disabled]="disableRefresh"
+                [disabled]="disableRefresh()"
                 (click)="itemViewPoints(r[0])"
                 matTooltip="Route points"
                 matTooltipPosition="above"
@@ -149,7 +149,7 @@
               @if(r[0] !== activeRoute()) {
               <button
                 mat-icon-button
-                [disabled]="disableRefresh"
+                [disabled]="disableRefresh()"
                 (click)="itemSetActive(r[0])"
                 matTooltip="Start"
                 matTooltipPosition="above"
@@ -159,7 +159,7 @@
               } @else {
               <button
                 mat-icon-button
-                [disabled]="disableRefresh"
+                [disabled]="disableRefresh()"
                 (click)="itemClearActive(r[0])"
                 matTooltip="Clear Active Route"
                 matTooltipPosition="above"
@@ -171,7 +171,7 @@
             <div>
               <button
                 mat-icon-button
-                [disabled]="disableRefresh"
+                [disabled]="disableRefresh()"
                 (click)="itemProperties(r[0])"
                 matTooltip="Edit Route Properties"
                 matTooltipPosition="above"
@@ -183,7 +183,7 @@
             <div>
               <button
                 mat-icon-button
-                [disabled]="disableRefresh"
+                [disabled]="disableRefresh()"
                 (click)="itemAddToGroup(r[0])"
                 matTooltip="Add to Group"
                 matTooltipPosition="above"

--- a/src/app/modules/skresources/components/routes/routelist.ts
+++ b/src/app/modules/skresources/components/routes/routelist.ts
@@ -2,6 +2,7 @@ import {
   Component,
   ChangeDetectionStrategy,
   signal,
+  computed,
   effect,
   inject,
   output,
@@ -66,7 +67,12 @@ export class RouteListComponent extends ResourceListBase {
 
   protected override fullList: FBRoutes = [];
   protected override filteredList = signal<FBRoutes>([]);
-  disableRefresh = false;
+  /** Disable list/visibility actions while a route is being edited. Reactive
+   *  (computed from the editingRouteId signal input) so it re-enables the moment
+   *  editing ends — ngOnChanges does not fire for signal-input changes. */
+  disableRefresh = computed(
+    () => this.editingRouteId()?.startsWith('route.') ?? false
+  );
 
   protected app = inject(AppFacade);
   private worker = inject(SKWorkerService);
@@ -90,8 +96,6 @@ export class RouteListComponent extends ResourceListBase {
 
   ngOnChanges() {
     this.initItems();
-    this.disableRefresh =
-      this.editingRouteId() && this.editingRouteId().indexOf('route') !== -1;
   }
 
   /**


### PR DESCRIPTION
The route list's controls (the show-on-map visibility checkboxes, reload, delete, etc.) could stay **disabled** after a route edit finished. Two pre-existing causes:

- `disableRefresh` was recomputed in `ngOnChanges`, which does not fire for signal-input changes — so it never re-evaluated when editing ended. It is now a `computed()` derived from the `editingRouteId` signal, so it re-enables reactively.
- The `editingId` marker (set on every modify drag) was never reset, so it stayed set after a draw or interaction ended. It is now cleared when a draw completes and when an interaction closes.

CodeRabbit review already performed at my fork. @coderabbitai ignore