### PR TITLE
feat(routes): live route editing — editable drafts + plotter-extension route API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@signalk/server-api": "^2.24.0",
         "geolib": "^3.3.3",
         "google-protobuf": "^4.0.1",
-        "signalk-plotterext-bus": "^0.5.0",
+        "signalk-plotterext-bus": "^0.7.1",
         "tslib": "^2.0.0",
         "uuid": "^11.1.0"
       },
@@ -10687,9 +10687,9 @@
       }
     },
     "node_modules/signalk-plotterext-bus": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.5.0.tgz",
-      "integrity": "sha512-i3OsOScXsoE/r9zrqCoYc3bXmN9TtSHGPnEe1/wDW4mQz4awrPZBr3EcF3fTO00ntTZPi96O7PiSprjTGNNSxw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.7.1.tgz",
+      "integrity": "sha512-8x2K79MmLevNHXzAB8ef3BP5kEk5lIzaGpwohm9xtaFowKEQuy0F5ZW+Xik/4tBzwi0DB01f/0rdZGWPS0kn/w==",
       "license": "MIT"
     },
     "node_modules/sigstore": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@signalk/server-api": "^2.24.0",
     "geolib": "^3.3.3",
     "google-protobuf": "^4.0.1",
-    "signalk-plotterext-bus": "^0.5.0",
+    "signalk-plotterext-bus": "^0.7.1",
     "tslib": "^2.0.0",
     "uuid": "^11.1.0"
   },

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -333,7 +333,7 @@
                   [id]="infoPanel.item().id"
                   [related]="infoPanel.related()"
                   [interacting]="isInteracting()"
-                  (edit)="skres.editRouteInfo($event)"
+                  (edit)="onRouteInfoEdit($event)"
                   (activate)="activateRoute($event)"
                   (panTo)="centerAndZoom($event.center, $event.zoomLevel)"
                 />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -105,6 +105,7 @@ import {
 } from './modules/map/fbmap-interact.service';
 import { RadarAPIService } from './modules/radar/radar-api.service';
 import { PlotterExtensionService } from './modules/plotterext/plotterext.service';
+import { RouteBufferRegistry } from './modules/plotterext/route-buffer.registry';
 import { PlotterExtensionOverlay } from './modules/plotterext/widget-overlay.component';
 import { PlotterBackgroundHost } from './modules/plotterext/background-runtime.component';
 import { PlotterPanelDrawer } from './modules/plotterext/panel-drawer.component';
@@ -272,6 +273,7 @@ export class AppComponent {
   protected autopilot = inject(AutopilotService);
   protected radarApi = inject(RadarAPIService);
   private symbols = inject(SymbolService);
+  protected routeBuffers = inject(RouteBufferRegistry);
   protected plotterExt = inject(PlotterExtensionService);
 
   constructor() {
@@ -1781,6 +1783,47 @@ export class AppComponent {
   }
 
   /** Handle feature DrawEnded event and prompt to save */
+  /**
+   * Route info-panel "edit" action. For an unsaved live buffer this is the
+   * "Save" button: persist it to a stored route. For a saved route it edits
+   * the name/description as before.
+   */
+  protected onRouteInfoEdit(id: string) {
+    // The registry also mirrors clean saved routes, so route only an unsaved
+    // draft / pending-edit buffer to the save flow; a clean saved route uses the
+    // normal route-details edit path.
+    const b = this.routeBuffers.get(id);
+    if (b && (!b.saved || b.dirty)) {
+      this.saveRouteBuffer(id);
+    } else {
+      this.skres.editRouteInfo(id);
+    }
+  }
+
+  /**
+   * Persist an unsaved route edit buffer to a stored route via the Route
+   * Details dialog (name/description). On save, discard the buffer and re-open
+   * the info panel on the now-saved route (so its action becomes "Edit").
+   * Cancelling the dialog leaves the buffer unsaved.
+   */
+  protected async saveRouteBuffer(bufferId: string) {
+    // The shared save bridge handles the naming dialog, the server write,
+    // the route.saved event and discarding the buffer; we just re-open the
+    // info panel on the now-saved route so its action becomes "Edit".
+    // dialog: true — the FSK SAVE button always prompts for a name.
+    try {
+      const result = await this.plotterExt.saveBuffer(bufferId, {
+        dialog: true
+      });
+      if (result) {
+        this.infoPanel.open('routes', result.href);
+      }
+    } catch {
+      // saveBuffer already surfaced the server error via parseHttpErrorResponse;
+      // the buffer stays dirty so the user can retry.
+    }
+  }
+
   protected handleDrawEnded(e: DrawFeatureInfo) {
     this.mapInteract.isDrawing();
     // A completed draw is no longer being edited — clear the marker (set on
@@ -1799,7 +1842,16 @@ export class AppComponent {
         this.skres.newWaypointAt(e.coordinates as Position);
         break;
       case 'route':
-        this.skres.newRouteAt(e.coordinates as LineString);
+        // Draw a route into a live edit buffer (rendered as an amber draft)
+        // rather than immediately prompting to save. This lets routes-capable
+        // extensions (e.g. auto-routing) lock onto and rewrite the route before
+        // the user decides to persist it. Saving a buffer to a stored route
+        // (route.save) is a later slice.
+        this.routeBuffers.create({
+          points: (e.coordinates as LineString).map((position) => ({
+            position
+          }))
+        });
         break;
       case 'region':
         const region = new SKRegion();
@@ -1838,24 +1890,49 @@ export class AppComponent {
           return;
         }
 
-        // save changes
+        // save changes. Editing an unsaved live buffer just applies the change
+        // to the draft (it is not persisted here — that is an explicit Save),
+        // so word the prompt to match rather than implying a named save.
+        const fsParts = this.mapInteract.draw.forSave.id.split('.');
+        // A draft edit (unsaved live buffer) just stages the change; a saved
+        // route — or a saved buffer — persists on confirm, so word to match.
+        const draftBuf =
+          fsParts[0] === 'route'
+            ? this.routeBuffers.get(fsParts[1])
+            : undefined;
+        const isDraftEdit = !!draftBuf && !draftBuf.saved;
         this.app
           .showConfirm(
-            `Do you want to save the changes made to ${
-              this.mapInteract.draw.forSave.id.split('.')[0]
-            }?`,
-            'Save Changes'
+            isDraftEdit
+              ? 'Keep the changes to this unsaved route?'
+              : `Do you want to save the changes made to ${fsParts[0]}?`,
+            isDraftEdit ? 'Keep Changes' : 'Save Changes'
           )
           .subscribe((result) => {
             const r = this.mapInteract.draw.forSave.id.split('.');
             if (result) {
               // save changes
               if (r[0] === 'route') {
-                this.skres.updateRouteCoords(
-                  r[1],
-                  this.mapInteract.draw.forSave.coords,
-                  this.mapInteract.draw.forSave.coordsMetadata
-                );
+                const buf = this.routeBuffers.get(r[1]);
+                if (buf && !buf.saved) {
+                  // Unsaved draft: stage the modified geometry to the buffer
+                  // (emits route.dirty). Persisted only via an explicit Save.
+                  this.routeBuffers.replace(
+                    r[1],
+                    this.mapInteract.draw.forSave.coords.map((position) => ({
+                      position
+                    }))
+                  );
+                } else {
+                  // Saved route (plain resource or a saved buffer): persist the
+                  // edit, mirrored through the registry so extensions observe it
+                  // (route.visible/dirty → route.saved).
+                  this.plotterExt.saveNativeRouteEdit(
+                    r[1],
+                    this.mapInteract.draw.forSave.coords,
+                    this.mapInteract.draw.forSave.coordsMetadata
+                  );
+                }
               }
               if (r[0] === 'waypoint') {
                 this.skres.updateWaypointPosition(
@@ -1885,7 +1962,17 @@ export class AppComponent {
             } else {
               // do not save
               if (r[0] === 'route') {
-                this.skres.refreshRoutes();
+                const buf = this.routeBuffers.get(r[1]);
+                if (buf && (!buf.saved || buf.dirty)) {
+                  // Restore the draft (or dirty saved buffer): the Modify
+                  // interaction moved the map feature, but the buffer itself
+                  // was never changed.
+                  this.routeBuffers.refresh();
+                } else {
+                  // Clean saved route — re-render from the resource to revert
+                  // the unsaved geometry move.
+                  this.skres.refreshRoutes();
+                }
               }
               if (r[0] === 'waypoint') {
                 this.skres.refreshWaypoints();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1917,10 +1917,19 @@ export class AppComponent {
                 if (buf && !buf.saved) {
                   // Unsaved draft: stage the modified geometry to the buffer
                   // (emits route.dirty). Persisted only via an explicit Save.
+                  // Carry the per-point name/description so the metadata is not
+                  // dropped on a later Save.
+                  const meta = this.mapInteract.draw.forSave.coordsMetadata as
+                    | Array<{ name?: string; description?: string }>
+                    | undefined;
                   this.routeBuffers.replace(
                     r[1],
-                    this.mapInteract.draw.forSave.coords.map((position) => ({
-                      position
+                    this.mapInteract.draw.forSave.coords.map((position, i) => ({
+                      position,
+                      ...(meta?.[i]?.name ? { name: meta[i].name } : {}),
+                      ...(meta?.[i]?.description
+                        ? { description: meta[i].description }
+                        : {})
                     }))
                   );
                 } else {

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -267,6 +267,18 @@
   >
   </fb-routes>
 
+  <!-- Route edit buffers (unsaved drafts) rendered amber over saved routes -->
+  <fb-routes
+    [routes]="bufferRoutes()"
+    [routeStyles]="draftRouteStyles"
+    [activeRoute]="activeRoute"
+    [darkMode]="app.uiConfig().invertColor"
+    [labelMinZoom]="this.app.config.map.labelsMinZoom"
+    [mapZoom]="mapZoomLevel()"
+    [zIndex]="510"
+  >
+  </fb-routes>
+
   <!-- Routes -->
   @if (activeRoute && !app.data.activeRouteIsEditing) {
     <fb-route-direction
@@ -550,7 +562,9 @@
           "
           [featureCount]="overlay().featureCount"
           [units]="scaleUnits()"
+          [canSave]="isUnsavedRoute()"
           (modify)="modifyFeature(); popoverClosed()"
+          (save)="saveRouteFromPopover(); popoverClosed()"
           (delete)="
             deleteFeature(overlay().id, overlay().type); popoverClosed()
           "

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -917,6 +917,16 @@ export class FBMapComponent implements OnInit, OnDestroy {
     rte.feature.geometry.coordinates = b.points.map(
       (p) => p.position
     ) as LineString;
+    // Carry per-point metadata so editing a named draft (which seeds
+    // coordsMetadata from the rendered feature's pointMetadata) doesn't drop
+    // waypoint names/descriptions on save.
+    const coordsMeta = b.points.map((p) => ({
+      ...(p.name ? { name: p.name } : {}),
+      ...(p.description ? { description: p.description } : {})
+    }));
+    if (coordsMeta.some((m) => Object.keys(m).length > 0)) {
+      rte.feature.properties.coordinatesMeta = coordsMeta;
+    }
     rte.distance = GeoUtils.routeLength(rte.feature.geometry.coordinates);
     return [b.routeId, rte, true];
   }

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -8,6 +8,7 @@ import {
   ViewChild,
   SimpleChanges,
   signal,
+  computed,
   input,
   effect,
   inject
@@ -47,7 +48,13 @@ import { Feature as GeoJsonFeature } from 'geojson';
 
 import { Convert } from 'src/app/lib/convert';
 import { GeoUtils, Angle } from 'src/app/lib/geoutils';
-import { LineString, MultiLineString, Position } from 'src/app/types';
+import {
+  FBRoute,
+  FBRoutes,
+  LineString,
+  MultiLineString,
+  Position
+} from 'src/app/types';
 
 import { AppFacade } from 'src/app/app.facade';
 import { PlotterExtensionService } from 'src/app/modules/plotterext/plotterext.service';
@@ -82,10 +89,16 @@ import {
   destinationStyles,
   laylineStyles,
   drawStyles,
+  routeDraftStyles,
   targetAngleStyle,
   raceCourseStyles,
   bearingDistanceStyle
 } from './mapconfig';
+import { SKRoute } from 'src/app/modules/skresources/resource-classes';
+import {
+  RouteBuffer,
+  RouteBufferRegistry
+} from 'src/app/modules/plotterext/route-buffer.registry';
 import { ModifyEvent } from 'ol/interaction/Modify';
 import { DrawEvent } from 'ol/interaction/Draw';
 import { Coordinate } from 'ol/coordinate';
@@ -233,6 +246,18 @@ export class FBMapComponent implements OnInit, OnDestroy {
     bearingDistance: bearingDistanceStyle
   };
 
+  // Live route edit buffers (unsaved drafts) rendered via a second fb-routes
+  // layer in the amber draft style.
+  protected draftRouteStyles = routeDraftStyles;
+  protected bufferRoutes = computed<FBRoutes>(() =>
+    this.routeBuffers
+      .live()
+      // A saved + clean route renders from the resource layer (green); only
+      // unsaved or dirty routes get the amber draft styling.
+      .filter((b) => !b.saved || b.dirty)
+      .map((b) => this.bufferToFBRoute(b))
+  );
+
   // ** map feature data
   protected dfeat: IFeatureData = {
     aircraft: new Map(),
@@ -277,6 +302,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   private settings = inject(SettingsFacade);
   private bottomSheet = inject(MatBottomSheet);
   private infoPanel = inject(InfoPanelFacade);
+  protected routeBuffers = inject(RouteBufferRegistry);
 
   constructor() {
     effect(() => {
@@ -874,16 +900,55 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   /** Enter modify mode */
+  /** Convert a live route edit buffer to the FBRoute tuple fb-routes renders. */
+  /** The route buffer for `routeId` only when it represents an unsaved draft or
+   *  a route with pending edits. The registry now also mirrors clean saved
+   *  routes, so a plain `routeBuffers.has()` would wrongly treat those as
+   *  unsaved. */
+  private getUnsavedRouteBuffer(routeId: string): RouteBuffer | undefined {
+    const b = this.routeBuffers.get(routeId);
+    return b && (!b.saved || b.dirty) ? b : undefined;
+  }
+
+  private bufferToFBRoute(b: RouteBuffer): FBRoute {
+    const rte = new SKRoute();
+    rte.name = b.name ?? '';
+    rte.description = b.description ?? '';
+    rte.feature.geometry.coordinates = b.points.map(
+      (p) => p.position
+    ) as LineString;
+    rte.distance = GeoUtils.routeLength(rte.feature.geometry.coordinates);
+    return [b.routeId, rte, true];
+  }
+
+  /** True when the popover's route is an unsaved draft (or has pending edits). */
+  protected isUnsavedRoute(): boolean {
+    if (this.overlay().type !== 'route') {
+      return false;
+    }
+    const b = this.routeBuffers.get(this.overlay().id);
+    return !!b && (!b.saved || b.dirty);
+  }
+
+  /**
+   * Popover "Save" shortcut for an unsaved route — opens the standard Route
+   * Details dialog (same path as the info-panel SAVE) and persists. Saves the
+   * user a trip through INFO.
+   */
+  protected saveRouteFromPopover() {
+    void this.plotterExt.saveBuffer(this.overlay().id, { dialog: true });
+  }
+
   protected modifyFeature(featureType?: string) {
     if (this.mapInteract.draw.features.getLength() === 0) {
       return;
     }
     this.mapInteract.startModifying(this.overlay());
     if (this.overlay().type === 'route') {
-      this.mapInteract.measurementCoords = this.skres.fromCache(
-        'routes',
-        this.overlay().id
-      )[1].feature.geometry.coordinates;
+      const rid = this.overlay().id;
+      this.mapInteract.measurementCoords = this.routeBuffers.has(rid)
+        ? (this.routeBuffers.get(rid)!.points.map((p) => p.position) as LineString)
+        : this.skres.fromCache('routes', rid)[1].feature.geometry.coordinates;
     }
     if (featureType === 'anchor') {
       this.overlay().type = featureType;
@@ -1062,8 +1127,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
               class: 'icon-route'
             };
             addToFeatureList = true;
-            const r = this.skres.fromCache('routes', t[1]);
-            text = r[1].name;
+            const ub = this.getUnsavedRouteBuffer(t[1]);
+            if (ub) {
+              text = ub.name || 'Route (unsaved)';
+            } else {
+              const r = this.skres.fromCache('routes', t[1]);
+              text = r[1].name;
+            }
             break;
           case 'waypoint':
             icon = {
@@ -1366,22 +1436,38 @@ export class FBMapComponent implements OnInit, OnDestroy {
           this.popoverInfo();
         }
         break;
-      case 'route':
-        item = [this.skres.fromCache('routes', t[1])];
-        if (!item) {
-          return false;
+      case 'route': {
+        const ub = this.getUnsavedRouteBuffer(t[1]);
+        if (ub) {
+          // Unsaved live edit buffer (amber draft): build the popover from the
+          // registry, not the saved-route cache. The popover header shows the
+          // route name, so fall back to "(unsaved)" for an unnamed draft.
+          const skr = this.bufferToFBRoute(ub)[1];
+          skr.name = skr.name || '(unsaved)';
+          poData.id = t[1];
+          poData.type = 'route';
+          poData.title = 'Route (unsaved)';
+          poData.resource = [t[1], skr];
+          poData.show = true;
+          poData.readOnly = false;
+        } else {
+          item = [this.skres.fromCache('routes', t[1])];
+          if (!item) {
+            return false;
+          }
+          poData.id = t[1];
+          poData.type = t[0];
+          poData.title = 'Route';
+          poData.resource = item[0];
+          poData.show = true;
+          poData.readOnly = item[0][1]?.feature?.properties?.readOnly ?? false;
         }
-        poData.id = t[1];
-        poData.type = t[0];
-        poData.title = 'Route';
-        poData.resource = item[0];
-        poData.show = true;
-        poData.readOnly = item[0][1]?.feature?.properties?.readOnly ?? false;
         if (this.infoPanel.opened()) {
           this.overlay.set(poData);
           this.popoverInfo();
         }
         break;
+      }
       case 'waypoint':
         item = [this.skres.fromCache('waypoints', t[1])];
         if (!item) {
@@ -1443,7 +1529,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
       ['notes', 'regions', 'waypoints', 'routes'].includes(collection) &&
       this.app.useInfoPanel()
     ) {
-      this.infoPanel.open(collection, this.overlay().id);
+      const ub = this.getUnsavedRouteBuffer(this.overlay().id);
+      if (collection === 'routes' && ub) {
+        // Unsaved live buffer: open the info panel directly from the registry
+        // (it is not on the server, so infoPanel.open()'s fetch would fail).
+        this.infoPanel.openWith('routes', this.bufferToFBRoute(ub));
+      } else {
+        this.infoPanel.open(collection, this.overlay().id);
+      }
     } else {
       this.skres.resourceProperties(this.overlay());
     }
@@ -1746,9 +1839,22 @@ export class FBMapComponent implements OnInit, OnDestroy {
       case 'waypoint':
         this.skres.deleteWaypoint(id);
         break;
-      case 'route':
-        this.skres.deleteRoute(id);
+      case 'route': {
+        const b = this.routeBuffers.get(id);
+        if (b && !b.saved) {
+          // Unsaved draft — discard the live buffer locally.
+          this.routeBuffers.delete(id);
+        } else {
+          // Saved route (clean or dirty, with or without a buffer) — delete the
+          // stored resource, dropping any live buffer too. hiddenSaved=false so
+          // the registry's hidden event reports a permanent delete, not a hide.
+          if (b) {
+            this.routeBuffers.delete(id, false);
+          }
+          this.skres.deleteRoute(id);
+        }
         break;
+      }
       case 'note':
         this.skres.deleteNote(id);
         break;

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -935,8 +935,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
    * Details dialog (same path as the info-panel SAVE) and persists. Saves the
    * user a trip through INFO.
    */
-  protected saveRouteFromPopover() {
-    void this.plotterExt.saveBuffer(this.overlay().id, { dialog: true });
+  protected async saveRouteFromPopover() {
+    try {
+      await this.plotterExt.saveBuffer(this.overlay().id, { dialog: true });
+    } catch {
+      // saveBuffer surfaced the server error via parseHttpErrorResponse; the
+      // buffer stays dirty so the user can retry.
+    }
   }
 
   protected modifyFeature(featureType?: string) {
@@ -1834,7 +1839,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   // ********************
 
   // ** delete selected feature **
-  protected deleteFeature(id: string, type: string) {
+  protected async deleteFeature(id: string, type: string) {
     switch (type) {
       case 'waypoint':
         this.skres.deleteWaypoint(id);
@@ -1846,12 +1851,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
           this.routeBuffers.delete(id);
         } else {
           // Saved route (clean or dirty, with or without a buffer) — delete the
-          // stored resource, dropping any live buffer too. hiddenSaved=false so
-          // the registry's hidden event reports a permanent delete, not a hide.
-          if (b) {
+          // stored resource by its href (a saved draft keeps its draft routeId),
+          // and only drop the live buffer once the server delete is confirmed so
+          // a cancel/failure doesn't lose it. hiddenSaved=false so the registry's
+          // hidden event reports a permanent delete, not a hide.
+          const ok = await this.skres.deleteRoute(b?.href ?? id);
+          if (ok && b) {
             this.routeBuffers.delete(id, false);
           }
-          this.skres.deleteRoute(id);
         }
         break;
       }

--- a/src/app/modules/map/mapconfig.ts
+++ b/src/app/modules/map/mapconfig.ts
@@ -89,6 +89,29 @@ export const routeStyles = {
   })
 };
 
+// Live route edit buffers (unsaved drafts). A distinct amber colour so a draft
+// at rest reads differently from a committed (green) saved route; vertex dots
+// come from the line style. Interactive edit-mode handles are added later.
+export const routeDraftStyles = {
+  default: new Style({
+    stroke: new Stroke({
+      color: '#e8932b',
+      width: 3,
+      lineDash: [10, 6]
+    }),
+    text: new Text({
+      text: '',
+      offsetY: 10
+    })
+  }),
+  active: new Style({
+    stroke: new Stroke({
+      color: '#e8932b',
+      width: 4
+    })
+  })
+};
+
 // ***********
 
 export const anchorStyles = {

--- a/src/app/modules/map/popovers/resource-popover.component.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.ts
@@ -335,9 +335,12 @@ export class ResourcePopoverComponent {
       this.ctrl.showSaveButton = this.type() === 'route' && this.canSave();
       if (this.ctrl.showSaveButton) {
         // Unsaved draft: also offer a quick Delete (discard) shortcut, and hide
-        // Start — navigating a route that isn't persisted doesn't work.
+        // the actions that only work against a stored resource — Start
+        // (navigation), Route Points and Show Notes — which a draft has none of.
         this.ctrl.showDeleteButton = true;
         this.ctrl.canActivate = false;
+        this.ctrl.showPointsButton = false;
+        this.ctrl.showNotesButton = false;
       }
     });
   }

--- a/src/app/modules/map/popovers/resource-popover.component.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.ts
@@ -28,10 +28,12 @@ interface PopoverCtrl {
   showRelatedButton: boolean;
   showPointsButton: boolean;
   showNotesButton: boolean;
+  showSaveButton: boolean;
   canActivate: boolean;
   isActive: boolean;
   activeText: string;
   isReadOnly: boolean;
+  modifyLabel: string;
 }
 
 @Component({
@@ -110,7 +112,10 @@ interface PopoverCtrl {
 
       <div style="display:flex;flex-wrap: wrap;">
         @if (ctrl.showModifyButton) {
-          <div class="popover-action-button">
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 1 : null"
+          >
             <button
               mat-button
               (click)="emitModify()"
@@ -119,7 +124,7 @@ interface PopoverCtrl {
               [disabled]="this.ctrl.isReadOnly"
             >
               <mat-icon>touch_app</mat-icon>
-              MOVE
+              {{ ctrl.modifyLabel }}
             </button>
           </div>
         }
@@ -137,7 +142,10 @@ interface PopoverCtrl {
           </div>
         }
         @if (ctrl.showDeleteButton) {
-          <div class="popover-action-button">
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 6 : null"
+          >
             <button
               mat-button
               [disabled]="ctrl.isReadOnly || ctrl.isActive"
@@ -151,7 +159,10 @@ interface PopoverCtrl {
           </div>
         }
         @if (ctrl.canActivate && !ctrl.isActive) {
-          <div class="popover-action-button">
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 2 : null"
+          >
             <button
               mat-button
               (click)="emitActive(true)"
@@ -167,7 +178,10 @@ interface PopoverCtrl {
             </button>
           </div>
         } @else if (ctrl.canActivate && ctrl.isActive) {
-          <div class="popover-action-button">
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 2 : null"
+          >
             <button
               mat-button
               (click)="emitActive(false)"
@@ -180,7 +194,10 @@ interface PopoverCtrl {
           </div>
         }
         @if (ctrl.showPointsButton) {
-          <div class="popover-action-button">
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 3 : null"
+          >
             <button
               mat-button
               (click)="emitPoints()"
@@ -206,7 +223,10 @@ interface PopoverCtrl {
           </div>
         }
         @if (ctrl.showNotesButton) {
-          <div class="popover-action-button">
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 4 : null"
+          >
             <button
               mat-button
               (click)="emitNotes()"
@@ -219,7 +239,10 @@ interface PopoverCtrl {
           </div>
         }
         @if (ctrl.showInfoButton) {
-          <div class="popover-action-button">
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 5 : null"
+          >
             <button
               mat-button
               (click)="emitInfo()"
@@ -228,6 +251,23 @@ interface PopoverCtrl {
             >
               <mat-icon>info_outline</mat-icon>
               INFO
+            </button>
+          </div>
+        }
+        @if (ctrl.showSaveButton) {
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 2 : null"
+          >
+            <button
+              mat-button
+              color="primary"
+              (click)="emitSave()"
+              matTooltip="Save Route"
+              matTooltipPosition="after"
+            >
+              <mat-icon>save</mat-icon>
+              SAVE
             </button>
           </div>
         }
@@ -244,7 +284,10 @@ export class ResourcePopoverComponent {
   featureCount = input<number>(0);
   units = input<string>('m');
   canClose = input<boolean>();
+  /** Host-set: this route is an unsaved draft → show the Save shortcut. */
+  canSave = input<boolean>(false);
   modify = output<void>();
+  save = output<void>();
   delete = output<void>();
   addNote = output<void>();
   activated = output<void>();
@@ -266,10 +309,12 @@ export class ResourcePopoverComponent {
     showRelatedButton: false,
     showPointsButton: false,
     showNotesButton: false,
+    showSaveButton: false,
     canActivate: false,
     isActive: false,
     activeText: 'ACTIVE',
-    isReadOnly: false
+    isReadOnly: false,
+    modifyLabel: 'MOVE'
   };
   protected hasMarkdown = signal<boolean>(false);
   protected icon: AppIconDef;
@@ -283,6 +328,17 @@ export class ResourcePopoverComponent {
       this.parse();
       this.ctrl.showModifyButton =
         this.type() !== 'destination' && this.featureCount() > 0 ? true : false;
+      // Routes/regions are shape-edited ("Modify"); points are moved ("Move").
+      this.ctrl.modifyLabel =
+        this.type() === 'route' || this.type() === 'region' ? 'MODIFY' : 'MOVE';
+      // Save shortcut: only for an unsaved route (host-decided via canSave).
+      this.ctrl.showSaveButton = this.type() === 'route' && this.canSave();
+      if (this.ctrl.showSaveButton) {
+        // Unsaved draft: also offer a quick Delete (discard) shortcut, and hide
+        // Start — navigating a route that isn't persisted doesn't work.
+        this.ctrl.showDeleteButton = true;
+        this.ctrl.canActivate = false;
+      }
     });
   }
 
@@ -378,9 +434,9 @@ export class ResourcePopoverComponent {
     this.ctrl.showNotesButton = this.app.useInfoPanel() ? false : true;
     this.ctrl.showAddNoteButton = false;
     this.ctrl.showRelatedButton = false;
-    this.ctrl.showDeleteButton = this.app.useInfoPanel()
-      ? false
-      : !this.ctrl.isReadOnly;
+    // Always offer Delete for routes (consistent lower-right action), even with
+    // the info panel; the button itself is disabled when the route is active.
+    this.ctrl.showDeleteButton = !this.ctrl.isReadOnly;
 
     this.icon = getResourceIcon('routes', this.resource()[1]);
     this._title.set(this.resource()[1].name ?? '');
@@ -445,6 +501,10 @@ export class ResourcePopoverComponent {
 
   emitModify() {
     this.modify.emit();
+  }
+
+  emitSave() {
+    this.save.emit();
   }
 
   emitAddNote() {

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -18,7 +18,13 @@
 //
 // Map/resource host APIs (buttons, filters, map.*) belong to phase 3.
 
-import { Injectable, computed, isDevMode, signal } from '@angular/core';
+import {
+  Injectable,
+  computed,
+  effect,
+  isDevMode,
+  signal
+} from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { firstValueFrom } from 'rxjs';
 import { SignalKClient } from 'signalk-client-angular';
@@ -28,10 +34,11 @@ import * as uuid from 'uuid';
 import { AppFacade } from 'src/app/app.facade';
 import { SKResourceService } from 'src/app/modules/skresources/resources.service';
 import { MapService } from 'src/app/modules/map/ol/lib/map.service';
-import { FBNotes } from 'src/app/types';
+import { FBNotes, LineString, Position } from 'src/app/types';
 import {
   HostConnection,
   MethodHandler,
+  RoutePoint,
   RpcError,
   RPC_ERRORS,
   windowPort
@@ -56,6 +63,8 @@ import {
   cellHeightPx,
   parseSize
 } from './types';
+import { RouteBufferRegistry } from './route-buffer.registry';
+import { createRouteMethods } from './route-methods';
 
 const STATE_STORAGE_KEY = 'fb-plotterext-state';
 const SK_PATH_PERIOD = 1000; // default delta period (ms) for relayed paths
@@ -560,7 +569,8 @@ export class PlotterExtensionService {
     private signalk: SignalKClient,
     private dialog: MatDialog,
     private skres: SKResourceService,
-    private mapService: MapService
+    private mapService: MapService,
+    private routeRegistry: RouteBufferRegistry
   ) {
     if (isDevMode()) {
       // console handle for exercising the host API during development
@@ -572,6 +582,363 @@ export class PlotterExtensionService {
     window.addEventListener('resize', () =>
       this.viewportTick.update((n) => n + 1)
     );
+    this.bridgeRouteEvents();
+    // Mirror Freeboard's displayed (selected) routes into the visible-route
+    // registry so the `routes` capability reflects them — including routes
+    // restored from a previous session's selection state on load. Reads
+    // skres.routes() so it re-runs whenever the displayed set changes.
+    effect(() => this.syncVisibleFromSelections());
+  }
+
+  /**
+   * Bring the registry in line with the host's displayed saved routes: show any
+   * that are displayed but not yet mirrored (emits `route.visible saved:true`),
+   * and hide mirrors of routes no longer displayed that have no pending edits
+   * (emits `route.hidden saved:true`). Drafts and dirty edits are left alone.
+   */
+  /** Build RoutePoints from a route's geometry + coordinatesMeta, carrying each
+   *  point's name AND description so they survive a round-trip through the
+   *  registry and back into coordinatesMeta on save. */
+  private pointsFromRoute(
+    coords: Position[],
+    meta?: Array<{ name?: string; description?: string }>
+  ): RoutePoint[] {
+    return coords.map((position, i) => ({
+      position,
+      ...(meta?.[i]?.name ? { name: meta[i].name } : {}),
+      ...(meta?.[i]?.description ? { description: meta[i].description } : {})
+    }));
+  }
+
+  /** Deep-compare two point lists (position + name + description) so a
+   *  same-length geometry/metadata edit is still detected as a change. */
+  private pointsEqual(a: RoutePoint[], b: RoutePoint[]): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+    return a.every((p, i) => {
+      const q = b[i];
+      return (
+        p.position[0] === q.position[0] &&
+        p.position[1] === q.position[1] &&
+        (p.name ?? null) === (q.name ?? null) &&
+        (p.description ?? null) === (q.description ?? null)
+      );
+    });
+  }
+
+  private syncVisibleFromSelections(): void {
+    const displayed = this.skres.routes();
+    const displayedHrefs = new Set(displayed.map((r) => r[0]));
+    for (const [id, route] of displayed) {
+      const coords = (route.feature?.geometry?.coordinates ?? []) as Position[];
+      const meta = route.feature?.properties?.coordinatesMeta as
+        | Array<{ name?: string; description?: string }>
+        | undefined;
+      const points = this.pointsFromRoute(coords, meta);
+      // Resolve by href, not routeId: a draft saved via route.save keeps its
+      // original (draft) routeId while its href points at the new resource, so
+      // get(id) can be undefined while a buffer for this resource exists.
+      const mirror = this.routeRegistry.getByHref(id);
+      if (mirror) {
+        // Refresh our own clean mirror when the backing route changed
+        // server-side; never clobber a draft or a buffer with pending edits.
+        const stale =
+          mirror.saved &&
+          !mirror.dirty &&
+          ((mirror.name ?? null) !== (route.name ?? null) ||
+            (mirror.description ?? null) !== (route.description ?? null) ||
+            !this.pointsEqual(mirror.points, points));
+        if (stale) {
+          this.routeRegistry.show({
+            routeId: mirror.routeId,
+            name: route.name ?? null,
+            description: route.description ?? null,
+            points,
+            href: id
+          });
+        }
+        continue;
+      }
+      this.routeRegistry.show({
+        routeId: id,
+        name: route.name ?? null,
+        description: route.description ?? null,
+        points,
+        href: id
+      });
+    }
+    for (const buf of this.routeRegistry.all()) {
+      if (buf.saved && !buf.dirty && buf.href && !displayedHrefs.has(buf.href)) {
+        this.routeRegistry.delete(buf.routeId, true);
+      }
+    }
+  }
+
+  /**
+   * Bridge RouteBufferRegistry mutations to `route.*` bus events. Delivery is
+   * subscription-gated by broadcastMessage, so only contexts that subscribed
+   * to (e.g.) `route.**` receive them. The service is an app-lifetime singleton,
+   * so this subscription lives for the session by design.
+   */
+  private bridgeRouteEvents(): void {
+    this.routeRegistry.events$.subscribe((e) => {
+      switch (e.type) {
+        case 'visible':
+          this.broadcastMessage('route.visible', {
+            routeId: e.routeId,
+            rev: e.rev,
+            name: e.name,
+            pointCount: e.pointCount,
+            saved: e.saved,
+            dirty: e.dirty
+          });
+          break;
+        case 'hidden':
+          this.broadcastMessage('route.hidden', {
+            routeId: e.routeId,
+            rev: e.rev,
+            saved: e.saved
+          });
+          break;
+        case 'dirty':
+          this.broadcastMessage('route.dirty', {
+            routeId: e.routeId,
+            rev: e.rev,
+            ...(e.reason !== undefined ? { reason: e.reason } : {})
+          });
+          break;
+      }
+    });
+  }
+
+  /** Host API handlers for the `routes` capability. */
+  private routeMethods(): Record<string, MethodHandler> {
+    return createRouteMethods(this.routeRegistry, {
+      onSave: (routeId, params) => this.saveBuffer(routeId, params),
+      onShow: (ref) => this.showRoute(ref),
+      onHide: (routeId) => this.hideRoute(routeId),
+      onDelete: (routeId) => this.deleteRoute(routeId)
+    });
+  }
+
+  /**
+   * `route.hide`: remove a route from the map. A saved route's visibility is
+   * unchecked (the stored resource is untouched → `route.hidden saved:true`); an
+   * unsaved draft is discarded (`route.hidden saved:false`).
+   */
+  hideRoute(routeId: string): void {
+    const buf = this.routeRegistry.get(routeId);
+    if (!buf) {
+      return;
+    }
+    if (buf.saved && buf.href) {
+      this.skres.selectionRemove('routes', buf.href);
+      this.skres.refreshRoutes();
+      this.routeRegistry.delete(routeId, true);
+    } else {
+      this.routeRegistry.delete(routeId, false);
+    }
+  }
+
+  /**
+   * `route.delete`: permanently delete a saved route from the store (and discard
+   * an unsaved one — same effect as hide). The route leaves the visible set as
+   * `route.hidden saved:false` (gone) in both cases.
+   */
+  async deleteRoute(routeId: string): Promise<void> {
+    const buf = this.routeRegistry.get(routeId);
+    if (!buf) {
+      return;
+    }
+    if (buf.saved && buf.href) {
+      // Delete the resource directly (no confirm dialog — the extension already
+      // chose to delete) and await it; keep the route on failure so host state
+      // matches the server.
+      try {
+        await this.skres.deleteFromServer('routes', buf.href);
+      } catch (err) {
+        this.app.parseHttpErrorResponse(err);
+        return;
+      }
+    }
+    this.routeRegistry.delete(routeId, false);
+  }
+
+  /**
+   * Bring a stored route into the visible set (capability `route.show`): ensure
+   * it is displayed, load its geometry, and register it as an addressable
+   * saved + clean route under its resource id. Throws `routes.badRef` if no such
+   * route exists.
+   */
+  async showRoute(ref: string): Promise<{ routeId: string; rev: number }> {
+    // Already mirrored (a displayed route, or shown before)? Return the existing
+    // buffer rather than creating a duplicate for the same resource.
+    const existing = this.routeRegistry.getByHref(ref);
+    if (existing) {
+      return { routeId: existing.routeId, rev: existing.rev };
+    }
+    this.skres.selectionAdd('routes', ref);
+    await this.skres.refreshRoutes();
+    const cached = this.skres.fromCache('routes', ref);
+    if (!cached) {
+      // Undo the speculative selection so an unknown ref doesn't linger in config.
+      this.skres.selectionRemove('routes', ref);
+      throw new RpcError('No such route', { reason: 'routes.badRef' });
+    }
+    const route = cached[1];
+    const coords = (route.feature?.geometry?.coordinates ?? []) as Position[];
+    const meta = route.feature?.properties?.coordinatesMeta as
+      | Array<{ name?: string; description?: string }>
+      | undefined;
+    const points = this.pointsFromRoute(coords, meta);
+    const buf = this.routeRegistry.show({
+      routeId: ref,
+      name: route.name ?? null,
+      description: route.description ?? null,
+      points,
+      href: ref
+    });
+    return { routeId: buf.routeId, rev: buf.rev };
+  }
+
+  /**
+   * Mirror a native edit of a stored route through the registry so extensions
+   * observe it, then persist. The route becomes addressable (`route.visible` if
+   * newly mirrored, else `route.dirty`) and is then saved (`route.saved`). The
+   * geometry is persisted via the existing resource path, preserving per-point
+   * metadata. Called by the host's own Modify-route flow.
+   */
+  async saveNativeRouteEdit(
+    routeId: string,
+    coords: Position[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    coordsMetadata?: Array<any>
+  ): Promise<void> {
+    const points = this.pointsFromRoute(coords, coordsMetadata);
+    let buf = this.routeRegistry.get(routeId);
+    if (!buf) {
+      const cached = this.skres.fromCache('routes', routeId);
+      const name = cached ? (cached[1].name ?? null) : null;
+      const description = cached ? (cached[1].description ?? null) : null;
+      buf = this.routeRegistry.show({
+        routeId,
+        name,
+        description,
+        points,
+        href: routeId
+      });
+    } else {
+      this.routeRegistry.replace(routeId, points);
+      buf = this.routeRegistry.get(routeId);
+    }
+    const href = buf?.href ?? routeId;
+    // Await persistence — only mark saved + broadcast route.saved if the PUT
+    // succeeded; otherwise the buffer stays dirty.
+    const ok = await this.skres.updateRouteCoords(href, coords, coordsMetadata);
+    if (!ok) {
+      return;
+    }
+    const rev = this.routeRegistry.markSaved(routeId, href) ?? 0;
+    this.broadcastMessage('route.saved', {
+      routeId,
+      rev,
+      href,
+      name: buf?.name ?? null,
+      saved: true,
+      dirty: false
+    });
+  }
+
+  /**
+   * Persist a live route to the `routes` resource, emit `route.saved`, and keep
+   * it in the visible set under the same `routeId` (now `saved:true,
+   * dirty:false`) — saving does not consume the route. Resolves with
+   * `{ href, rev }` on save, or null if the user cancelled. Shared by the
+   * `route.save` host method and the FSK info-panel "Save" action so both behave
+   * identically. Pass `dialog:true` to prompt for the name/description.
+   */
+  async saveBuffer(
+    routeId: string,
+    opts: { name?: string; description?: string; dialog?: boolean } = {}
+  ): Promise<{ href: string; rev: number } | null> {
+    const buf = this.routeRegistry.get(routeId);
+    if (!buf) {
+      return null;
+    }
+    const [, route] = this.skres.buildRoute(
+      buf.points.map((p) => p.position) as LineString
+    );
+    // buildRoute keeps only positions — carry the per-point names/descriptions
+    // and the route-level description so they are not silently dropped on save.
+    const coordinatesMeta = buf.points.map((p) => ({
+      ...(p.name ? { name: p.name } : {}),
+      ...(p.description ? { description: p.description } : {})
+    }));
+    if (coordinatesMeta.some((m) => Object.keys(m).length > 0)) {
+      route.feature.properties.coordinatesMeta = coordinatesMeta;
+    }
+    route.name = opts.name ?? buf.name ?? '';
+    route.description = opts.description ?? buf.description ?? '';
+    let savedId: string | null;
+    if (buf.href) {
+      // Backed by an existing resource — update it in place (keep its id).
+      try {
+        await this.skres.putToServer('routes', buf.href, route);
+        savedId = buf.href;
+      } catch (err) {
+        this.app.parseHttpErrorResponse(err);
+        // A server rejection is a real failure, not a user cancel — surface it
+        // so route.save reports routes.saveFailed instead of routes.saveCancelled.
+        throw new RpcError('Failed to save route', {
+          reason: 'routes.saveFailed'
+        });
+      }
+    } else if (opts.dialog) {
+      // Interactive: open the Route Details dialog (prefilled) so the user
+      // names it. Returns null if they cancel.
+      savedId = await this.skres.saveNewRoute(route);
+    } else {
+      // Headless create: persist directly with the supplied (or buffer) name.
+      try {
+        const rte = await this.skres.postToServer('routes', route);
+        savedId = rte.id;
+        // The dialog path (saveNewRoute) selects the new route; do the same for
+        // the headless path so it stays displayed after a refresh.
+        this.skres.selectionAdd('routes', savedId);
+      } catch (err) {
+        this.app.parseHttpErrorResponse(err);
+        throw new RpcError('Failed to save route', {
+          reason: 'routes.saveFailed'
+        });
+      }
+    }
+    if (!savedId) {
+      // Only the interactive dialog path returns null — the user cancelled.
+      return null;
+    }
+    // Keep the route in the visible set under the same routeId, now saved+clean,
+    // recording the backing resource id + the (possibly dialog-set) name.
+    const savedName = route.name || null;
+    const rev =
+      this.routeRegistry.markSaved(
+        routeId,
+        savedId,
+        savedName,
+        route.description || null
+      ) ?? buf.rev + 1;
+    this.broadcastMessage('route.saved', {
+      routeId,
+      rev,
+      href: savedId,
+      name: savedName,
+      saved: true,
+      dirty: false
+    });
+    // The route is persisted and no longer being edited — clear the editing
+    // marker so the route-list visibility checkboxes are not left disabled.
+    this.app.data.editingId = '';
+    return { href: savedId, rev };
   }
 
   /** Fetch manifests. Called after the server connection is established. */
@@ -963,6 +1330,7 @@ export class PlotterExtensionService {
         ...this.unitsMethods(),
         ...this.resourcesMethods(placed.extension),
         ...this.mapMethods(),
+        ...this.routeMethods(),
         ...this.uiPanelMethods(placed.extension),
         'ui.openConfigPanel': async () => {
           this.openConfigPanel(placed);
@@ -1017,6 +1385,7 @@ export class PlotterExtensionService {
         ...this.unitsMethods(),
         ...this.resourcesMethods(opts.extension),
         ...this.mapMethods(),
+        ...this.routeMethods(),
         ...this.uiPanelMethods(opts.extension),
         'ui.closePanel': async () => {
           opts.close();
@@ -1061,6 +1430,7 @@ export class PlotterExtensionService {
         ...this.unitsMethods(),
         ...this.resourcesMethods(opts.extension),
         ...this.mapMethods(),
+        ...this.routeMethods(),
         ...this.uiPanelMethods(opts.extension)
       },
       onError: (err) => console.warn('plotterext background error', err)

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -621,6 +621,7 @@ export class PlotterExtensionService {
       return (
         p.position[0] === q.position[0] &&
         p.position[1] === q.position[1] &&
+        (p.position[2] ?? null) === (q.position[2] ?? null) &&
         (p.name ?? null) === (q.name ?? null) &&
         (p.description ?? null) === (q.description ?? null)
       );
@@ -896,8 +897,15 @@ export class PlotterExtensionService {
       }
     } else if (opts.dialog) {
       // Interactive: open the Route Details dialog (prefilled) so the user
-      // names it. Returns null if they cancel.
-      savedId = await this.skres.saveNewRoute(route);
+      // names it. Resolves null on cancel; rejects on a server failure, which
+      // we surface as routes.saveFailed rather than letting it look like a cancel.
+      try {
+        savedId = await this.skres.saveNewRoute(route);
+      } catch {
+        throw new RpcError('Failed to save route', {
+          reason: 'routes.saveFailed'
+        });
+      }
     } else {
       // Headless create: persist directly with the supplied (or buffer) name.
       try {

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -759,8 +759,13 @@ export class PlotterExtensionService {
       try {
         await this.skres.deleteFromServer('routes', buf.href);
       } catch (err) {
+        // The server rejected the delete — surface it and reject so route.delete
+        // reports failure instead of letting the extension drop local state for
+        // a route that still exists.
         this.app.parseHttpErrorResponse(err);
-        return;
+        throw new RpcError('Failed to delete route', {
+          reason: 'routes.deleteFailed'
+        });
       }
     }
     this.routeRegistry.delete(routeId, false);
@@ -822,17 +827,19 @@ export class PlotterExtensionService {
       const cached = this.skres.fromCache('routes', routeId);
       const name = cached ? (cached[1].name ?? null) : null;
       const description = cached ? (cached[1].description ?? null) : null;
-      buf = this.routeRegistry.show({
+      this.routeRegistry.show({
         routeId,
         name,
         description,
         points,
         href: routeId
       });
-    } else {
-      this.routeRegistry.replace(routeId, points);
-      buf = this.routeRegistry.get(routeId);
     }
+    // Mark the edit dirty (in both the new-mirror and existing-buffer cases)
+    // before persisting, so a failed PUT leaves an unsaved edit as dirty rather
+    // than a clean saved route, and extensions still see route.dirty.
+    this.routeRegistry.replace(routeId, points);
+    buf = this.routeRegistry.get(routeId);
     const href = buf?.href ?? routeId;
     // Await persistence — only mark saved + broadcast route.saved if the PUT
     // succeeded; otherwise the buffer stays dirty.

--- a/src/app/modules/plotterext/route-buffer.registry.spec.ts
+++ b/src/app/modules/plotterext/route-buffer.registry.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RouteBufferRegistry,
+  RouteRegistryEvent
+} from './route-buffer.registry';
+
+describe('RouteBufferRegistry', () => {
+  it('creates a buffer with rev 1 and returns it via get', () => {
+    const reg = new RouteBufferRegistry();
+    const { routeId, rev } = reg.create({
+      name: 'Test',
+      points: [{ position: [-80.1, 25.7] }]
+    });
+    expect(rev).toBe(1);
+    const b = reg.get(routeId);
+    expect(b?.name).toBe('Test');
+    expect(b?.rev).toBe(1);
+    expect(b?.saved).toBe(false);
+    expect(b?.dirty).toBe(true);
+    expect(b?.points).toHaveLength(1);
+    expect(b?.points[0].position).toEqual([-80.1, 25.7]);
+  });
+
+  it('defaults name to null and points to empty', () => {
+    const reg = new RouteBufferRegistry();
+    const { routeId } = reg.create();
+    const b = reg.get(routeId);
+    expect(b?.name).toBeNull();
+    expect(b?.points).toEqual([]);
+  });
+
+  it('lists all live buffers as summaries', () => {
+    const reg = new RouteBufferRegistry();
+    const a = reg.create({ name: 'A' });
+    const b = reg.create({ name: 'B' });
+    const ids = reg
+      .list()
+      .map((s) => s.routeId)
+      .sort();
+    expect(ids).toEqual([a.routeId, b.routeId].sort());
+    const sumA = reg.list().find((s) => s.routeId === a.routeId);
+    expect(sumA).toMatchObject({
+      name: 'A',
+      rev: 1,
+      pointCount: 0,
+      saved: false,
+      dirty: true
+    });
+  });
+
+  it('returns undefined for an unknown id and false when deleting it', () => {
+    const reg = new RouteBufferRegistry();
+    expect(reg.get('nope')).toBeUndefined();
+    expect(reg.has('nope')).toBe(false);
+    expect(reg.delete('nope')).toBe(false);
+  });
+
+  it('deletes a buffer, removing it from get and list', () => {
+    const reg = new RouteBufferRegistry();
+    const { routeId } = reg.create({ name: 'X' });
+    expect(reg.delete(routeId)).toBe(true);
+    expect(reg.get(routeId)).toBeUndefined();
+    expect(reg.list()).toEqual([]);
+  });
+
+  it('assigns a unique id to each buffer', () => {
+    const reg = new RouteBufferRegistry();
+    const a = reg.create();
+    const b = reg.create();
+    expect(a.routeId).not.toBe(b.routeId);
+  });
+
+  it('emits visible then hidden with a monotonic rev and flags', () => {
+    const reg = new RouteBufferRegistry();
+    const seen: RouteRegistryEvent[] = [];
+    reg.events$.subscribe((e) => seen.push(e));
+    const { routeId } = reg.create({
+      name: 'X',
+      points: [{ position: [0, 0] }]
+    });
+    reg.delete(routeId);
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toMatchObject({
+      type: 'visible',
+      routeId,
+      rev: 1,
+      name: 'X',
+      pointCount: 1,
+      saved: false,
+      dirty: true
+    });
+    // A draft hidden ⇒ deleted: saved:false.
+    expect(seen[1]).toMatchObject({
+      type: 'hidden',
+      routeId,
+      rev: 2,
+      saved: false
+    });
+  });
+
+  it('show() adds a saved+clean addressable route with an href, emitting visible', () => {
+    const reg = new RouteBufferRegistry();
+    const seen: RouteRegistryEvent[] = [];
+    reg.events$.subscribe((e) => seen.push(e));
+    const b = reg.show({
+      routeId: 'res-1',
+      name: 'Stored',
+      points: [{ position: [0, 0] }, { position: [1, 1] }],
+      href: 'res-1'
+    });
+    expect(b.saved).toBe(true);
+    expect(b.dirty).toBe(false);
+    expect(b.href).toBe('res-1');
+    expect(reg.get('res-1')?.points).toHaveLength(2);
+    expect(seen[0]).toMatchObject({
+      type: 'visible',
+      routeId: 'res-1',
+      saved: true,
+      dirty: false,
+      pointCount: 2
+    });
+  });
+
+  it('markSaved flips a draft to saved+clean, keeping it addressable', () => {
+    const reg = new RouteBufferRegistry();
+    const { routeId } = reg.create({
+      name: 'P',
+      points: [{ position: [0, 0] }]
+    });
+    const rev = reg.markSaved(routeId, 'routes/saved-1');
+    expect(rev).toBe(2);
+    const b = reg.get(routeId);
+    expect(b?.saved).toBe(true);
+    expect(b?.dirty).toBe(false);
+    // Still in the visible set under the same id.
+    expect(reg.list().map((s) => s.routeId)).toContain(routeId);
+  });
+
+  it('tracks a route-level description (create + markSaved updates it)', () => {
+    const reg = new RouteBufferRegistry();
+    const { routeId } = reg.create({
+      name: 'D',
+      description: 'around the shoal',
+      points: [{ position: [0, 0] }]
+    });
+    expect(reg.get(routeId)?.description).toBe('around the shoal');
+    reg.markSaved(routeId, 'routes/abc', 'D', 'updated note');
+    expect(reg.get(routeId)?.description).toBe('updated note');
+  });
+
+  it('snapshots defensively — mutating a returned buffer does not affect the registry', () => {
+    const reg = new RouteBufferRegistry();
+    const { routeId } = reg.create({ points: [{ position: [1, 2] }] });
+    const b = reg.get(routeId)!;
+    b.points[0].position[0] = 999;
+    b.points.push({ position: [3, 4] });
+    const fresh = reg.get(routeId)!;
+    expect(fresh.points).toHaveLength(1);
+    expect(fresh.points[0].position[0]).toBe(1);
+  });
+
+  it('replace sets all points, bumps rev, and emits a dirty event', () => {
+    const reg = new RouteBufferRegistry();
+    const { routeId } = reg.create({ points: [{ position: [0, 0] }] });
+    const events: RouteRegistryEvent[] = [];
+    reg.events$.subscribe((e) => events.push(e));
+    const updated = reg.replace(routeId, [
+      { position: [1, 1] },
+      { position: [2, 2] }
+    ]);
+    expect(updated?.rev).toBe(2);
+    expect(updated?.points).toHaveLength(2);
+    expect(reg.get(routeId)?.points[1].position).toEqual([2, 2]);
+    expect(events).toEqual([
+      { type: 'dirty', routeId, rev: 2, reason: 'replaced' }
+    ]);
+  });
+
+  it('replace on an unknown id returns undefined', () => {
+    const reg = new RouteBufferRegistry();
+    expect(reg.replace('nope', [])).toBeUndefined();
+  });
+
+  it('exposes a reactive live() signal that tracks create/replace/delete', () => {
+    const reg = new RouteBufferRegistry();
+    expect(reg.live()).toEqual([]);
+    const { routeId } = reg.create({ name: 'A', points: [{ position: [0, 0] }] });
+    expect(reg.live()).toHaveLength(1);
+    expect(reg.live()[0].routeId).toBe(routeId);
+    reg.replace(routeId, [{ position: [1, 1] }, { position: [2, 2] }]);
+    expect(reg.live()[0].points).toHaveLength(2);
+    reg.delete(routeId);
+    expect(reg.live()).toEqual([]);
+  });
+});

--- a/src/app/modules/plotterext/route-buffer.registry.ts
+++ b/src/app/modules/plotterext/route-buffer.registry.ts
@@ -1,0 +1,316 @@
+import { Injectable, signal } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import type { RoutePoint, RouteSummary } from 'signalk-plotterext-bus/host';
+
+/**
+ * A live, in-memory route edit buffer. Not necessarily persisted: a buffer is
+ * a route the host is currently holding/rendering, addressed by a host-assigned
+ * `routeId`, that may never be saved (persistence is opt-in elsewhere).
+ */
+export interface RouteBuffer {
+  routeId: string;
+  name: string | null;
+  /** Route-level description (distinct from a waypoint's per-point description). */
+  description: string | null;
+  /** Monotonic revision; increments on every mutation. */
+  rev: number;
+  /** Whether the route is backed by a persisted routes resource. */
+  saved: boolean;
+  /** Whether the in-memory route has pending unsaved changes. */
+  dirty: boolean;
+  /** Backing routes-resource id when saved (the resource this route persists
+   *  to). Undefined for a never-saved draft. */
+  href?: string;
+  points: RoutePoint[];
+}
+
+/**
+ * A registry mutation, surfaced on `events$`. The host bridges these to the
+ * `route.*` bus events of the plotter-extensions `routes` capability
+ * (`visible`/`hidden`/`dirty`). Point mutations (`route.point.*`) extend this
+ * union in a later slice; `dirty` is the conformance-floor catch-all. The
+ * `route.saved` event is emitted by the host service (it owns the resource
+ * `href`), not via this stream.
+ */
+export type RouteRegistryEvent =
+  | {
+      type: 'visible';
+      routeId: string;
+      rev: number;
+      name: string | null;
+      pointCount: number;
+      saved: boolean;
+      dirty: boolean;
+    }
+  | { type: 'hidden'; routeId: string; rev: number; saved: boolean }
+  | { type: 'dirty'; routeId: string; rev: number; reason?: string };
+
+/**
+ * Holds the host's live route edit buffers. The single source of truth for
+ * routes being built or edited via the `routes` capability: extensions CRUD
+ * buffers through it, native draw/modify gestures feed it, and it renders them
+ * on the chart. This service owns the data + the `rev` contract and emits
+ * mutation events; wiring to the bus and the map layer lives elsewhere.
+ */
+@Injectable({ providedIn: 'root' })
+export class RouteBufferRegistry {
+  private readonly buffers = new Map<string, RouteBuffer>();
+  private readonly events = new Subject<RouteRegistryEvent>();
+
+  /** Stream of buffer mutations (created / deleted / dirty). */
+  readonly events$: Observable<RouteRegistryEvent> = this.events.asObservable();
+
+  private readonly liveSignal = signal<RouteBuffer[]>([]);
+  /** Reactive snapshot of all live buffers, for chart rendering. */
+  readonly live = this.liveSignal.asReadonly();
+
+  /** Create a new buffer, optionally seeded with a name and/or points. */
+  create(
+    opts: { name?: string; description?: string; points?: RoutePoint[] } = {}
+  ): RouteBuffer {
+    const routeId = this.newRouteId();
+    const buffer: RouteBuffer = {
+      routeId,
+      name: opts.name ?? null,
+      description: opts.description ?? null,
+      rev: 1,
+      saved: false,
+      dirty: true,
+      points: (opts.points ?? []).map((p) => this.clonePoint(p))
+    };
+    this.buffers.set(routeId, buffer);
+    this.refreshLive();
+    this.events.next({
+      type: 'visible',
+      routeId,
+      rev: buffer.rev,
+      name: buffer.name,
+      pointCount: buffer.points.length,
+      saved: buffer.saved,
+      dirty: buffer.dirty
+    });
+    return this.snapshot(buffer);
+  }
+
+  /**
+   * Bring a stored route into the visible set as an addressable, saved + clean
+   * entry (or refresh an existing entry's geometry). `href` is the backing
+   * routes-resource id. Emits `visible` (`saved:true, dirty:false`).
+   */
+  show(opts: {
+    routeId: string;
+    name?: string | null;
+    description?: string | null;
+    points?: RoutePoint[];
+    href: string;
+  }): RouteBuffer {
+    const existing = this.buffers.get(opts.routeId);
+    const buffer: RouteBuffer = {
+      routeId: opts.routeId,
+      name: opts.name ?? existing?.name ?? null,
+      description: opts.description ?? existing?.description ?? null,
+      rev: existing ? existing.rev + 1 : 1,
+      saved: true,
+      dirty: false,
+      href: opts.href,
+      // A metadata-only refresh (no points) must keep the existing geometry,
+      // not blank it.
+      points: (opts.points ?? existing?.points ?? []).map((p) =>
+        this.clonePoint(p)
+      )
+    };
+    this.buffers.set(opts.routeId, buffer);
+    this.refreshLive();
+    this.events.next({
+      type: 'visible',
+      routeId: buffer.routeId,
+      rev: buffer.rev,
+      name: buffer.name,
+      pointCount: buffer.points.length,
+      saved: true,
+      dirty: false
+    });
+    return this.snapshot(buffer);
+  }
+
+  /** Snapshot of a buffer, or undefined if no buffer has that id. */
+  get(routeId: string): RouteBuffer | undefined {
+    const b = this.buffers.get(routeId);
+    return b ? this.snapshot(b) : undefined;
+  }
+
+  /** Whether a buffer with the given id exists. */
+  has(routeId: string): boolean {
+    return this.buffers.has(routeId);
+  }
+
+  /** Whether any buffer is backed by the given resource id (href). Used to
+   *  dedupe when mirroring the host's displayed routes into the visible set. */
+  hasHref(href: string): boolean {
+    return this.getByHref(href) !== undefined;
+  }
+
+  /** Snapshot of the buffer backed by the given resource id (href), if any.
+   *  Resolves a draft-saved route by its backing resource even though it is
+   *  still keyed under its original (draft) routeId. */
+  getByHref(href: string): RouteBuffer | undefined {
+    for (const b of this.buffers.values()) {
+      if (b.href === href) {
+        return this.snapshot(b);
+      }
+    }
+    return undefined;
+  }
+
+  /** Non-reactive snapshot of every buffer (does not read the live() signal, so
+   *  it is safe to call inside an effect that also mutates the registry). */
+  all(): RouteBuffer[] {
+    return [...this.buffers.values()].map((b) => this.snapshot(b));
+  }
+
+  /** Summaries of all live routes (the visible set). */
+  list(): RouteSummary[] {
+    return [...this.buffers.values()].map((b) => ({
+      routeId: b.routeId,
+      name: b.name,
+      rev: b.rev,
+      pointCount: b.points.length,
+      saved: b.saved,
+      dirty: b.dirty
+    }));
+  }
+
+  /**
+   * Remove a route from the visible set. Returns true if it existed. Emits
+   * `hidden` carrying the route's `saved` flag: `saved:true` ⇒ a stored route
+   * was made invisible (the resource is untouched); `saved:false` ⇒ a draft was
+   * deleted.
+   */
+  delete(routeId: string, hiddenSaved?: boolean): boolean {
+    const b = this.buffers.get(routeId);
+    if (!b) {
+      return false;
+    }
+    b.rev += 1;
+    // The emitted `saved` reflects whether the route still exists on the server
+    // afterwards: defaults to the buffer's flag (hide), but a permanent delete
+    // passes false (gone) even for a route that was saved.
+    const saved = hiddenSaved ?? b.saved;
+    this.buffers.delete(routeId);
+    this.refreshLive();
+    this.events.next({ type: 'hidden', routeId, rev: b.rev, saved });
+    return true;
+  }
+
+  /**
+   * Mark a route persisted (`saved:true, dirty:false`) after a server write,
+   * keeping it in the visible set under the same `routeId`. Returns the new
+   * `rev`, or undefined if no route has that id. Does not emit — the host
+   * service broadcasts `route.saved` (it owns the resource `href`).
+   */
+  markSaved(
+    routeId: string,
+    href?: string,
+    name?: string | null,
+    description?: string | null
+  ): number | undefined {
+    const b = this.buffers.get(routeId);
+    if (!b) {
+      return undefined;
+    }
+    // A draft only becomes "saved" once it has a backing resource id — that id
+    // is what hasHref()/the selection-mirror rely on.
+    if (!b.saved && href === undefined) {
+      throw new Error('markSaved requires an href when saving a draft route');
+    }
+    b.rev += 1;
+    b.saved = true;
+    b.dirty = false;
+    if (href !== undefined) {
+      b.href = href;
+    }
+    if (name !== undefined) {
+      b.name = name;
+    }
+    if (description !== undefined) {
+      b.description = description;
+    }
+    this.refreshLive();
+    return b.rev;
+  }
+
+  /**
+   * Replace all points of a buffer (bulk set). Returns the updated snapshot, or
+   * undefined if no buffer has that id. Emits a `dirty` event (reason
+   * `replaced`) — the auto-router's primary write path.
+   */
+  replace(routeId: string, points: RoutePoint[]): RouteBuffer | undefined {
+    const b = this.buffers.get(routeId);
+    if (!b) {
+      return undefined;
+    }
+    b.points = (points ?? []).map((p) => this.clonePoint(p));
+    b.rev += 1;
+    b.dirty = true;
+    this.refreshLive();
+    this.events.next({
+      type: 'dirty',
+      routeId,
+      rev: b.rev,
+      reason: 'replaced'
+    });
+    return this.snapshot(b);
+  }
+
+  private refreshLive(): void {
+    this.liveSignal.set(
+      [...this.buffers.values()].map((b) => this.snapshot(b))
+    );
+  }
+
+  /**
+   * Re-emit the live() signal without changing any buffer. Used to force a
+   * chart re-render — e.g. to restore a draft's geometry after the user
+   * cancels an in-place edit (the map feature was moved by the Modify
+   * interaction but the registry was never updated).
+   */
+  refresh(): void {
+    this.refreshLive();
+  }
+
+  private newRouteId(): string {
+    const c = (globalThis as { crypto?: Crypto }).crypto;
+    if (c?.randomUUID) {
+      return c.randomUUID();
+    }
+    // Fallback for environments without WebCrypto randomUUID.
+    return (
+      'rb-' +
+      Date.now().toString(36) +
+      '-' +
+      Math.random().toString(36).slice(2, 10)
+    );
+  }
+
+  private clonePoint(p: RoutePoint): RoutePoint {
+    return {
+      position: [...p.position] as RoutePoint['position'],
+      ...(p.name !== undefined ? { name: p.name } : {}),
+      ...(p.description !== undefined ? { description: p.description } : {})
+    };
+  }
+
+  /** Defensive copy so callers cannot mutate registry internals. */
+  private snapshot(b: RouteBuffer): RouteBuffer {
+    return {
+      routeId: b.routeId,
+      name: b.name,
+      description: b.description,
+      rev: b.rev,
+      saved: b.saved,
+      dirty: b.dirty,
+      ...(b.href !== undefined ? { href: b.href } : {}),
+      points: b.points.map((p) => this.clonePoint(p))
+    };
+  }
+}

--- a/src/app/modules/plotterext/route-methods.spec.ts
+++ b/src/app/modules/plotterext/route-methods.spec.ts
@@ -205,6 +205,21 @@ describe('route methods (host handlers)', () => {
     ).rejects.toHaveProperty('reason', 'routes.badRequest');
   });
 
+  it('route.create rejects non-string name/description metadata', async () => {
+    const { call } = setup();
+    await expect(
+      call('route.create', {
+        name: 1,
+        points: [{ position: [0, 0] }, { position: [1, 1] }]
+      })
+    ).rejects.toHaveProperty('reason', 'routes.badRequest');
+    await expect(
+      call('route.create', {
+        points: [{ position: [0, 0] }, { position: [1, 1], name: {} }]
+      })
+    ).rejects.toHaveProperty('reason', 'routes.badRequest');
+  });
+
   it('route.hide delegates to onHide when provided', async () => {
     const registry = new RouteBufferRegistry();
     const seen: string[] = [];

--- a/src/app/modules/plotterext/route-methods.spec.ts
+++ b/src/app/modules/plotterext/route-methods.spec.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import { createRouteMethods } from './route-methods';
+import { RouteBufferRegistry } from './route-buffer.registry';
+
+function setup() {
+  const registry = new RouteBufferRegistry();
+  const methods = createRouteMethods(registry);
+  // The bus dispatches handlers as (params, ctx); ctx is unused here.
+  const call = async (name: string, params?: unknown) =>
+    methods[name](params, {} as never);
+  return { registry, methods, call };
+}
+
+describe('route methods (host handlers)', () => {
+  it('route.create creates a buffer and returns routeId + rev', async () => {
+    const { call, registry } = setup();
+    const res = (await call('route.create', {
+      name: 'A',
+      points: [{ position: [1, 2] }, { position: [3, 4] }]
+    })) as { routeId: string; rev: number };
+    expect(res.rev).toBe(1);
+    expect(typeof res.routeId).toBe('string');
+    expect(registry.get(res.routeId)?.name).toBe('A');
+    expect(registry.get(res.routeId)?.points).toHaveLength(2);
+  });
+
+  it('route.get returns the buffer snapshot', async () => {
+    const { call } = setup();
+    const { routeId } = (await call('route.create', {
+      name: 'A',
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    })) as {
+      routeId: string;
+    };
+    const b = await call('route.get', { routeId });
+    expect(b).toMatchObject({
+      routeId,
+      name: 'A',
+      rev: 1,
+      saved: false,
+      dirty: true,
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    });
+  });
+
+  it('route.list returns { routes }', async () => {
+    const { call } = setup();
+    await call('route.create', {
+      name: 'A',
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    });
+    await call('route.create', {
+      name: 'B',
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    });
+    const res = (await call('route.list')) as { routes: unknown[] };
+    expect(res.routes).toHaveLength(2);
+  });
+
+  it('route.hide removes the buffer and returns {}', async () => {
+    const { call, registry } = setup();
+    const { routeId } = (await call('route.create', {
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    })) as { routeId: string };
+    const res = await call('route.hide', { routeId });
+    expect(res).toEqual({});
+    expect(registry.has(routeId)).toBe(false);
+  });
+
+  it('route.get on an unknown id rejects with routes.unknownId', async () => {
+    const { call } = setup();
+    await expect(call('route.get', { routeId: 'nope' })).rejects.toHaveProperty(
+      'reason',
+      'routes.unknownId'
+    );
+  });
+
+  it('route.hide on an unknown id rejects with routes.unknownId', async () => {
+    const { call } = setup();
+    await expect(
+      call('route.hide', { routeId: 'nope' })
+    ).rejects.toHaveProperty('reason', 'routes.unknownId');
+  });
+
+  it('route.show without an onShow handler rejects routes.notSupported', async () => {
+    const { call } = setup();
+    await expect(
+      call('route.show', { ref: 'routes/abc' })
+    ).rejects.toHaveProperty('reason', 'routes.notSupported');
+  });
+
+  it('route.show without a ref rejects routes.badRef', async () => {
+    const methods = createRouteMethods(new RouteBufferRegistry(), {
+      onShow: async () => ({ routeId: 'r', rev: 1 })
+    });
+    await expect(
+      (async () => methods['route.show']({}, {} as never))()
+    ).rejects.toHaveProperty('reason', 'routes.badRef');
+  });
+
+  it('route.show delegates to onShow and returns its result', async () => {
+    const seen: string[] = [];
+    const methods = createRouteMethods(new RouteBufferRegistry(), {
+      onShow: async (ref) => {
+        seen.push(ref);
+        return { routeId: 'route-shown', rev: 3 };
+      }
+    });
+    const res = await methods['route.show']({ ref: 'routes/abc' }, {} as never);
+    expect(res).toEqual({ routeId: 'route-shown', rev: 3 });
+    expect(seen).toEqual(['routes/abc']);
+  });
+
+  it('route.get without a routeId rejects', async () => {
+    const { call } = setup();
+    await expect(call('route.get', {})).rejects.toBeInstanceOf(Error);
+  });
+
+  it('route.replace sets points and returns the new rev', async () => {
+    const { call, registry } = setup();
+    const { routeId } = (await call('route.create', {
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    })) as { routeId: string };
+    const res = (await call('route.replace', {
+      routeId,
+      points: [{ position: [1, 1] }, { position: [2, 2] }]
+    })) as { rev: number };
+    expect(res.rev).toBe(2);
+    expect(registry.get(routeId)?.points).toHaveLength(2);
+  });
+
+  it('route.replace on an unknown id rejects with routes.unknownId', async () => {
+    const { call } = setup();
+    await expect(
+      call('route.replace', {
+        routeId: 'nope',
+        points: [{ position: [0, 0] }, { position: [1, 1] }]
+      })
+    ).rejects.toHaveProperty('reason', 'routes.unknownId');
+  });
+
+  it('route.replace with fewer than two points rejects routes.badRequest', async () => {
+    const { call, registry } = setup();
+    const { routeId } = registry.create({
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    });
+    await expect(
+      call('route.replace', { routeId, points: [{ position: [9, 9] }] })
+    ).rejects.toHaveProperty('reason', 'routes.badRequest');
+  });
+  it('route.save delegates to onSave and returns its result', async () => {
+    const registry = new RouteBufferRegistry();
+    const seen: string[] = [];
+    const methods = createRouteMethods(registry, {
+      onSave: async (routeId) => {
+        seen.push(routeId);
+        return { href: 'routes/abc', rev: 5 };
+      }
+    });
+    const { routeId } = registry.create({ name: 'A' });
+    const res = await methods['route.save']({ routeId }, {} as never);
+    expect(res).toEqual({ href: 'routes/abc', rev: 5 });
+    expect(seen).toEqual([routeId]);
+  });
+
+  it('route.save without an onSave handler rejects routes.notSupported', async () => {
+    const registry = new RouteBufferRegistry();
+    const methods = createRouteMethods(registry);
+    const { routeId } = registry.create();
+    await expect(
+      (async () => methods['route.save']({ routeId }, {} as never))()
+    ).rejects.toHaveProperty('reason', 'routes.notSupported');
+  });
+
+  it('route.save on an unknown id rejects routes.unknownId', async () => {
+    const registry = new RouteBufferRegistry();
+    const methods = createRouteMethods(registry, {
+      onSave: async () => ({ href: 'x', rev: 1 })
+    });
+    await expect(
+      (async () => methods['route.save']({ routeId: 'nope' }, {} as never))()
+    ).rejects.toHaveProperty('reason', 'routes.unknownId');
+  });
+
+  it('route.create with fewer than two points rejects routes.badRequest', async () => {
+    const { call } = setup();
+    await expect(
+      call('route.create', { points: [{ position: [0, 0] }] })
+    ).rejects.toHaveProperty('reason', 'routes.badRequest');
+    await expect(call('route.create', {})).rejects.toHaveProperty(
+      'reason',
+      'routes.badRequest'
+    );
+  });
+
+  it('route.create rejects points without a numeric [lon, lat] position', async () => {
+    const { call } = setup();
+    await expect(
+      call('route.create', { points: [{}, {}] })
+    ).rejects.toHaveProperty('reason', 'routes.badRequest');
+    await expect(
+      call('route.create', {
+        points: [{ position: [0, 0] }, { position: ['x', 1] }]
+      })
+    ).rejects.toHaveProperty('reason', 'routes.badRequest');
+  });
+
+  it('route.hide delegates to onHide when provided', async () => {
+    const registry = new RouteBufferRegistry();
+    const seen: string[] = [];
+    const methods = createRouteMethods(registry, {
+      onHide: (routeId) => {
+        seen.push(routeId);
+      }
+    });
+    const { routeId } = registry.create({
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    });
+    await methods['route.hide']({ routeId }, {} as never);
+    expect(seen).toEqual([routeId]);
+  });
+
+  it('route.delete delegates to onDelete; falls back to discarding the buffer', async () => {
+    const registry = new RouteBufferRegistry();
+    const seen: string[] = [];
+    const withHandler = createRouteMethods(registry, {
+      onDelete: (routeId) => {
+        seen.push(routeId);
+      }
+    });
+    const a = registry.create({
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    });
+    await withHandler['route.delete']({ routeId: a.routeId }, {} as never);
+    expect(seen).toEqual([a.routeId]);
+
+    // No handler — discards the buffer (draft semantics).
+    const noHandler = createRouteMethods(registry);
+    const b = registry.create({
+      points: [{ position: [0, 0] }, { position: [1, 1] }]
+    });
+    await noHandler['route.delete']({ routeId: b.routeId }, {} as never);
+    expect(registry.has(b.routeId)).toBe(false);
+  });
+});

--- a/src/app/modules/plotterext/route-methods.ts
+++ b/src/app/modules/plotterext/route-methods.ts
@@ -1,0 +1,201 @@
+import {
+  RPC_ERRORS,
+  RpcError,
+  type MethodHandler,
+  type RoutePoint
+} from 'signalk-plotterext-bus/host';
+import { RouteBufferRegistry } from './route-buffer.registry';
+
+/**
+ * Host method handlers for the `routes` capability (Slice 0 surface:
+ * list/create/get/delete). A pure factory over a {@link RouteBufferRegistry},
+ * so the handlers are unit-testable without the Angular host service; the
+ * service spreads the result into each extension context's method table
+ * (matching the existing `stateMethods` / `resourcesMethods` pattern).
+ *
+ * Point operations and rename extend this surface in later slices.
+ */
+
+/**
+ * Persist a buffer to the routes resource. The host owns the UX (e.g. a naming
+ * dialog) and the server write; resolves with the stored resource href. Injected
+ * because persistence is host-specific (the registry is pure data).
+ */
+export type RouteSaveHandler = (
+  routeId: string,
+  params: { name?: string; description?: string; dialog?: boolean }
+) => Promise<{ href: string; rev: number } | null>;
+
+/**
+ * Bring a stored route (identified by `ref`) into the visible set, returning its
+ * addressable `routeId`. Injected because loading + displaying a resource is
+ * host-specific.
+ */
+export type RouteShowHandler = (
+  ref: string
+) => Promise<{ routeId: string; rev: number }>;
+
+/** Remove a route from the map: unchecks a saved route's visibility, or deletes
+ *  an unsaved draft. Host-specific (touches resource selections). */
+export type RouteHideHandler = (routeId: string) => Promise<void> | void;
+
+/** Permanently delete a saved route from the store (or discard an unsaved one).
+ *  Host-specific (deletes the resource). */
+export type RouteDeleteHandler = (routeId: string) => Promise<void> | void;
+
+export function createRouteMethods(
+  registry: RouteBufferRegistry,
+  opts: {
+    onSave?: RouteSaveHandler;
+    onShow?: RouteShowHandler;
+    onHide?: RouteHideHandler;
+    onDelete?: RouteDeleteHandler;
+  } = {}
+): Record<string, MethodHandler> {
+  const requireRouteId = (params: unknown): string => {
+    const routeId = (params as { routeId?: unknown } | null)?.routeId;
+    if (typeof routeId !== 'string' || routeId.length === 0) {
+      throw new RpcError('route method requires a routeId', {
+        code: RPC_ERRORS.INVALID_PARAMS,
+        reason: 'routes.badRequest'
+      });
+    }
+    return routeId;
+  };
+
+  const unknownId = () =>
+    new RpcError('Unknown route buffer', { reason: 'routes.unknownId' });
+
+  // A route needs at least two points, and every point must be a numeric
+  // [lon, lat] tuple — otherwise the registry blows up in clonePoint() and the
+  // caller sees an internal error instead of routes.badRequest.
+  const requireValidPoints = (points: unknown): RoutePoint[] => {
+    if (!Array.isArray(points) || points.length < 2) {
+      throw new RpcError('a route needs at least two points', {
+        code: RPC_ERRORS.INVALID_PARAMS,
+        reason: 'routes.badRequest'
+      });
+    }
+    for (const p of points) {
+      const pos = (p as RoutePoint)?.position;
+      if (
+        !Array.isArray(pos) ||
+        pos.length < 2 ||
+        !Number.isFinite(pos[0]) ||
+        !Number.isFinite(pos[1])
+      ) {
+        throw new RpcError(
+          'each route point needs a numeric [lon, lat] position',
+          { code: RPC_ERRORS.INVALID_PARAMS, reason: 'routes.badRequest' }
+        );
+      }
+    }
+    return points as RoutePoint[];
+  };
+
+  return {
+    'route.list': () => ({ routes: registry.list() }),
+
+    'route.create': (params) => {
+      const { name, description, points } = (params ?? {}) as {
+        name?: string;
+        description?: string;
+        points?: RoutePoint[];
+      };
+      const validPoints = requireValidPoints(points);
+      const buffer = registry.create({ name, description, points: validPoints });
+      return { routeId: buffer.routeId, rev: buffer.rev };
+    },
+
+    'route.replace': (params) => {
+      const routeId = requireRouteId(params);
+      const { points } = (params ?? {}) as { points?: RoutePoint[] };
+      // Same invariants as route.create — never let a replace wipe a route down
+      // to an invalid geometry or feed the registry malformed points.
+      const validPoints = requireValidPoints(points);
+      const updated = registry.replace(routeId, validPoints);
+      if (!updated) {
+        throw unknownId();
+      }
+      return { rev: updated.rev };
+    },
+
+    'route.save': async (params) => {
+      const routeId = requireRouteId(params);
+      if (!registry.has(routeId)) {
+        throw unknownId();
+      }
+      if (!opts.onSave) {
+        throw new RpcError('This host cannot persist routes', {
+          reason: 'routes.notSupported'
+        });
+      }
+      const { name, description, dialog } = (params ?? {}) as {
+        name?: string;
+        description?: string;
+        dialog?: boolean;
+      };
+      const result = await opts.onSave(routeId, { name, description, dialog });
+      if (!result) {
+        throw new RpcError('Route save was cancelled', {
+          reason: 'routes.saveCancelled'
+        });
+      }
+      return result;
+    },
+
+    'route.get': (params) => {
+      const buffer = registry.get(requireRouteId(params));
+      if (!buffer) {
+        throw unknownId();
+      }
+      return buffer;
+    },
+
+    'route.hide': async (params) => {
+      const routeId = requireRouteId(params);
+      if (!registry.has(routeId)) {
+        throw unknownId();
+      }
+      // Unchecking a saved route's visibility is host-specific; a draft just
+      // leaves the buffer.
+      if (opts.onHide) {
+        await opts.onHide(routeId);
+      } else {
+        registry.delete(routeId);
+      }
+      return {};
+    },
+
+    'route.delete': async (params) => {
+      const routeId = requireRouteId(params);
+      if (!registry.has(routeId)) {
+        throw unknownId();
+      }
+      // Permanently deleting a saved resource is host-specific; without wiring
+      // we can only discard the buffer (draft semantics, saved:false).
+      if (opts.onDelete) {
+        await opts.onDelete(routeId);
+      } else {
+        registry.delete(routeId, false);
+      }
+      return {};
+    },
+
+    'route.show': (params) => {
+      const ref = (params as { ref?: unknown } | null)?.ref;
+      if (typeof ref !== 'string' || ref.length === 0) {
+        throw new RpcError('route.show requires a ref', {
+          code: RPC_ERRORS.INVALID_PARAMS,
+          reason: 'routes.badRef'
+        });
+      }
+      if (!opts.onShow) {
+        throw new RpcError('route.show is not supported by this host', {
+          reason: 'routes.notSupported'
+        });
+      }
+      return opts.onShow(ref);
+    }
+  };
+}

--- a/src/app/modules/plotterext/route-methods.ts
+++ b/src/app/modules/plotterext/route-methods.ts
@@ -66,15 +66,26 @@ export function createRouteMethods(
   const unknownId = () =>
     new RpcError('Unknown route buffer', { reason: 'routes.unknownId' });
 
+  const badRequest = (message: string) =>
+    new RpcError(message, {
+      code: RPC_ERRORS.INVALID_PARAMS,
+      reason: 'routes.badRequest'
+    });
+
+  // Reject a non-string metadata field at the boundary so it can't be stored in
+  // the registry and later emitted/persisted, breaking the routes API contract.
+  const requireOptString = (v: unknown, field: string): void => {
+    if (v !== undefined && typeof v !== 'string') {
+      throw badRequest(`${field} must be a string`);
+    }
+  };
+
   // A route needs at least two points, and every point must be a numeric
-  // [lon, lat] tuple — otherwise the registry blows up in clonePoint() and the
-  // caller sees an internal error instead of routes.badRequest.
+  // [lon, lat] tuple with string metadata — otherwise the registry blows up in
+  // clonePoint() and the caller sees an internal error instead of badRequest.
   const requireValidPoints = (points: unknown): RoutePoint[] => {
     if (!Array.isArray(points) || points.length < 2) {
-      throw new RpcError('a route needs at least two points', {
-        code: RPC_ERRORS.INVALID_PARAMS,
-        reason: 'routes.badRequest'
-      });
+      throw badRequest('a route needs at least two points');
     }
     for (const p of points) {
       const pos = (p as RoutePoint)?.position;
@@ -84,11 +95,10 @@ export function createRouteMethods(
         !Number.isFinite(pos[0]) ||
         !Number.isFinite(pos[1])
       ) {
-        throw new RpcError(
-          'each route point needs a numeric [lon, lat] position',
-          { code: RPC_ERRORS.INVALID_PARAMS, reason: 'routes.badRequest' }
-        );
+        throw badRequest('each route point needs a numeric [lon, lat] position');
       }
+      requireOptString((p as RoutePoint).name, 'point name');
+      requireOptString((p as RoutePoint).description, 'point description');
     }
     return points as RoutePoint[];
   };
@@ -102,6 +112,8 @@ export function createRouteMethods(
         description?: string;
         points?: RoutePoint[];
       };
+      requireOptString(name, 'name');
+      requireOptString(description, 'description');
       const validPoints = requireValidPoints(points);
       const buffer = registry.create({ name, description, points: validPoints });
       return { routeId: buffer.routeId, rev: buffer.rev };
@@ -135,6 +147,11 @@ export function createRouteMethods(
         description?: string;
         dialog?: boolean;
       };
+      requireOptString(name, 'name');
+      requireOptString(description, 'description');
+      if (dialog !== undefined && typeof dialog !== 'boolean') {
+        throw badRequest('dialog must be a boolean');
+      }
       const result = await opts.onSave(routeId, { name, description, dialog });
       if (!result) {
         throw new RpcError('Route save was cancelled', {

--- a/src/app/modules/plotterext/types.ts
+++ b/src/app/modules/plotterext/types.ts
@@ -18,6 +18,7 @@ export const HOST_CAPABILITIES = [
   'map',
   'resources',
   'resources.filter',
+  'routes',
   'background.iframe',
   'ui'
 ];

--- a/src/app/modules/skresources/components/routes/route-panel.html
+++ b/src/app/modules/skresources/components/routes/route-panel.html
@@ -27,6 +27,17 @@
 
     <div style="display: flex">
       <div>
+        @if (isUnsaved()) {
+        <button
+          mat-button
+          [disabled]="interacting()"
+          (click)="onEdit()"
+          matTooltip="Save as a route"
+        >
+          <mat-icon>save</mat-icon>
+          SAVE
+        </button>
+        } @else {
         <button
           mat-button
           [disabled]="_route()?.feature?.properties?.readOnly  || interacting()"
@@ -36,10 +47,11 @@
           <mat-icon>edit</mat-icon>
           EDIT
         </button>
+        }
         &nbsp; @if (this.app.data.activeRoute !== id()) {
         <button
           mat-button
-          [disabled]="interacting()"
+          [disabled]="interacting() || isUnsaved()"
           (click)="onGoto()"
           matTooltip="Navigate To"
         >
@@ -100,7 +112,10 @@
       "
     >
       <div style="font-weight: bold; font-size: larger; padding-bottom: 5px">
-        {{_route()?.name}}
+        {{ _route()?.name }}
+        @if (isUnsaved()) {
+        <span style="color: gray; font-style: italic">&nbsp;(unsaved)</span>
+        }
       </div>
     </div>
   </div>
@@ -135,7 +150,7 @@
           <button
             matIconButton
             matTooltip="Re-order points"
-            [disabled]="interacting()"
+            [disabled]="interacting() || isUnsaved()"
             (click)="arrangePoints()"
           >
             <mat-icon>import_export</mat-icon>
@@ -160,7 +175,7 @@
             <button
               matIconButton
               matTooltip="Start here"
-              [disabled]="interacting()"
+              [disabled]="interacting() || isUnsaved()"
               (click)="onGoto(point.index)"
             >
               <mat-icon>near_me</mat-icon>
@@ -187,7 +202,7 @@
           <button
             matIconButton
             matTooltip="Add Note"
-            [disabled]="interacting()"
+            [disabled]="interacting() || isUnsaved()"
             (click)="addNote()"
           >
             <mat-icon>add</mat-icon>
@@ -217,7 +232,7 @@
           <button
             matIconButton
             matTooltip="Add to Group"
-            [disabled]="interacting()"
+            [disabled]="interacting() || isUnsaved()"
             (click)="addToGroup()"
           >
             <mat-icon>add</mat-icon>

--- a/src/app/modules/skresources/components/routes/route-panel.ts
+++ b/src/app/modules/skresources/components/routes/route-panel.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  computed,
   DestroyRef,
   effect,
   inject,
@@ -8,6 +9,7 @@ import {
   output,
   signal
 } from '@angular/core';
+import { RouteBufferRegistry } from 'src/app/modules/plotterext/route-buffer.registry';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -20,6 +22,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { RemarkModule } from 'ngx-remark';
 
 import { AppFacade } from 'src/app/app.facade';
+import { InfoPanelFacade } from 'src/app/modules/info-panel/info-panel.facade';
 import { AppIconDef, getResourceIcon } from 'src/app/modules/icons';
 import { SKRoute } from '../../resource-classes';
 import { SKResourceService } from '../../resources.service';
@@ -67,6 +70,14 @@ export class RoutePanel {
   }>();
 
   protected _route = linkedSignal(() => this.route());
+  /** True when this id refers to a route with pending unsaved changes — a
+   *  never-saved draft or a stored route edited but not yet re-saved: the panel
+   *  shows "Save" instead of "Edit" and acts locally. A saved + clean buffer is
+   *  treated as a normal stored route (shows "Edit"). */
+  protected isUnsaved = computed(() => {
+    const b = this.routeBuffers.get(this.id());
+    return !!b && (!b.saved || b.dirty);
+  });
   protected notes = signal<FBNotes>([]);
   protected groups = signal<FBResourceGroups>([]);
   protected points = signal<
@@ -84,6 +95,8 @@ export class RoutePanel {
   protected icon: AppIconDef;
   protected app = inject(AppFacade);
   private skres = inject(SKResourceService);
+  private routeBuffers = inject(RouteBufferRegistry);
+  private infoPanel = inject(InfoPanelFacade);
   private course = inject(CourseService);
   protected skgroups = inject(SKResourceGroupService);
   private dialog = inject(MatDialog);
@@ -241,7 +254,24 @@ export class RoutePanel {
   }
 
   protected onDelete() {
-    this.skres.deleteRoute(this.id());
+    const b = this.routeBuffers.get(this.id());
+    if (b && !b.saved) {
+      // Unsaved draft — just discard the live buffer.
+      this.routeBuffers.delete(this.id());
+    } else {
+      // Saved route (clean or dirty) — delete the stored resource, dropping any
+      // live buffer too. hiddenSaved=false so the registry's hidden event
+      // reports a permanent delete, not a hide.
+      if (b) {
+        this.routeBuffers.delete(this.id(), false);
+      }
+      this.skres.deleteRoute(this.id());
+    }
+    // The route no longer exists — close the panel so its now-stale actions
+    // (Save/Edit/Start…) don't linger. A draft delete fires no server delta, so
+    // closing here is the only trigger; for a saved route this just makes the
+    // close immediate rather than waiting on the delete delta round-trip.
+    this.infoPanel.close();
   }
 
   protected onPanTo() {

--- a/src/app/modules/skresources/components/routes/route-panel.ts
+++ b/src/app/modules/skresources/components/routes/route-panel.ts
@@ -75,7 +75,9 @@ export class RoutePanel {
    *  shows "Save" instead of "Edit" and acts locally. A saved + clean buffer is
    *  treated as a normal stored route (shows "Edit"). */
   protected isUnsaved = computed(() => {
-    const b = this.routeBuffers.get(this.id());
+    // Read the live() signal (not the plain get() Map lookup) so the Save/Edit
+    // label re-evaluates when the buffer's saved/dirty state changes.
+    const b = this.routeBuffers.live().find((x) => x.routeId === this.id());
     return !!b && (!b.saved || b.dirty);
   });
   protected notes = signal<FBNotes>([]);
@@ -253,25 +255,26 @@ export class RoutePanel {
     }
   }
 
-  protected onDelete() {
+  protected async onDelete() {
     const b = this.routeBuffers.get(this.id());
     if (b && !b.saved) {
-      // Unsaved draft — just discard the live buffer.
+      // Unsaved draft — just discard the live buffer and close; no server
+      // round-trip, so this is the only close trigger.
       this.routeBuffers.delete(this.id());
-    } else {
-      // Saved route (clean or dirty) — delete the stored resource, dropping any
-      // live buffer too. hiddenSaved=false so the registry's hidden event
-      // reports a permanent delete, not a hide.
+      this.infoPanel.close();
+      return;
+    }
+    // Saved route (clean or dirty) — only drop the live buffer and close the
+    // panel once the server delete is confirmed and succeeds; a cancel or
+    // failure leaves the route (and any dirty edits) intact. hiddenSaved=false
+    // so the registry's hidden event reports a permanent delete, not a hide.
+    const ok = await this.skres.deleteRoute(this.id());
+    if (ok) {
       if (b) {
         this.routeBuffers.delete(this.id(), false);
       }
-      this.skres.deleteRoute(this.id());
+      this.infoPanel.close();
     }
-    // The route no longer exists — close the panel so its now-stale actions
-    // (Save/Edit/Start…) don't linger. A draft delete fires no server delta, so
-    // closing here is the only trigger; for a saved route this just makes the
-    // close immediate rather than waiting on the delete delta round-trip.
-    this.infoPanel.close();
   }
 
   protected onPanTo() {

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -1151,7 +1151,7 @@ export class SKResourceService {
    * persist a live edit buffer into a stored route.
    */
   public saveNewRoute(route: SKRoute): Promise<string | null> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.dialog
         .open(RouteDialog, {
           disableClose: true,
@@ -1165,10 +1165,13 @@ export class SKResourceService {
               this.selectionAdd('routes', rte.id);
               resolve(rte.id);
             } catch (err) {
+              // A server rejection is a real failure, not a cancel — reject so
+              // callers don't mistake it for the user dismissing the dialog.
               this.app.parseHttpErrorResponse(err);
-              resolve(null);
+              reject(err);
             }
           } else {
+            // User dismissed / chose not to save.
             resolve(null);
           }
         });
@@ -1216,35 +1219,44 @@ export class SKResourceService {
    * @description Confirm deletion of Route with supplied id
    * @param id Route identifier
    */
-  public async deleteRoute(id: string) {
+  public async deleteRoute(id: string): Promise<boolean> {
     if (!id) {
-      return;
+      return false;
     }
     // are there notes attached?
     const notes = await this.fetchRelatedNotes('routes', id);
     const checkText = notes?.length !== 0 ? 'Delete attached Notes.' : '';
-    this.app
-      .showConfirm(
-        'Do you want to delete this Route from the server?\n',
-        'Delete Route:',
-        'YES',
-        'NO',
-        checkText
-      )
-      .subscribe(async (result: { ok: boolean; checked: boolean }) => {
-        if (result && result.ok) {
-          try {
-            await this.deleteFromServer('routes', id);
-            if (result.checked) {
-              notes.forEach((note: FBNote) => {
-                this.deleteFromServer('notes', note[0]);
-              });
+    // Resolve true only once the user confirms AND the server delete succeeds,
+    // so callers can defer destructive local cleanup (dropping live buffers,
+    // closing panels) until the route is actually gone.
+    return new Promise<boolean>((resolve) => {
+      this.app
+        .showConfirm(
+          'Do you want to delete this Route from the server?\n',
+          'Delete Route:',
+          'YES',
+          'NO',
+          checkText
+        )
+        .subscribe(async (result: { ok: boolean; checked: boolean }) => {
+          if (result && result.ok) {
+            try {
+              await this.deleteFromServer('routes', id);
+              if (result.checked) {
+                notes.forEach((note: FBNote) => {
+                  this.deleteFromServer('notes', note[0]);
+                });
+              }
+              resolve(true);
+            } catch (err) {
+              this.app.parseHttpErrorResponse(err);
+              resolve(false);
             }
-          } catch (err) {
-            this.app.parseHttpErrorResponse(err);
+          } else {
+            resolve(false);
           }
-        }
-      });
+        });
+    });
   }
 
   // Modify Route point coordinates & refresh course

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -1243,9 +1243,19 @@ export class SKResourceService {
             try {
               await this.deleteFromServer('routes', id);
               if (result.checked) {
-                notes.forEach((note: FBNote) => {
-                  this.deleteFromServer('notes', note[0]);
-                });
+                // The route itself is gone; attached-note deletes are
+                // best-effort — await them so a failure is surfaced (not an
+                // unhandled rejection), but don't fail the route delete over one.
+                const outcomes = await Promise.allSettled(
+                  notes.map((note: FBNote) =>
+                    this.deleteFromServer('notes', note[0])
+                  )
+                );
+                for (const o of outcomes) {
+                  if (o.status === 'rejected') {
+                    this.app.parseHttpErrorResponse(o.reason);
+                  }
+                }
               }
               resolve(true);
             } catch (err) {

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -1145,6 +1145,37 @@ export class SKResourceService {
   }
 
   /**
+   * @description Open the Route Details dialog for an unsaved route and, on
+   * save, persist it to the server. Resolves with the saved resource id, or
+   * null if the user cancelled (closed the dialog without saving). Used to
+   * persist a live edit buffer into a stored route.
+   */
+  public saveNewRoute(route: SKRoute): Promise<string | null> {
+    return new Promise((resolve) => {
+      this.dialog
+        .open(RouteDialog, {
+          disableClose: true,
+          data: { title: 'Route Details', route }
+        })
+        .afterClosed()
+        .subscribe(async (r: { save: boolean; route: SKRoute }) => {
+          if (r?.save) {
+            try {
+              const rte = await this.postToServer('routes', r.route);
+              this.selectionAdd('routes', rte.id);
+              resolve(rte.id);
+            } catch (err) {
+              this.app.parseHttpErrorResponse(err);
+              resolve(null);
+            }
+          } else {
+            resolve(null);
+          }
+        });
+    });
+  }
+
+  /**
    * @description Fetch Route with supplied id and display edit dialog
    * @param id route identifier
    */
@@ -1228,10 +1259,10 @@ export class SKResourceService {
     coords: Array<Position>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     coordsMeta?: Array<any>
-  ) {
+  ): Promise<boolean> {
     const r = this.fromCache('routes', id);
     if (!r) {
-      return;
+      return Promise.resolve(false);
     }
     const rte = r[1];
     rte['feature']['geometry']['coordinates'] =
@@ -1241,9 +1272,14 @@ export class SKResourceService {
     if (coordsMeta) {
       rte['feature']['properties']['coordinatesMeta'] = coordsMeta;
     }
-    this.putToServer('routes', id, rte).catch((err) => {
-      this.app.parseHttpErrorResponse(err);
-    });
+    // Resolves true on success, false on failure (the error is surfaced here);
+    // callers that only fire-and-forget can ignore the result.
+    return this.putToServer('routes', id, rte)
+      .then(() => true)
+      .catch((err) => {
+        this.app.parseHttpErrorResponse(err);
+        return false;
+      });
   }
 
   // **** WAYPOINTS ****


### PR DESCRIPTION
Adds live route editing to Freeboard-SK, exposed both in the UI and as a new `routes` capability in the Plotter Extensions API so any extension (e.g. an auto-routing plugin) can create and edit routes on the chart.

## User-facing
- Drawing a route now creates an editable **draft** (amber) you can review and adjust on the chart before saving, instead of going straight to the save dialog.
- **Tap-to-edit** a live route; the route popover and info panel offer **Save / Edit / Delete** consistently (Delete is also available on the unsaved-route popover).
- Saving keeps the route on the map (it doesn't disappear), and per-point names/descriptions plus the route description round-trip through save.

## Plotter Extensions API — `routes` capability
- Methods: `route.list / create / show / get / replace / save / hide / delete`.
- A route carries `saved` (backed by a stored resource) and `dirty` (pending edits) flags; mutations are followed via `route.visible / dirty / saved / hidden` events (`route.dirty` is the re-snapshot conformance floor).
- The host mirrors Freeboard's own displayed/edited routes into the visible set so extensions observe native edits too.
- `route.create` / `route.replace` require ≥2 valid points.

Requires `signalk-plotterext-bus@^0.7.1` (the wire contract for the `route.*` types/events).

Implemented behind a new `RouteBufferRegistry`, wired into the host service's widget/panel/background attach paths. Includes unit tests for the registry and the route method handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, saving, and editing unsaved route drafts.
  * Draft routes are rendered above saved routes with distinct styling.
  * Route panels and resource popovers now offer a **Save** action and show an **(unsaved)** indicator when applicable.
* **Bug Fixes**
  * Improved preservation of route edits across draft and saved states.
  * Deleting now discards only drafts, while deleting saved routes removes the saved route from the backend.
  * Updated route edit/cancel flows and action availability/labels to better match unsaved state.
* **Tests**
  * Added unit tests for the route buffer registry and route host methods.
* **Chores**
  * Bumped the related plotter extension dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->