### PR TITLE
docs: add agent and contributor documentation set

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!--
+Before opening this PR, please consider:
+
+- One logical change per PR. If this bundles unrelated fixes/features, split it —
+  each PR becomes one App Store Changelog entry (generated from the PR title).
+- Every PR costs maintainer review time. Bug fixes that affect real users and
+  clearly-scoped features are always welcome; refactors or "improvements" without
+  a concrete problem being solved are likely to be closed.
+- Do NOT change version numbers — maintainers handle versioning at release.
+- Keep this description succinct. The diff shows WHAT changed; tell us WHY and
+  briefly HOW. If you used AI, trim the fluff — we'll ask if we need more.
+
+See CONTRIBUTING.md / AGENTS.md for the full guidelines.
+-->
+
+## What problem does this solve?
+
+<!-- The bug, limitation, or user-facing need this addresses. -->
+
+## How does it work?
+
+<!-- Briefly, the approach. Note any breaking changes. -->
+
+## How was this tested?
+
+<!-- How you verified it. New behaviour should have tests (npm run test:ci).
+     Include before/after screenshots for visible UI changes. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# Freeboard-SK
+
+Freeboard-SK (`@signalk/freeboard-sk`) is the primary chart-plotter web app for the
+[Signal K](https://signalk.org/) ecosystem. It is an **Angular** application served
+by a Signal K server as a `signalk-webapp`, and it ships a small companion
+`signalk-node-server-plugin` (the "helper") in the same package.
+
+These guidelines are written for AI coding assistants, but they apply equally to
+human contributors. Where something is "overly specific," it's an explicit guardrail
+for AI tools — humans should use judgment and follow the spirit.
+
+This project is an **upstream Signal K project** (`SignalK/freeboard-sk`). It has a
+large, often non-technical user base, so changes warrant extra care.
+
+## Repository layout
+
+| Path | What |
+|------|------|
+| `src/app/` | the Angular webapp; feature areas under `src/app/modules/` (`map`, `skresources`, `plotterext`, `autopilot`, `radar`, `weather`, `gpx`, `settings`, …) |
+| `helper/` | the companion server plugin (TypeScript) |
+| `scripts/` | build/test wrappers (`build-web.mjs`, `test-ci.mjs`) — see *Build/test* |
+| `docs/` | the documentation set this file indexes |
+| `public/` | build output: the webapp (served by the SK server at `/@signalk/freeboard-sk/`) — gitignored |
+| `plugin/` | build output: the compiled helper plugin — gitignored |
+| `.github/workflows/ci.yml` | CI: calls the shared Signal K `plugin-ci` workflow |
+
+## Build, test, run
+
+Node `>=18`. Install with `npm i`. Angular `21`.
+
+| Command | Use |
+|---------|-----|
+| `npm start` / `ng serve` | dev server at `http://localhost:4200` with live reload |
+| `npm run build:web` | build the **webapp** → `public/` (use this, not raw `ng build` — see below) |
+| `npm run build:helper` | build the **helper plugin** → `plugin/` |
+| `npm run build:all` / `build:prod` | both (what CI builds, what `npm pack` runs) |
+| `npm run test:ci` | run unit tests once and **exit** (what CI runs — see below) |
+| `npm test` | `ng test` in watch mode (local dev only — does not exit) |
+| `npm run format` | Prettier over `src/` (and `format:all` for `helper/` too) |
+
+> **Why `build:web` / `test:ci` exist (important).** Angular's esbuild-based
+> `ng build` / `ng test` complete successfully but then **fail to terminate** — a
+> lingering esbuild service keeps the event loop alive. In CI that hangs the job to
+> its timeout *even though everything passed*. The `scripts/build-web.mjs` and
+> `scripts/test-ci.mjs` wrappers run the Angular command, detect the
+> success/summary, and force-exit. **Always use `npm run build:web` and
+> `npm run test:ci` for anything that must terminate** (CI, scripts, an agent
+> verifying a change). Plain `npm test` stays as the local watch command.
+
+**Pointing the dev server at a server:** in dev mode the app connects to the
+Signal K server in the browser URL. To target a specific server while running
+`ng serve`, edit the `DEV_SERVER` object (`host`/`port`/`ssl`) in
+`src/app/app.facade.ts`. This applies in **development mode only**. See
+[`docs/signalk/local-dev-environment.md`](docs/signalk/local-dev-environment.md)
+for running a local Signal K server to develop against.
+
+## Code quality
+
+- **Scope discipline.** Make only the change requested or clearly necessary. A bug
+  fix doesn't need surrounding code cleaned up; a small feature doesn't need extra
+  configurability. Don't add error handling for cases that can't happen — validate
+  at boundaries (user input, server responses), trust internal code.
+- **Self-documenting code.** Comments explain *why*, not *what*. No echo comments.
+  Documentation describes current state, not development history.
+- **TypeScript.** New code is TypeScript with real types; avoid `any`. Reuse
+  existing types over inventing local ones.
+- **Angular conventions.** Standalone components and **signals** are the norm here.
+  Prefer signals/`computed`/`effect` over manual change detection. Keep components
+  focused; push logic into services.
+- **Logging.** Use `console.warn` (not `console.error`) for *recoverable*
+  feature-detection failures, and `this.app.debug()` for internal state tracing —
+  not `console.log`.
+- **Tests.** New behaviour needs tests where the test infrastructure supports it
+  (`*.spec.ts`, run via `npm run test:ci`). Test behaviour, not implementation.
+
+## Contributing — PR standards
+
+History note: many older PRs lack descriptions, tests, or a clean title. Don't
+continue that. The bar below is what "done correctly" means here.
+
+- **One logical change per PR.** Refactors and behaviour changes go in separate
+  PRs. If the change would be two lines in a changelog, it's two PRs — split them
+  *before* opening, even if you did them together. **Proactively enforce this:** if
+  asked for something unrelated to the current PR, suggest a separate PR rather than
+  silently bundling it.
+- **PR titles are release notes.** Freeboard's App Store "Changelog" is generated
+  from PR titles (see *Hard-won knowledge*). Use `type(scope): short imperative
+  subject` (lowercase, no period); types `feat|fix|perf|refactor|docs|test|chore`;
+  scope = the area (`map`, `routes`, `charts`, `plotterext`, `deps`, …). Ask: "if
+  someone read only the title, would they understand what this does?"
+- **PR descriptions: succinct, why + how, not what.** The diff shows *what*. Don't
+  pad with mechanics, changed-line lists, version numbers, or self-congratulation —
+  maintainers should not have to wade through AI fluff. Call out breaking changes.
+  If you include a test-plan checklist, **every box must be checked** before review.
+  Include before/after screenshots for visible UI changes.
+- **Tests + CI must pass.** Add/extend `*.spec.ts` for new behaviour. CI runs the
+  shared Signal K `plugin-ci` workflow (`build:all` + `test:ci`) across a
+  Linux/macOS/Windows + arm matrix; it must be green.
+- **Never change version numbers.** Maintainers own versioning and publish releases.
+- **Branch from latest `master`; rebase, never merge.** Clean up commit history
+  before opening (no "fix typo"/"oops" commits — amend into the relevant commit).
+  When updating with upstream: `git fetch && git rebase origin/master`, force-push.
+- **CodeRabbit** reviews PRs automatically — address its comments, then it's ready
+  for maintainer review.
+
+## Hard-won knowledge (read this — it saves time and tokens)
+
+Non-obvious facts about this project that took real effort to discover:
+
+- **`ng build` / `ng test` don't exit** (esbuild keeps the loop alive) → use
+  `npm run build:web` / `npm run test:ci`, never the raw Angular commands, for
+  anything that must terminate. (This is why those wrappers exist.)
+- **A PR title is literally a line in the App Store Changelog.** The chain is: *PR
+  title → GitHub auto-generated release notes (on a `v*` tag) → App Store Changelog
+  tab*, colour-coded by `feat`/`fix`/breaking prefix. This is the real reason the
+  title convention and one-change-per-PR rules matter so much. (Details:
+  [`docs/signalk/plugin-publishing.md`](docs/signalk/plugin-publishing.md).)
+- **CodeRabbit reviews the PR *branch*, not the merged result.** It diffs against
+  the merge-base and reads context from the head branch — so if `master` moved
+  after you branched, CR (and CI) reason about a stale tree. **Rebase onto current
+  `master` before relying on a re-review**, or it may flag issues already fixed
+  elsewhere.
+- **Angular signals in `effect()`:** reading *and* writing the same signal inside an
+  effect creates a feedback loop. Read the current value non-reactively (e.g. a
+  plain getter / snapshot method) when an effect also mutates that state.
+- **Build outputs are gitignored** (`public/`, `plugin/`); the server serves
+  `public/` at the package mount point. See
+  [`docs/signalk/extension-model.md`](docs/signalk/extension-model.md) for the
+  base-path rule.
+
+## DeepWiki (warm up your context)
+
+[DeepWiki](https://deepwiki.com/) maintains an AI-readable wiki of this repo and
+**re-scans Freeboard-SK weekly**, so it's a fast way to orient before diving into
+the code. Use the DeepWiki MCP (or the web URLs) before guessing at architecture:
+
+| Repo (MCP name) | URL | For |
+|---|---|---|
+| `SignalK/freeboard-sk` | https://deepwiki.com/SignalK/freeboard-sk | Freeboard architecture, modules, data flow |
+| `SignalK/signalk-server` | https://deepwiki.com/SignalK/signalk-server | server architecture, plugin system, REST/WS APIs |
+| `SignalK/specification` | https://deepwiki.com/SignalK/specification | path semantics, delta/full formats, schema |
+
+## Documentation index
+
+**Freeboard-specific** (`docs/freeboard/`):
+- [`freeboard-plotter-ext-support.md`](docs/freeboard/freeboard-plotter-ext-support.md)
+  — Freeboard's host implementation of the Plotter Extensions API (incl. the
+  `routes` capability).
+- [`freeboard-symbol-support.md`](docs/freeboard/freeboard-symbol-support.md) — how
+  Freeboard consumes custom map symbols.
+
+**Host-agnostic API specs** (`docs/api/`):
+- [`plotter-extensions-api.md`](docs/api/plotter-extensions-api.md) — the Plotter
+  Extensions API contract.
+- [`plotter_extension_provider_plugins.md`](docs/api/plotter_extension_provider_plugins.md)
+  — guide for plugin authors providing extensions.
+- [`symbols-api.md`](docs/api/symbols-api.md) — the `symbols` resource type.
+
+**General Signal K knowledge** (`docs/signalk/`) — *skip any you already know; they
+exist so contributors new to the Signal K ecosystem don't burn context relearning
+it*:
+- [`extension-model.md`](docs/signalk/extension-model.md) — how the server
+  discovers and serves plugins/webapps.
+- [`local-dev-environment.md`](docs/signalk/local-dev-environment.md) — running a
+  local server and linking a dev build into it.
+- [`plugin-publishing.md`](docs/signalk/plugin-publishing.md) — packaging for npm
+  and the App Store.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to Freeboard-SK
+
+Freeboard-SK is an Open Source project and contributions are welcome. Contributions
+are made via Pull Requests on the [GitHub repository](https://github.com/SignalK/freeboard-sk).
+
+_**Working on your first Pull Request?**_ Learn how from this free series:
+[How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+
+## Detailed guidelines
+
+[`AGENTS.md`](AGENTS.md) holds the detailed coding, commit, and PR guidelines.
+It's written primarily as explicit guardrails for AI coding assistants, but the
+content is equally relevant to human contributors — code-quality principles, the
+build/test workflow, contribution standards, and hard-won project knowledge. Don't
+worry if some instructions seem very specific; as a human, use your judgment — the
+spirit matters more than the letter.
+
+## Running the development server
+
+Freeboard-SK is an [Angular](https://angular.dev/) app. Installing the Angular CLI
+globally is recommended: `npm i -g @angular/cli@latest`.
+
+1. Clone the repository and install dependencies:
+   ```sh
+   git clone https://github.com/SignalK/freeboard-sk
+   cd freeboard-sk
+   npm i
+   ```
+2. Start the dev server and open `http://localhost:4200`:
+   ```sh
+   npm start
+   ```
+   The app reloads as you edit source files.
+
+In development mode the app connects to the Signal K server in the browser URL. To
+target a specific server, edit the `DEV_SERVER` object (`host`/`port`/`ssl`) in
+`src/app/app.facade.ts` — this applies in **development mode only**. To run a local
+Signal K server to develop against, see
+[`docs/signalk/local-dev-environment.md`](docs/signalk/local-dev-environment.md).
+
+To build for release: `npm run build:prod` (webapp → `public/`, helper plugin →
+`plugin/`). See the README for details.
+
+## Submitting a Pull Request
+
+Before you open a PR (full detail in [`AGENTS.md`](AGENTS.md)):
+
+1. [Fork](https://help.github.com/articles/fork-a-repo/) the repo and branch from
+   the latest `master`: `git checkout -b my-fix-branch master`.
+2. **One logical change per PR.** Split unrelated work into separate PRs — if the
+   changes would be two changelog entries, they're two PRs.
+3. **Do not change version numbers** — maintainers handle versioning at release.
+4. Add or extend tests for new behaviour, and run them:
+   ```sh
+   npm run format
+   npm run build:all
+   npm run test:ci      # runs tests once and exits (not `npm test`, which watches)
+   ```
+5. Commit with `type(scope): subject` messages (imperative, present tense). Keep
+   history clean — amend fixups rather than chaining "oops" commits.
+6. Push and open the PR.
+   - **The title becomes a line in the release notes / App Store Changelog** — make
+     it descriptive and user-facing.
+   - Keep the description succinct: the motivation (why) and the approach (how), not
+     the mechanics (what). Include before/after screenshots for UI changes. If you
+     use AI, **trim the fluff** — maintainers will ask if they need more.
+7. [CodeRabbit](https://coderabbit.ai/) reviews automatically; address its comments.
+   If changes are requested, rebase and force-push to update the PR:
+   ```sh
+   git fetch origin && git rebase origin/master
+   git push -f
+   ```

--- a/docs/api/plotter-extensions-api.md
+++ b/docs/api/plotter-extensions-api.md
@@ -1,0 +1,768 @@
+# Working with the Plotter Extensions API
+
+Web-based Signal K chartplotters (e.g. Freeboard-SK) are general-purpose
+applications. Many valuable features — instrument widgets, custom panels,
+domain-specific tooling — are too specific to bundle into a chartplotter's
+core, yet forking the application to add them fragments the community.
+
+The **Plotter Extensions API** defines a Signal K resource type —
+`plotterExtensions` — through which any server plugin can offer optional
+features to chartplotter applications without forking them. A host
+chartplotter discovers extension manifests at runtime and lets the user
+place and configure the contributions. Extensions are distributed through
+the existing Signal K plugin/app-store flow.
+
+`plotterExtensions` is a user-defined resource type hosted under the
+`resources` path, so the collection is accessible at:
+
+```text
+/signalk/v2/api/resources/plotterExtensions
+```
+
+> **Status: draft.** This document describes extension API version `1` as
+> implemented by the reference host (Freeboard-SK) and the reference
+> extensions (`signalk-instrument-widgets`, `signalk-poi-search`): widgets,
+> panels, toolbar buttons, state storage, Signal K data relay, unit
+> preferences, resource display filters, map control, live route editing
+> and headless background runtimes. Manifest-declared filter chains and
+> host-into-runtime calls are out of scope for this version (see Non-Goals).
+
+---
+
+## Design Principles
+
+1. **Host-agnostic.** Nothing in the manifest or wire protocol names a
+   specific chartplotter. Hosts identify themselves and their capabilities
+   at runtime; extensions declare what they need.
+2. **Framework-neutral.** The baseline integration unit is a sandboxed
+   iframe plus a plain-JSON message protocol. Extensions need no particular
+   UI framework and no TypeScript.
+3. **Capability negotiation, not version lockstep.** An extension declares
+   required and optional capabilities; a host only offers extensions whose
+   requirements it can meet.
+4. **The host stays the orchestrator.** Extensions interact through a
+   deliberate host API — never host internals or the host DOM.
+5. **Enablement lives on the server.** The user installed and enabled the
+   providing plugin; that is the consent signal. The server's plugin
+   enable/disable switch turns the whole extension off. Hosts must not add
+   a second per-extension enable gate — presence in the
+   `plotterExtensions` collection means enabled.
+
+---
+
+## Discovery
+
+A host fetches the collection and receives extension manifests keyed by
+extension id (the providing plugin's id is the recommended key):
+
+```json
+{
+  "signalk-instrument-widgets": {
+    "name": "Instrument Widgets",
+    "description": "Single-value instrument widgets: gauge, percent meter and switch.",
+    "version": "0.2.0",
+    "apiVersion": "1",
+    "requires": ["widgets", "panels.iframe", "signalk.stream"],
+    "optional": ["signalk.put", "units"],
+    "widgets": [
+      {
+        "id": "gauge",
+        "title": "Gauge",
+        "type": "iframe",
+        "url": "/plotterext/signalk-instrument-widgets/gauge.html",
+        "size": "1x1",
+        "configPanel": "instrument-config",
+        "lifecycle": "whileEnabled"
+      }
+    ],
+    "panels": [
+      {
+        "id": "instrument-config",
+        "title": "Instrument Setup",
+        "type": "iframe",
+        "url": "/plotterext/signalk-instrument-widgets/config.html",
+        "lifecycle": "onOpen"
+      }
+    ]
+  }
+}
+```
+
+**Manifest fields**
+
+- `name`, `description`, `version` — display metadata.
+- `apiVersion` (required) — extension API major version; this document
+  defines `"1"`. Hosts must not offer manifests targeting a newer version.
+- `requires` — capability ids the host must support for the extension to be
+  offered at all.
+- `optional` — capability ids the extension uses when present; absence must
+  not prevent it from running.
+- Contribution sections: `widgets`, `panels`, `buttons`, `background` (this
+  version). Hosts must ignore unknown sections and fields.
+- Any individual contribution entry may declare its own `apiVersion` when
+  it needs a newer host API than the manifest baseline; hosts silently omit
+  contributions they cannot satisfy while keeping the rest.
+
+**Capability identifiers (version 1)**
+
+| Capability          | Meaning                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `widgets`           | Host supports the widget grid described below (including the configuration-panel methods `ui.openConfigPanel` / `ui.closePanel`). |
+| `panels.iframe`     | Host supports iframe panels.                                                                                                      |
+| `background.iframe` | Host supports headless background-runtime iframes (no UI, loaded while the extension is present).                                 |
+| `buttons`           | Host renders extension toolbar buttons in at least one slot.                                                                      |
+| `signalk.stream`    | Host streams Signal K path values to extension contexts over the message bus.                                                     |
+| `signalk.put`       | Host relays Signal K PUT requests from extension contexts.                                                                        |
+| `units`             | Host exposes the user's preferred display units (`units.get`).                                                                    |
+| `map`               | Host implements the `map.*` methods (view query and control).                                                                     |
+| `resources`         | Host implements `resources.list` (relayed resource queries).                                                                      |
+| `resources.filter`  | Host implements imperative resource display filters.                                                                              |
+| `routes`            | Host implements live route edit-buffer commands (`route.*`) and emits route lifecycle/mutation events.                            |
+| `ui`                | Host implements `ui.openPanel` / `ui.closePanel`.                                                                                 |
+
+The vocabulary is open-ended: future versions add ids (buttons, resource
+filters, map control), and hosts may expose vendor-specific experiments
+under a prefix such as `x-<host>.<capability>`. Unknown ids in `optional`
+are ignored; unknown ids in `requires` make the extension incompatible.
+
+---
+
+## Widgets
+
+A widget is a small, always-visible tile overlaid on the chart — for
+glanceable state, not complex interaction (interaction belongs in panels).
+
+**Layout model.** The host defines _widget areas_ at fixed anchor positions
+of the chartplotter window — typically corners and/or edge centers; the set
+is the host's choice (the reference host uses top-right, top-center,
+bottom-center, bottom-left and bottom-right, reserving top-left for its own
+controls). Each area is a grid of **2 columns × 2 rows**. A widget declares
+only its size in grid cells as `<columns>x<rows>`: `1x1`, `2x1`, `1x2`, or
+`2x2`.
+
+**Placement is entirely the user's choice.** The user decides which area
+and cells a widget occupies; the host provides the placement UI and
+persists the layout. A widget never requests a position. (Reference host
+UI: press-and-hold an empty anchor cell lists the widgets that fit there;
+widgets pack from the screen edge inward.)
+
+**Instances.** Placement is cell-based, not area-exclusive: widgets from
+different extensions may share an area, and the same widget definition may
+be placed multiple times. The host assigns each placement a unique, stable
+instance id (a GUID), persists it with the layout, and passes it in the
+handshake `context.instanceId`. Per-instance state is keyed by that id, so
+two instances of the same widget are configured independently.
+
+**Configuration.** A widget entry may name a panel from the same manifest
+via `configPanel`. Pointer events inside a sandboxed iframe are invisible
+to the host, so the press-and-hold gesture is detected by the widget
+content itself (the reference client library implements it), which calls
+the host method `ui.openConfigPanel` or `ui.toggleConfigPanel`. The host
+opens the named panel with `context.targetInstance` set to the widget's
+instance id and `context.targetWidget` set to the widget's manifest-local
+id, and must also provide a gesture-independent path to the same panel plus
+an affordance to **remove** the widget instance (the reference host places a
+Remove button in the configuration dialog). A widget that also handles a
+short tap should distinguish it from a long press so the press-and-hold does
+not trigger the tap action. A widget with **no** `configPanel` still gets a
+configuration dialog on long-press so it can be removed (the reference host
+shows a remove-only dialog).
+
+**Widget fields:** `id`, `title`, `type` (`iframe`), `url`, `size`,
+`configPanel?`, `lifecycle?`, `apiVersion?`.
+
+---
+
+## Panels
+
+A panel is interactive content the host displays inside its existing UI
+(dialog, drawer — the host chooses the chrome). The baseline type every
+host supporting `panels.iframe` must implement is a sandboxed iframe served
+by the providing plugin.
+
+**Panel fields:** `id`, `title`, `type` (`iframe`), `url`, `lifecycle?`,
+`apiVersion?`.
+
+**Lifecycle values**
+
+- `onOpen` — load when opened, unload when closed.
+- `keepAlive` — load on first open, keep running (hidden) while available;
+  panel state survives close/reopen.
+- `whileEnabled` — load while the extension is available, independent of
+  visibility (the expected default for placed widgets).
+
+Panels are opened by toolbar buttons, by the host methods `ui.openPanel` /
+`ui.togglePanel` (e.g. a widget tap), or — for configuration panels — by
+`ui.openConfigPanel` / `ui.toggleConfigPanel`. The `toggle*` variants close
+the panel if it is already the active one, otherwise open it. The reference
+host shows general panels in a right-side drawer that pushes the chart
+aside, and configuration panels in a dialog.
+
+---
+
+## Background Runtimes
+
+A background runtime is a **headless** extension context — a hidden iframe
+with no UI — declared in a `background` manifest section and gated by the
+`background.iframe` capability:
+
+```json
+{
+  "background": [
+    {
+      "id": "search-service",
+      "title": "POI Search Service",
+      "type": "iframe",
+      "url": "/plotterext/signalk-poi-search/runtime.html"
+    }
+  ]
+}
+```
+
+The host loads one iframe per declared runtime **while the extension is
+present in the collection** (i.e. its providing plugin is enabled) and tears
+it down when the extension leaves — independent of any panel or widget being
+open. This is the distinction from a `keepAlive` panel: a kept-alive panel is
+a _visible_ context that had to be opened at least once, whereas a runtime
+runs from the moment the extension is available with no user interaction. A
+host that supports `background.iframe` **must not** keep a visible panel
+alive merely to give an extension background behavior — that is what runtimes
+are for.
+
+A runtime speaks the same bus protocol as widgets and panels; its handshake
+`context.kind` is `background`. It may call the host API — `state.*`
+(extension scope by default, as it has no widget instance), `signalk.*`,
+`resources.*` including `resources.setFilter`, `route.*`, `units.get`,
+`map.*`, and `ui.openPanel`/`ui.togglePanel`. It has no `ui.closePanel` or
+`ui.*ConfigPanel` (those are panel/widget affordances). The typical use is a
+client-side service that holds session state and keeps work alive so a panel
+can **close itself** (`ui.closePanel`) without losing that state, then
+reattach to the runtime's state when reopened.
+
+`whileEnabled` is the only meaningful lifecycle for a runtime and is implied;
+the host does not unload a runtime on its own while the extension is present.
+
+To **trigger** a runtime, the runtime subscribes to a topic with
+`events.subscribe` and a `sendMessage` button (see Buttons) publishes that
+topic — fire-and-forget, the direction this version supports.
+
+**Background fields:** `id`, `title?`, `type` (`iframe`), `url`,
+`lifecycle?`, `apiVersion?`.
+
+> Runtimes a host can _call into_ from a button or a declarative filter (the
+> `callRuntime` action) are a further step not part of this version; a
+> version-1 runtime drives the host, not the other way around.
+
+---
+
+## Buttons
+
+An extension may contribute buttons to host-defined UI slots:
+
+```json
+{
+  "id": "open-poi-search",
+  "title": "POI Search",
+  "slot": "mapToolbar",
+  "icon": "travel_explore",
+  "action": { "type": "openPanel", "panel": "poi-search-panel" }
+}
+```
+
+- `slot` — host-defined placement; `mapToolbar` is the one well-known slot
+  every host supporting `buttons` must map to a reasonable toolbar
+  location. Hosts fall back to a default slot for unknown values.
+- `icon` — a Material icon name the host may render; hosts without that
+  icon set may substitute a generic extension icon. (A generic `symbol`
+  reference field is reserved for the symbols resource integration.)
+- `action` — what the button does:
+
+  - `togglePanel` — open the named `panel` from the same manifest, or close
+    it if it is already the active panel (recommended; matches the host's
+    built-in panel-button behavior).
+  - `openPanel` — always open (or switch to) the named `panel`.
+  - `sendMessage` — publish a message onto the host bus. The button carries a
+    `topic` (the event name) and optional `params`; the host publishes it as
+    a bus event delivered to every live extension context that subscribed to
+    that topic via `events.subscribe`. This is fire-and-forget — no reply.
+
+    ```json
+    {
+      "id": "refresh-pois",
+      "title": "Refresh nearby POIs",
+      "slot": "mapToolbar",
+      "icon": "refresh",
+      "action": { "type": "sendMessage", "topic": "poi-search:refresh" }
+    }
+    ```
+
+    The **primary use case is to reach the extension's own background
+    runtime** — a button poke that a kept-alive headless context handles
+    (re-run a search, recompute a filter, etc.), with any visible result
+    flowing back through the normal event loop (`state.changed`,
+    `filters.changed`, …). But it is a general message: the host delivers a
+    topic to _any_ subscribed context, so it can also drive a panel or, across
+    extensions, let a federation of plugins coordinate and even build ad-hoc
+    service discovery over nothing but this messaging infrastructure.
+
+    Delivery is subscription-gated — a context receives a topic only if it
+    subscribed — so an unheard message simply does nothing. Topics **should**
+    be namespaced (e.g. `<extension-id>:<name>` or an `ext.*` prefix) to avoid
+    colliding with host events (`state.changed`, `sk.*`, `filters.changed`) or
+    with another extension's topics. This is a **convention, not an enforced
+    requirement**; the host does not validate topic names.
+
+---
+
+## Communication
+
+Extension iframes talk to the host over a message bus: **JSON-RPC 2.0
+inside a routing envelope over `postMessage`**:
+
+```json
+{ "bus": "plotterExt/1", "msg": { "jsonrpc": "2.0", "...": "..." } }
+```
+
+- **Calls** are JSON-RPC requests with a fresh per-call `id` nonce; exactly
+  one response with `result` XOR `error`. Protocol errors use the JSON-RPC
+  reserved codes; host API errors use implementation-defined codes with a
+  stable string in `error.data.reason`.
+- **Events** are JSON-RPC notifications whose `method` is a hierarchical
+  dot-separated event name. Hosts only forward events a context subscribed
+  to via `events.subscribe`; subscription patterns support
+  eventemitter2-style wildcards (`*` one segment, `**` any remainder).
+- **Connection**: the extension repeats the `bus.ready` notification until
+  the host answers with `bus.handshake`:
+
+```json
+{
+  "host": "freeboard-sk",
+  "hostVersion": "2.24.0",
+  "apiVersion": "1",
+  "capabilities": [
+    "widgets",
+    "panels.iframe",
+    "buttons",
+    "signalk.stream",
+    "signalk.put",
+    "units",
+    "map",
+    "resources",
+    "resources.filter",
+    "routes",
+    "background.iframe",
+    "ui"
+  ],
+  "context": {
+    "kind": "widget",
+    "id": "gauge",
+    "instanceId": "b9c1a7e2-4f3d-4c2a-9d1e-7a5b3c8e0f42",
+    "targetInstance": null,
+    "targetWidget": null
+  }
+}
+```
+
+`context.kind` is `widget`, `panel` or `background` (this version). For a
+configuration panel, `targetInstance`/`targetWidget` identify the widget
+being configured; a `background` runtime carries neither.
+
+The reference implementation of both sides of this protocol is the
+[`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
+npm package (`/host` and `/extension` entry points). Its README documents
+the full wire format; **the documented wire format, not the package, is the
+contract** — any conforming implementation interoperates.
+
+---
+
+## Host API (version 1)
+
+| Method                  | Params                                         | Result                     |
+| ----------------------- | ---------------------------------------------- | -------------------------- |
+| `events.subscribe`      | `{ patterns: string[] }`                       | `{ subscriptionId }`       |
+| `events.unsubscribe`    | `{ subscriptionId }`                           | `{}`                       |
+| `state.get`             | `{ scope?, keys? }`                            | `{ values }`               |
+| `state.set`             | `{ scope?, values }`                           | `{}`                       |
+| `signalk.subscribe`     | `{ paths: string[] }` (literal paths)          | `{ subscriptionId }`       |
+| `signalk.unsubscribe`   | `{ subscriptionId }`                           | `{}`                       |
+| `signalk.put`           | `{ path, value }`                              | server PUT response        |
+| `units.get`             | —                                              | `{ units }`                |
+| `resources.list`        | `{ type, query? }`                             | resource collection        |
+| `resources.setFilter`   | `{ type, filter }`                             | `{}`                       |
+| `resources.clearFilter` | `{ type }`                                     | `{}`                       |
+| `route.list`            | —                                              | `{ routes }` (the visible set) |
+| `route.create`          | `{ points (≥2), name?, description? }`         | `{ routeId, rev }`         |
+| `route.show`            | `{ ref }` (stored route reference)             | `{ routeId, rev }`         |
+| `route.hide`            | `{ routeId }`                                  | `{}`                       |
+| `route.delete`          | `{ routeId }`                                  | `{}`                       |
+| `route.get`             | `{ routeId }`                                  | `{ routeId, name, description, rev, saved, dirty, points }` |
+| `route.replace`         | `{ routeId, points (≥2) }`                     | `{ rev }`                  |
+| `route.save`            | `{ routeId, name?, description?, dialog? }`    | `{ href, rev }`            |
+| `map.getView`           | —                                              | `{ center, zoom, bounds }` |
+| `map.center`            | `{ position: [lon, lat], zoom? }`              | `{}`                       |
+| `map.fitBounds`         | `{ bounds: [minLon, minLat, maxLon, maxLat] }` | `{}`                       |
+| `ui.openPanel`          | `{ panel }`                                    | `{}`                       |
+| `ui.togglePanel`        | `{ panel }`                                    | `{}`                       |
+| `ui.openConfigPanel`    | — (widget contexts)                            | `{}`                       |
+| `ui.toggleConfigPanel`  | — (widget contexts)                            | `{}`                       |
+| `ui.closePanel`         | — (panel contexts)                             | `{}`                       |
+
+**Host events**
+
+These events are part of the API contract — any conforming host emits them,
+they are not host-specific. Each is delivered only to contexts that have
+subscribed to its name via `events.subscribe` (so a context that never
+subscribes pays nothing). A host emits an event when the corresponding
+capability is supported: `state.changed` always; `sk.<path>` with
+`signalk.stream`; `filters.changed` with `resources.filter`; route events
+(`route.*`) with `routes`. The
+connection-level notifications `bus.ready` and `bus.handshake` (see
+Communication) are the only other host/extension events and are
+handled by the protocol layer, not subscribed to.
+
+- `state.changed` — `{ scope, instanceId, keys }`: the extension's stored
+  state changed (e.g. its configuration panel saved). Published to the
+  extension's subscribed contexts.
+- `sk.<path>` — `{ path, value, timestamp, $source }`: a subscribed
+  Signal K path value, relayed over the host's multiplexed server
+  connection (one upstream connection per host, not per widget).
+- `filters.changed` — `{ type, active }`: the extension's display filter for
+  a resource type was set (`active: true`) or cleared (`active: false`, e.g.
+  the user dismissed the host's filter chip). Extensions should reflect a
+  clear in their own UI/state.
+- `route.visible` — `{ routeId, rev, name, pointCount, saved, dirty }`: a route
+  entered the visible set (became rendered on the chart). A freshly drawn or
+  `route.create`d draft arrives `saved:false, dirty:true`; a stored route brought
+  into view (`route.show`, or the user displaying it) arrives `saved:true,
+  dirty:false`.
+- `route.dirty` — `{ routeId, rev, reason? }`: content changed — a reorder,
+  multi-point edit, metadata change, or whole-geometry replace. Sets
+  `dirty:true`; leaves `saved` unchanged. A subscriber should re-seed with
+  `route.get`. This is the conformance floor — see *Live routes*.
+- `route.saved` — `{ routeId, rev, href, name, saved, dirty }`: the route's
+  current state was persisted to the `routes` resource collection; arrives
+  `saved:true, dirty:false`. `href` is the stored resource id, and `name` is the
+  persisted name (which the host's save dialog may have just set — e.g. an
+  unnamed draft saved as "rt1"), so a follower can relabel without re-fetching.
+  The route stays visible and addressable under the same `routeId`.
+- `route.hidden` — `{ routeId, rev, saved }`: a route left the visible set.
+  `saved:true` — a stored route was made invisible (the resource is untouched and
+  can be shown again); `saved:false` — an unsaved draft was deleted (gone for
+  good). The umbrella name never overstates what happened.
+
+### Resource queries and display filters
+
+`resources.list` relays a resource collection request through the host's
+authenticated client: `{ type: "notes", query: { position: [lon, lat],
+distance: 18520 } }` serializes to the resources API query string. This
+keeps extensions inside the host's auth/session semantics; extensions may
+still call the server REST API directly (same-origin) when needed.
+
+`resources.setFilter` controls what the host _displays_ for a resource
+type — it never modifies stored resources:
+
+```json
+{
+  "type": "notes",
+  "filter": {
+    "mode": "include",
+    "ids": ["urn:mrn:signalk:uuid:..."],
+    "match": [
+      { "path": "properties.skIcon", "op": "eq", "value": "anchorage" }
+    ],
+    "label": "Anchorage < 10 nm: 2 matches"
+  }
+}
+```
+
+- `mode` — `include` (show only matching) or `exclude` (hide matching).
+- `ids` — resource ids;
+- `match` — AND-combined property conditions with
+  `op` one of `eq | ne | lt | lte | gt | gte | in | contains | regex |
+exists`. `contains` is case-insensitive substring for strings, membership
+  for arrays; `regex` tests a JavaScript regular-expression pattern string
+  (in `value`) against the field's string value — a non-string field or an
+  invalid pattern fails. Conditions on missing fields are false except
+  `exists`. At least one of `ids`/`match` is required; when both are present
+  a resource must satisfy both.
+
+  **Symbol-reference tolerance.** `eq`, `ne` and `in` compare symbol
+  references (per the [Symbols API](https://github.com/joelkoz/signalk-symbol-manager))
+  namespace-tolerantly: a bare local id matches a qualified `namespace:id`
+  with the same id, and vice versa. So `{ "path": "properties.skIcon",
+"op": "eq", "value": "anchorage" }` matches a resource whose stored value
+  the host has qualified to `default:anchorage` (or `custom:anchorage`).
+  Differing namespaces (`custom:x` vs `fsk:x`) do not match, and only
+  single-colon `namespace:id` values participate — multi-colon strings such
+  as URNs keep strict equality. An extension that needs exact matching of a
+  qualified reference should set `"exact": true` on the condition (or write
+  the fully-qualified `value`, or use `regex`). With `exact`, `eq`/`ne`/`in`
+  compare strictly and `anchorage` will not match `default:anchorage`.
+
+- `label` — short human-readable description. **Hosts must surface active
+  filters to the user** (the reference host renders clearable chips) and
+  let the user clear any filter without opening the owning extension.
+
+The host tracks at most one filter per (extension, resource type); a new
+`setFilter` replaces it. Filters from multiple extensions compose by
+intersection. Filters are not persisted across host reloads.
+
+### Live routes
+
+The `routes` capability gives an extension read/write access to the routes the
+host currently has **visible on the chart**, plus a stream of lifecycle and
+mutation events. The visible set is small and practical — the one or two routes a
+user is actually working with — never the hundreds that may be stored on the
+server.
+
+**The visible set.** A host renders some routes on the chart: routes the user is
+drawing or modifying, routes an extension created, and stored routes the user has
+chosen to display. Every route in that set is addressable. Routes that exist only
+on the server (the stored catalog) are **not** — an extension that wants one
+browses the server's resources API directly (`GET /resources/routes` returns the
+whole catalog with full geometry) and asks the host to display it (`route.show`).
+
+**Addressing — opaque handles.** Each visible route has a host-assigned `routeId`
+that is **opaque**: the extension treats it as a token and never parses it. The
+host mints and decodes it (it may encode a stored resource id, an ephemeral draft
+id, or anything else — that is implementation, kept behind the handle). A
+`routeId` is stable for as long as the route stays visible. Every command and
+event names its `routeId`. `route.list` enumerates the visible set; a host that
+only ever shows one route at a time simply exposes one entry.
+
+**Two flags: `saved` and `dirty`.** Orthogonal, and both appear on `route.get`,
+`route.list`, and the lifecycle events:
+
+- `saved` — is the route backed by a persisted `routes` resource? A never-saved
+  draft is `false`; a stored route is `true`.
+- `dirty` — does the in-memory geometry differ from what is persisted (pending
+  unsaved changes)? A clean route is `false`; an edited one is `true`.
+
+  | `saved` | `dirty` | state |
+  | ------- | ------- | ----- |
+  | `false` | `true`  | a draft with content — needs saving to persist |
+  | `true`  | `false` | a clean stored route — matches the server |
+  | `true`  | `true`  | a stored route with unsaved edits |
+
+**Editing stages; it does not write through.** Manipulating a visible route —
+`route.replace`, or the user's own native editing — changes the in-memory route
+and emits `route.dirty` (setting `dirty:true`); it does **not** touch the server,
+and it leaves `saved` unchanged. The change is committed only by `route.save`, or
+discarded by the host's editing UI / `route.hide` (for a draft). This mirrors how
+a native editor already works — manipulate, then save or discard — and applies
+uniformly to drafts and stored routes.
+
+**Bringing routes in and out of view.** The function calls are deliberately the
+traditional **create / show / hide / delete**; the visibility/`saved`/`dirty`
+model lives in the *events* and route properties, not in the verbs.
+
+- `route.create({ points, name?, description? })` adds a new unsaved route to the
+  visible set (`saved:false`). `points` is **required and must hold at least two
+  waypoints** (a route needs a segment); fewer is rejected with
+  `routes.badRequest`. `description` is the route-level description (distinct from
+  a waypoint's per-point `description`) and round-trips through `route.get` and
+  `route.save`.
+- `route.show({ ref })` brings an existing **stored** route into the visible set
+  and returns its `routeId`, so the extension can read and edit it in place.
+- `route.hide({ routeId })` removes a route from the map. For a **stored** route
+  this just unchecks its visibility — the resource is untouched
+  (`route.hidden saved:true`). For an **unsaved** route it deletes it, since the
+  only store it has is the visibility buffer (`route.hidden saved:false`).
+- `route.delete({ routeId })` **permanently deletes a stored route** from the
+  resource collection. Deleting an *unsaved* route has the same effect as hiding
+  it (the draft is discarded). Either way the route leaves the visible set as
+  `route.hidden saved:false` (gone — no longer retrievable).
+
+So `hide` and `delete` both emit `route.hidden`; the event's `saved` flag tells a
+follower the outcome (`true` = still on the server, `false` = gone), while the
+*verb the extension called* carries the intent.
+
+**Points and geometry.** A route's points are an ordered list (0-based). A point
+is `{ position: [lon, lat, alt?], name?, description? }` — `name`/`description`
+map to a host's per-point metadata and round-trip through `route.get`,
+`route.replace`, and `route.save`. `route.create` and `route.replace` require at
+least two points and reject a malformed point (a non-numeric `position`, or
+non-string `name`/`description`) with `routes.badRequest`.
+
+**Revisions and mirroring.** Each route carries a monotonic `rev` that
+increments on every mutation. `route.get` and `route.list` report the current
+`rev`, and every mutation event and every mutating command result carries the
+post-change `rev`. In v1 the mutation signal is **`route.dirty`**: an extension
+mirrors a route by calling `route.get` whenever it sees `route.dirty` (or a `rev`
+gap). The protocol still offers a full snapshot (`route.get`) so the author never
+has to reconstruct state from a partial stream.
+
+**`route.dirty` is the conformance floor.** Every change to a visible route's
+content — a multi-point edit, a whole-geometry `route.replace` (e.g. an
+auto-router's), a metadata change, or the reference host's `Modify` flow (which
+hands back a whole coordinate array with no "which vertex moved") — emits
+`route.dirty`. A host emits `route.visible`, `route.hidden`, `route.saved`, and
+`route.dirty` — geometry is always edited as a whole (`route.replace` or the
+host's own native editing), so a single "on `route.dirty`, `route.get`" keeps a
+follower in sync without tracking who changed what.
+
+**Origin transparency.** Events are emitted for _every_ change regardless of
+origin — an extension command, the user's native editing, or another
+extension — so a follower stays consistent no matter who is driving. As with
+all host events, a context receives them only after `events.subscribe` (e.g.
+`{ patterns: ["route.**"] }`).
+
+**Saving.** `route.save` persists the route's current state to the `routes`
+resource collection through the user's authenticated session, returning the
+stored resource `href` and emitting `route.saved` (`saved:true, dirty:false`).
+The route **stays visible and addressable under the same `routeId`** — saving
+does not remove or invalidate it. For a never-saved draft this creates a new
+resource; for an already-stored route with pending edits it updates that
+resource. It is **headless by default** — saved with the supplied
+`name`/`description`, falling back to the route's current name. Pass
+`dialog: true` to have the host prompt for the name/description instead, its
+dialog prefilled from those params; the reference host (Freeboard-SK) opens its
+Route Details dialog, and a cancelled dialog rejects with `routes.saveCancelled`.
+
+Note the `routeId` is the host's **opaque handle**, distinct from the `href` of
+the saved resource (an `/resources/routes/<id>` reference returned by the save) —
+they are not interchangeable, and a saved route keeps the same `routeId` it had
+before the save.
+
+**Errors** use the standard `error.data.reason` convention: `routes.unknownId`
+(no such `routeId`), `routes.badRequest` (invalid params — e.g. `route.create`
+with fewer than two points, a non-numeric `position`, or non-string metadata),
+`routes.badRef` (`route.show` reference not found), `routes.saveFailed` (server
+rejected the persist — distinct from a user cancel), `routes.saveCancelled` (the
+user dismissed the save dialog), `routes.notSupported` (host lacks `routes`).
+
+### State storage
+
+`state.get`/`state.set` give an extension small host-persisted key/value
+storage. Two scopes:
+
+- `instance` — keyed by the context's widget instance (default for widget
+  contexts; configuration panels opened with `targetInstance` read and
+  write the _target's_ instance scope).
+- `extension` — shared across the extension's contexts.
+
+Every successful `state.set` triggers a `state.changed` event — the loop
+that lets a widget re-render live while its configuration panel edits it.
+Quota and persistence backend are host-defined.
+
+### Unit preferences
+
+Signal K values are SI on the wire, and a path's `meta.units` names the
+unit. What the _user_ wants displayed is host configuration. `units.get`
+exposes it:
+
+```json
+{
+  "units": {
+    "speed": "kn",
+    "distance": "naut-mile",
+    "depth": "m",
+    "length": "m",
+    "temperature": "C"
+  }
+}
+```
+
+Vocabulary: `speed` `kn|m/s|km/h|mph`; `distance` `kilometer|naut-mile`;
+`depth`/`length` `m|foot`; `temperature` `C|F`. Hosts may add keys;
+extensions must tolerate missing ones. Extensions rendering path values
+should combine a path's `meta.units` with these preferences to decide which
+conversions to offer and which to preselect.
+
+---
+
+## Providing an Extension
+
+A Signal K plugin:
+
+1. Registers a resource provider for the custom type `plotterExtensions`
+   (works on current servers — no server upgrade required):
+
+   ```js
+   app.registerResourceProvider({
+     type: 'plotterExtensions',
+     methods: {
+       listResources: async () => ({ [PLUGIN_ID]: manifest }),
+       getResource: async (id) => {
+         /* ... */
+       },
+       setResource: async () => {
+         throw new Error('read-only')
+       },
+       deleteResource: async () => {
+         throw new Error('read-only')
+       }
+     }
+   })
+   ```
+
+2. Serves its widget, panel and background assets from a **publicly
+   readable**, non-admin-gated route. Manifest URLs are server-relative;
+   hosts resolve them against the Signal K server origin. The asset files are
+   inert UI code — all data flows through the bus over the user's own
+   authenticated session, and extension _discovery_ is gated by the
+   authenticated resources API, so an unauthenticated user sees no extensions
+   regardless of how the assets are served. For how to mount such a route from
+   a plugin, see
+   [Plotter Extension Provider plugins](./plotter_extension_provider_plugins.md).
+
+3. Declares inter-plugin relationships through the App Store mechanism
+   (`"signalk": { "recommends": ["<plugin-name>"] }` in `package.json`)
+   rather than hard dependencies — e.g. an extension that searches another
+   provider's resources.
+
+---
+
+## Security and Trust
+
+By the time a manifest is visible, the user has already installed a server
+plugin — code that runs unrestricted on the server. Install time is the
+trust decision; browser-side isolation is **fault containment, not an
+adversarial boundary**:
+
+- Baseline iframe sandbox: `allow-scripts allow-same-origin allow-forms`.
+  Same-origin assets plus scripts mean the sandbox attribute is not a
+  security boundary; its value is lifecycle isolation, CSS/DOM separation
+  and crash containment. `allow-top-navigation`, `allow-popups` and
+  `allow-modals` are withheld to prevent accidents.
+- The host API validates arguments and applies call timeouts; one broken
+  extension must not prevent the host from loading.
+- Extension contexts are same-origin with the Signal K server and may call
+  its REST/WebSocket APIs directly with the user's session where the host
+  API does not suffice.
+
+---
+
+## Reference Implementations
+
+- **Protocol**: [`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
+  — wire format documentation plus host/extension endpoints with a
+  conformance test suite.
+- **Extensions**: [`signalk-instrument-widgets`](https://github.com/joelkoz/signalk-instrument-widgets)
+  — gauge, meter, switch and display-value widgets with a
+  shared unit-aware configuration panel — and
+  [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search) — a
+  toolbar button + keepAlive search panel + results widget exercising
+  resource queries, display filters and map control — and
+  `signalk-auto-route` *(planned)* — a toolbar button + parameter panel +
+  server-side routing engine exercising the `routes` capability (land-avoidance
+  auto-routing over the host's live route buffer; see its own SPEC).
+- **Host**: Freeboard-SK (feature branch, in development) — anchor-area
+  widget overlay, placement UI, state storage, multiplexed Signal K relay,
+  toolbar buttons, panel drawer, filter chips, map control.
+
+---
+
+## Non-Goals
+
+This version deliberately does not specify:
+
+- **Manifest-declared filter chains.** Display filtering here is imperative:
+  running extension code pushes an id set or `match` predicate via
+  `resources.setFilter`. Filters declared _statically in the manifest_ and
+  evaluated by the host on every resource fetch are out of scope for this
+  version.
+- **Host-into-runtime calls (`callRuntime`).** Background runtimes drive the
+  host — they call host methods and react to host events; the host does not
+  call into a runtime. The reverse call direction is out of scope for this
+  version.

--- a/docs/api/plotter_extension_provider_plugins.md
+++ b/docs/api/plotter_extension_provider_plugins.md
@@ -1,0 +1,589 @@
+# Plotter Extension Provider plugins
+
+A _plotter extension provider_ is a Signal K server plugin that adds optional
+UI and behaviour to **chartplotter applications** — widgets overlaid on the
+chart, interactive panels, toolbar buttons, resource display filters and
+headless background runtimes — without the chartplotter needing to know the
+plugin exists. The user installs your plugin from the App Store; any host
+chartplotter that supports the mechanism then offers what your plugin
+contributes. Freeboard-SK is the reference host.
+
+This guide is the how-to for **writing one**. The wire contract it builds on —
+the `plotterExtensions` resource type, the manifest shape, capability
+negotiation, the message bus and the host API — is defined in the
+[Plotter Extensions API](./plotter-extensions-api.md); keep
+it open alongside this guide. General plugin mechanics (`package.json`
+keywords, `start`/`stop`, `schema`, `npm link`, debugging) are **not** repeated
+here — see [Server plugins](https://github.com/SignalK/signalk-server/blob/master/docs/develop/plugins/README.md) for those.
+
+## It is more than "iframes on a chart"
+
+The visible part of an extension is an iframe (a widget or panel). What makes
+it powerful is what that iframe is plugged into:
+
+- **A host API.** From inside the iframe you call host methods to manipulate the plotter UI — drive the map, add a button to open a panel, subscribe to
+  live Signal K values, filter resource queries, listen for and react to events.
+- **A publish/subscribe message bus.** Every context (widget, panel,
+  background runtime) and the host share an event bus. The host emits contract
+  events (`state.changed`, `sk.<path>`, `filters.changed`); a button can
+  publish a topic; contexts from the _same or different_ plugins can coordinate
+  over it.
+- **Headless background runtimes.** A hidden iframe that runs while your plugin
+  is enabled — a client-side service that holds session state and reacts to
+  events, so a panel can close without losing work.
+- **New resource types with UI around them.** Because a plugin can be a
+  resource provider _and_ contribute the panels/widgets/filters that present
+  those resources, a single plugin can introduce an entirely new kind of data
+  and everything needed to work with it on the chart.
+
+So a "Display value" widget and a route-optimising background service are the
+same mechanism at different points on a spectrum.
+
+### Good candidates
+
+- Glanceable instrument readouts overlaid on the chart (a single SK value).
+- A search/filter panel over a resource type ("show anchorages within 10 nm").
+- A workflow that creates or curates resources (a dive-site logger that
+  provides a custom resource type, drops symbols for it, and offers a panel to
+  search and route to sites).
+- A route tool that reshapes the route the user is editing (the `routes`
+  capability) — an auto-router that detours around land, a leg optimiser, a
+  "reverse this route" button.
+- A background service that reacts to host events (a route shown or edited,
+  config changed) and computes something.
+
+### Poor candidates
+
+- A full-screen standalone application with its own navigation — that is a
+  [webapp](https://github.com/SignalK/signalk-server/blob/master/docs/develop/webapps.md), not an extension. Extensions are guests inside the
+  host's chrome.
+- Anything that needs to take over the chart, the host's menus, or the whole
+  viewport. Extensions interact only through the host API, never the host DOM.
+- Heavy, always-running computation in a visible widget. Put work in a
+  background runtime and keep widgets glanceable.
+
+## Who does what
+
+The single most important thing to understand before building:
+
+| Concern              | The **host** provides                                                                            | Your **plugin** provides                                                 |
+| -------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Integration surface  | The bus, the handshake, the capabilities it advertises, the host API methods, the iframe sandbox | A manifest declaring contributions, and the iframe assets that fill them |
+| Widget **placement** | The widget areas, the placement UI, and persistence of the chosen layout                         | Only the widget's **size** (`1x1`…`2x2`) and its content                 |
+| Panel **chrome**     | The drawer/dialog the panel is shown in, and the open/close controls                             | The panel's content and behaviour                                        |
+| Live data, resources | A multiplexed Signal K connection and authenticated resource access, relayed over the bus        | The calls that consume them                                              |
+| Enablement           | Nothing — there is no host-side per-extension switch                                             | Enablement _is_ the server plugin being enabled                          |
+
+Two consequences worth stating plainly because they surprise people:
+
+- **A widget never chooses where it appears.** It declares a size; the _user_
+  picks the area and cells through host UI, and the host persists that. Your
+  code receives a stable `instanceId` for each placement and nothing about
+  position. (The spec does not prescribe a layout to the host either — the
+  reference host happens to offer five anchor areas, each a 2×2 cell grid.)
+- **There is no "enable extension" step in the host.** Presence in the
+  `plotterExtensions` collection — i.e. the providing plugin is installed and
+  enabled — _is_ the consent signal.
+
+### What is the minimum?
+
+- **Minimum a plugin must deliver:** register the `plotterExtensions` resource
+  provider returning a manifest with `apiVersion`, `requires`, and **one**
+  contribution (e.g. a single widget), plus the iframe asset that contribution
+  points at. That is a working extension.
+- **Minimum a host must support to run it:** the bus handshake plus every
+  capability your manifest lists in `requires`. A host that cannot meet your
+  `requires` simply does not offer your extension; capabilities in `optional`
+  are used when present and skipped when not. The reference host implements all
+  version-1 capabilities.
+
+## Server side: two responsibilities
+
+The plugin's Node code is deliberately tiny — all UI lives in iframes. It does
+two things.
+
+### 1. Register the manifest as a read-only resource
+
+Expose your manifest as a single, read-only resource of the custom type
+`plotterExtensions`. No server upgrade is required — it works on current
+servers as a user-defined resource type. The manifest is code, not user data,
+so the write methods reject:
+
+```js
+module.exports = (app) => {
+  const PLUGIN_ID = 'my-plotter-extension'
+  let running = false
+
+  const buildManifest = () => ({
+    /* see "The manifest" below */
+  })
+
+  return {
+    id: PLUGIN_ID,
+    name: 'My Plotter Extension',
+    start() {
+      running = true
+      app.registerResourceProvider({
+        type: 'plotterExtensions',
+        methods: {
+          listResources: async () =>
+            running ? { [PLUGIN_ID]: buildManifest() } : {},
+          getResource: async (id) => {
+            if (!running || id !== PLUGIN_ID) {
+              throw new Error(`No such plotterExtensions resource: ${id}`)
+            }
+            return buildManifest()
+          },
+          setResource: async () => {
+            throw new Error(`${PLUGIN_ID} is a read-only provider`)
+          },
+          deleteResource: async () => {
+            throw new Error(`${PLUGIN_ID} is a read-only provider`)
+          }
+        }
+      })
+    },
+    stop() {
+      running = false
+    }
+  }
+}
+```
+
+`registerResourceProvider` is the same server method used by every
+[resource provider plugin](https://github.com/SignalK/signalk-server/blob/master/docs/develop/plugins/resource_provider_plugins.md); here the resource
+type just happens to be your manifest.
+
+### 2. Serve the iframe assets
+
+Widget, panel and background pages must be reachable from the browser at the
+server-relative URLs your manifest declares. The `app` object passed to your
+plugin is the Signal K server API — a copy of the server's Express application
+extended with the server methods — so it also exposes Express's `use()`. Mount
+your asset directory as a top-level static route during startup:
+
+```js
+const path = require('path')
+const ASSET_BASE = `/plotterext/${PLUGIN_ID}`
+const PUBLIC_DIR = path.join(__dirname, '..', 'public')
+
+// in start():
+app.use(ASSET_BASE, require('express').static(PUBLIC_DIR))
+// manifest urls then point at `${ASSET_BASE}/<page>.html`
+```
+
+Express is provided by the server, so requiring it adds no runtime dependency
+of your own. A namespaced prefix such as `/plotterext/<package-name>/` keeps
+the top-level path collision-free.
+
+Two routes to **avoid**:
+
+- **`/plugins/*`** (e.g. via `registerWithRouter`) — the server gates the
+  entire `/plugins` path behind _admin_ authentication, so read-only users
+  could not load the assets.
+- **The `signalk-webapp` keyword** — it auto-mounts `public/` at
+  `/<package-name>/`, but it also lists the package in the server's Webapps
+  launcher. Extension assets are only ever loaded inside the host's iframe,
+  never launched standalone, so they should not appear there. Omit the keyword
+  and self-mount instead.
+
+Serving the asset _bytes_ publicly is not a data-exposure concern: the files
+are inert UI code, all data flows through the bus over the user's own
+authenticated session, and extension _discovery_ is gated by the authenticated
+resources API — an unauthenticated user sees no extensions regardless of how
+the assets are served.
+
+## The manifest
+
+The manifest is the contract between your plugin and any host. It names your
+required and optional capabilities and lists your contributions. A real one
+(from `signalk-poi-search`, which contributes all three visible kinds):
+
+```js
+{
+  name: 'POI Search',
+  description: 'Search points of interest (notes) by name, category and distance.',
+  version: pkg.version,
+  apiVersion: '1',                                  // extension API major version
+  requires: ['panels.iframe', 'resources', 'resources.filter'],
+  optional: ['buttons', 'widgets', 'map', 'units'],
+  buttons: [
+    {
+      id: 'open-poi-search',
+      title: 'POI Search',
+      slot: 'mapToolbar',                           // host-defined placement
+      icon: 'travel_explore',                       // Material icon name
+      action: { type: 'togglePanel', panel: 'poi-search-panel' }
+    }
+  ],
+  panels: [
+    {
+      id: 'poi-search-panel',
+      title: 'POI Search',
+      type: 'iframe',
+      url: `${ASSET_BASE}/panel.html`,
+      lifecycle: 'keepAlive'                        // stay alive when hidden
+    }
+  ],
+  widgets: [
+    {
+      id: 'poi-results',
+      title: 'POI Search Results',
+      type: 'iframe',
+      url: `${ASSET_BASE}/widget.html`,
+      size: '2x1',                                  // 2 cols × 1 row
+      lifecycle: 'whileEnabled'
+    }
+  ]
+}
+```
+
+**Top-level fields**
+
+- `apiVersion` (**required**) — the extension API major version your manifest
+  targets; this document and spec define `"1"`. A host ignores manifests
+  targeting a newer version.
+- `requires` — capability ids the host **must** support or it will not offer
+  your extension at all. List only what you genuinely cannot work without.
+- `optional` — capabilities you _use when present_. Absence must not stop your
+  extension running; check at runtime with `client.hasCapability(id)` and
+  degrade gracefully.
+- Contribution arrays — `widgets`, `panels`, `buttons`, `background`. Include
+  only the ones you provide.
+
+**Capabilities you will reach for** (full list in the spec):
+
+| Capability          | What it lets you do                                           |
+| ------------------- | ------------------------------------------------------------- |
+| `widgets`           | Contribute chart-overlay widgets (and config panels)          |
+| `panels.iframe`     | Contribute iframe panels                                      |
+| `buttons`           | Add toolbar buttons                                           |
+| `signalk.stream`    | Subscribe to live SK path values (`client.signalk.subscribe`) |
+| `signalk.put`       | Send SK PUT requests (`client.signalk.put`)                   |
+| `resources`         | Run resource queries (`resources.list`)                       |
+| `resources.filter`  | Push display filters (`resources.setFilter`)                  |
+| `map`               | Read/drive the map view (`map.*`)                             |
+| `routes`            | Read & edit the routes on the chart (`route.*`)               |
+| `units`             | Read the user's display-unit preferences (`units.get`)        |
+| `background.iframe` | Run a headless background runtime                             |
+
+**Contribution fields**
+
+- **Widget:** `id`, `title`, `type: 'iframe'`, `url`, `size`
+  (`1x1`|`2x1`|`1x2`|`2x2`), optional `configPanel` (id of a panel in the same
+  manifest), optional `lifecycle`.
+- **Panel:** `id`, `title`, `type: 'iframe'`, `url`, optional `lifecycle`.
+- **Button:** `id`, `title`, `slot` (`mapToolbar` is the well-known slot),
+  `icon` (Material icon name), `action` — one of
+  `{ type: 'togglePanel'|'openPanel', panel }` or
+  `{ type: 'sendMessage', topic, params? }`.
+- **Background:** `id`, `title?`, `type: 'iframe'`, `url`.
+
+**Lifecycle** controls when the host loads a context's iframe:
+
+- `onOpen` — load when shown, unload when closed (good for config panels).
+- `keepAlive` — load on first open, keep running hidden; state survives
+  close/reopen.
+- `whileEnabled` — load while the extension is available regardless of
+  visibility (the norm for placed widgets).
+
+## Inside an extension iframe
+
+All the reference contributions are plain JavaScript built on the reference
+client library [`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
+(the `/extension` entry point). No framework, no TypeScript required. You
+connect once, then talk to the host through the returned `client`:
+
+```js
+import { connectExtension } from 'signalk-plotterext-bus/extension'
+
+const client = await connectExtension() // resolves after the host handshake
+
+client.context // { kind, id, instanceId, targetInstance, targetWidget }
+client.hasCapability('map') // is an optional capability available?
+
+await client.call('method', params) // call any host API method (table in spec)
+await client.subscribe(['event.name'], (name, params) => {}) // bus events
+```
+
+`client` also wraps the most common calls so you do not hand-assemble them:
+
+- `client.state.get(keys?, scope?)` / `client.state.set(values, scope?)` —
+  host-persisted key/value storage. Scope defaults to the widget `instance`;
+  pass `'extension'` for state shared across all your contexts.
+- `client.signalk.subscribe(paths, ev => …)` — live SK values; the callback
+  gets `{ path, value, … }`. Returns an unsubscribe function.
+- `client.signalk.put(path, value)` — a SK PUT through the user's session.
+
+The full host method list and the contract events (`state.changed`,
+`sk.<path>`, `filters.changed`) are in the
+[Host API section of the spec](./plotter-extensions-api.md#host-api-version-1).
+The two examples below show the surface in practice.
+
+## Example: a widget (the simplest contribution)
+
+The "Display value" widget shows one Signal K value as text. The HTML is
+trivial — a single mount point — so this section is all host API:
+
+```
+<!-- display.html (skeleton) -->
+<div id="root"></div>
+<script type="module" src="display.js"></script>
+```
+
+The whole widget lifecycle is four host interactions: **load config**,
+**follow the configured path**, **reload when the config panel saves**, and
+**open the config panel on long-press**.
+
+```js
+import { connectExtension } from 'signalk-plotterext-bus/extension'
+
+const root = document.getElementById('root')
+const client = await connectExtension()
+
+let unsubscribe = null
+
+async function applyConfig() {
+  // Per-instance config — two placements of this widget are independent.
+  const config = await client.state.get() // default scope: this instance
+
+  if (unsubscribe) await unsubscribe()
+  root.textContent = config.path ? '--' : 'Not configured'
+
+  if (config.path) {
+    // Live values arrive over the host's multiplexed SK connection.
+    unsubscribe = await client.signalk.subscribe([config.path], (ev) => {
+      root.textContent = ev.value ?? '--'
+    })
+  }
+}
+
+// The config panel writes instance state, which fires state.changed; reload.
+await client.subscribe(['state.changed'], () => applyConfig())
+await applyConfig()
+
+// Pointer events inside a sandboxed iframe are invisible to the host, so the
+// widget detects its own long-press and asks the host to open its config panel.
+let timer
+addEventListener('pointerdown', () => {
+  timer = setTimeout(
+    () => client.call('ui.openConfigPanel').catch(() => {}),
+    1500
+  )
+})
+addEventListener('pointerup', () => clearTimeout(timer))
+```
+
+Points that generalise to every widget:
+
+- **It never positions itself.** It declares `size: '1x1'`; the user placed it
+  and the host gave this placement an `instanceId`. `client.state.get()` is
+  scoped to that instance automatically.
+- **Live data is relayed, not fetched.** `client.signalk.subscribe` rides the
+  host's single upstream Signal K connection — you do not open your own.
+- **The config loop is the bus.** The config panel saves to this instance's
+  state → the host emits `state.changed` → the widget re-reads and re-renders.
+
+(The reference plugin factors this shared wiring into a `common.js` so each
+widget file is just a `render()` — but the calls above are exactly what it
+does.)
+
+### The config panel side
+
+A widget names a panel with `configPanel: 'instrument-config'`. When the host
+opens it, `client.context.targetInstance` is the widget instance being
+configured, and `state.set` writes **that** instance's scope:
+
+```js
+const client = await connectExtension()
+const target = client.context.targetInstance
+// read current settings, render a form, then on save:
+await client.state.set({ path: chosenPath /* … */ }) // fires state.changed
+```
+
+A widget with no `configPanel` still gets a host-provided dialog on long-press
+so the user can remove it; the host always provides a Remove affordance.
+
+## Example: a panel that drives the host
+
+`signalk-poi-search` is a `keepAlive` panel opened by a toolbar button. It runs
+a resource query, shows only the matches on the chart with a display filter,
+and fits the map to them — exercising `resources.list`, `resources.setFilter`,
+`map.*` and extension-scope state. The form HTML is ordinary (`<input>`s and a
+`<button>`); the host API is the interesting part:
+
+```js
+import { connectExtension } from 'signalk-plotterext-bus/extension'
+
+const client = await connectExtension()
+// Extension-scope state: shared with the companion results widget and a
+// reopened panel (a keepAlive panel survives hide/show, but this also lets a
+// sibling widget read the summary).
+const saved = await client.state.get(undefined, 'extension').catch(() => ({}))
+
+// …render the form from `saved`…
+
+async function runSearch(keyword, category, distanceNm) {
+  // Relayed through the host's authenticated session — same auth as the user.
+  const collection = await client.call('resources.list', {
+    type: 'notes',
+    query: { position: [lon, lat], distance: distanceNm * 1852 }
+  })
+
+  const matches = Object.entries(
+    collection ?? {}
+  ).filter(/* keyword/category */)
+  const label = `POI: ${matches.length} matches`
+
+  if (matches.length) {
+    // Display-only: the host shows just these ids and renders a clearable
+    // chip with `label`. It never modifies the stored resources.
+    await client.call('resources.setFilter', {
+      type: 'notes',
+      filter: { mode: 'include', ids: matches.map(([id]) => id), label }
+    })
+
+    // `map` is optional — guard before using it.
+    if (client.hasCapability('map')) {
+      await client.call('map.fitBounds', { bounds }).catch(() => {})
+    }
+  } else {
+    await client.call('resources.clearFilter', { type: 'notes' })
+  }
+
+  // Publish a summary for the results widget; also survives reopen.
+  await client.state.set({ label, count: matches.length }, 'extension')
+}
+
+// The host renders the active filter as a chip the user can dismiss without
+// reopening this panel. Reflect that so our UI/state stay in sync.
+await client.subscribe(['filters.changed'], (_name, params) => {
+  if (params.type === 'notes' && params.active === false) {
+    // clear our own state / status
+  }
+})
+```
+
+Points that generalise:
+
+- **Prefer the relayed calls over direct REST.** `resources.list` keeps you
+  inside the host's auth/session and its resource semantics. (You _may_ call
+  the server REST API directly same-origin when the host API does not suffice —
+  the reference panel does that for the vessel position.)
+- **Filters are display-only and user-owned.** You push an id set or a property
+  `match`; the host must surface it as something the user can clear. Watch
+  `filters.changed` so an externally-cleared filter updates your UI.
+- **Guard optional capabilities** with `hasCapability` and carry on without
+  them.
+
+## Example: editing a route
+
+The `routes` capability lets an extension read and rewrite the routes the user
+is actively working with — the one or two on the chart, never the whole stored
+catalogue. An auto-router is the motivating case: the user draws a route, the
+extension reshapes it (below, just *reversing* it as a stand-in for a real
+routing engine), and the user saves when happy. The host owns the chart, the
+edit buffer and the Save dialog; the extension only supplies geometry.
+
+```js
+import { connectExtension } from 'signalk-plotterext-bus/extension'
+
+const client = await connectExtension()
+
+// `routes` is optional — degrade gracefully if the host doesn't offer it.
+if (!client.hasCapability('routes')) {
+  document.body.textContent = 'This host does not support route editing.'
+}
+
+// Lock onto a route. The visible set is small; take the most recent (or, with
+// several, let the user pick). A routeId is an opaque handle — never parse it.
+async function pickRoute() {
+  const { routes } = await client.call('route.list')
+  return routes[routes.length - 1]?.routeId ?? null
+}
+
+let routeId = await pickRoute()
+
+// Re-read whenever a route changes — by us, by the user's own editing, or by
+// another extension. `route.dirty` is the catch-all "it changed, re-fetch"
+// signal; `route.visible` means a route entered the set.
+await client.subscribe(['route.**'], async (name) => {
+  if (name === 'route.visible') routeId = await pickRoute()
+  if (name === 'route.dirty' && routeId) {
+    render(await client.call('route.get', { routeId }))
+  }
+})
+if (routeId) render(await client.call('route.get', { routeId }))
+
+// The panel's one button: reshape the route. Hand the host a whole new point
+// list with `route.replace`; it re-renders the chart and marks the route
+// `dirty` (unsaved). Nothing is written to the server.
+async function reshape() {
+  if (!routeId) return
+  const { points } = await client.call('route.get', { routeId })
+  const reworked = points.slice().reverse() // ← a real routing engine goes here
+  await client.call('route.replace', { routeId, points: reworked })
+}
+
+// Save on demand: the host persists it through the user's session and (with
+// `dialog: true`) prompts for a name. The route stays on the chart, now saved.
+async function save() {
+  if (routeId) await client.call('route.save', { routeId, dialog: true })
+}
+```
+
+Points that generalise:
+
+- **You edit the visible set, not the catalogue.** `route.list` is the one or
+  two routes on the chart. Pull a stored route in with `route.show({ ref })`
+  first; to browse the whole catalogue, read `/resources/routes` directly.
+- **Geometry is staged, never written through.** `route.replace` changes the
+  in-memory route and marks it `dirty` — the chart updates, the server does not.
+  Only `route.save` persists, and a server-rejected save reports
+  `routes.saveFailed` (distinct from the user cancelling the dialog,
+  `routes.saveCancelled`).
+- **Re-read on `route.dirty`.** It fires for every change whoever made it, so a
+  single "on dirty, `route.get`" keeps you in sync without tracking who edited.
+- **`routeId` is an opaque handle**, distinct from the saved resource's `href`
+  (which `route.save` returns) — the two are not interchangeable.
+
+## Background runtimes
+
+A `background` contribution is a hidden iframe with no UI that the host loads
+**while your plugin is enabled** (capability `background.iframe`), independent
+of any panel or widget being open. It speaks the same bus protocol; its
+`client.context.kind` is `'background'`.
+
+The canonical pattern: a panel does its real work in a runtime that holds the
+session state, so the panel can **close itself** (`ui.closePanel`) without
+losing it and reattach on reopen. To poke a runtime, give a button a
+`sendMessage` action publishing a topic the runtime subscribed to with
+`client.subscribe`; results flow back through the normal events
+(`state.changed`, `filters.changed`). A runtime drives the host, not the other
+way around, in this version.
+
+## Reference implementations
+
+Copy these — they are written to be read and adapted (an AI coding agent does
+well pointed at the spec plus one of these as a template):
+
+- [`signalk-instrument-widgets`](https://github.com/joelkoz/signalk-instrument-widgets)
+  — gauge, meter, switch and display-value widgets with a shared, unit-aware
+  configuration panel. The smallest end-to-end example.
+- [`signalk-poi-search`](https://github.com/joelkoz/signalk-poi-search) — a
+  toolbar button, a `keepAlive` search panel and a results widget exercising
+  resource queries, display filters and map control.
+- [`signalk-plotterext-bus`](https://github.com/joelkoz/signalk-plotterext-bus)
+  — the client/host library and the authoritative wire-format documentation.
+
+## Declaring companion plugins
+
+When your extension is more useful alongside another plugin (e.g. it searches
+resources another plugin provides), declare the relationship through the App
+Store recommendation mechanism rather than a hard dependency:
+
+```json
+{
+  "signalk": { "recommends": ["<plugin-name>"] }
+}
+```

--- a/docs/api/symbols-api.md
+++ b/docs/api/symbols-api.md
@@ -1,0 +1,398 @@
+# Working with the Symbols API
+
+Signal K applications often need a shared vocabulary of visual symbols. Each
+application may ship its own fixed icon set, and users who need domain-specific
+symbols must fork the client or request that icons be bundled upstream.
+
+The **Symbols API** defines a Signal K resource type — `symbols` — that any
+plugin can provide via the [Resource Provider API](https://github.com/SignalK/signalk-server/blob/master/docs/develop/rest-api/resources_api.md).
+Consumer applications such as chartplotters, logbooks, dashboards, route
+planners, note editors, and alert panels can discover and render the provided
+symbols without being tied to a specific plugin.
+
+`symbols` is a user-defined resource type hosted under the `resources` path, so
+the collection is accessible at:
+
+```text
+/signalk/v2/api/resources/symbols
+```
+
+---
+
+## Symbol Identity
+
+Each symbol has an immutable **`uuid`** that identifies it for its whole life,
+plus one or more **aliases** — the consumer-facing references other apps use to
+match it. An alias is a `<namespace>:<id>` pair:
+
+```text
+<namespace>:<id>
+```
+
+The `namespace` is a vendor/vocabulary label; the `id` is the local symbol id. A
+single symbol may carry several aliases so it can be matched by different
+chartplotters, for example:
+
+```text
+custom:dive-flag
+fsk:dive-site
+garmin:Diver Down Flag 1
+opencpn:scuba
+```
+
+Suggested namespace vocabulary:
+
+| namespace     | Meaning                                             |
+| ------------- | --------------------------------------------------- |
+| `custom`      | A user-defined symbol (the default for new symbols) |
+| `fsk`         | Freeboard-SK built-in icon ids                      |
+| `binnacle`    | Binnacle built-in icon ids                          |
+| `garmin`      | Garmin GPX `<sym>` names                            |
+| `opencpn`     | OpenCPN symbol names                                |
+| `s57`         | An S-57 marker                                      |
+| `<plugin-id>` | Symbols used directly by a specific plugin          |
+
+The namespace `default` is reserved for symbols built into the consuming
+application (e.g. `default:dive-site` means "use this app's built-in dive-site
+icon"). Providers must not use `default` as an alias namespace.
+
+`uuid` and `alias` are symbol payload metadata, separate from the Signal K
+`$source` response field (which identifies the provider plugin).
+
+**Alias rules:**
+
+- At least one alias is required per symbol.
+- `namespace` must match `[A-Za-z0-9_-]+` (no `:`) and must not be `default`.
+- `id` must not contain `:`.
+- Each `namespace:id` is globally unique within a provider — an alias maps to
+  exactly one symbol.
+
+---
+
+## Retrieving Symbols
+
+### List all symbols
+
+```typescript
+HTTP GET "/signalk/v2/api/resources/symbols"
+```
+
+Returns an object keyed by each symbol's immutable `uuid`:
+
+```JSON
+{
+  "b3f1c2a0-1e4d-4a6b-9c2f-0a1b2c3d4e5f": {
+    "uuid": "b3f1c2a0-1e4d-4a6b-9c2f-0a1b2c3d4e5f",
+    "alias": ["custom:dive-flag", "fsk:dive-site", "garmin:Diver Down Flag 1"],
+    "$source": "signalk-symbol-manager",
+    "timestamp": "2026-06-05T12:30:00.000Z",
+    "name": "Dive Site",
+    "description": "A custom dive site marker.",
+    "mediaType": "image/svg+xml",
+    "url": "/signalk/symbol-manager/symbols/b3f1c2a0-1e4d-4a6b-9c2f-0a1b2c3d4e5f.svg",
+    "roles": ["note", "waypoint", "map-marker"],
+    "tags": ["diving"],
+    "scale": 0.65,
+    "anchor": [1, 37],
+    "gpxType": "Waypoint",
+    "gpxSym": "Diver Down Flag 1"
+  },
+  "9a8b7c6d-5e4f-4012-8a9b-c0d1e2f30415": {
+    "uuid": "9a8b7c6d-5e4f-4012-8a9b-c0d1e2f30415",
+    "alias": ["custom:anchorage"],
+    "$source": "signalk-symbol-manager",
+    "timestamp": "2026-06-04T09:00:00.000Z",
+    "name": "Anchorage",
+    "mediaType": "image/svg+xml",
+    "url": "/signalk/symbol-manager/symbols/9a8b7c6d-5e4f-4012-8a9b-c0d1e2f30415.svg",
+    "roles": ["map-marker"],
+    "tags": [],
+    "scale": 0.65,
+    "anchor": [24, 48]
+  }
+}
+```
+
+### Retrieve a single symbol
+
+By `uuid`:
+
+```typescript
+HTTP GET "/signalk/v2/api/resources/symbols/b3f1c2a0-1e4d-4a6b-9c2f-0a1b2c3d4e5f"
+```
+
+By a qualified alias `namespace:id`:
+
+```typescript
+HTTP GET "/signalk/v2/api/resources/symbols/fsk:dive-site"
+```
+
+By unqualified local id (succeeds only when exactly one symbol carries an alias
+with that id — see _Symbol Resolution_ below):
+
+```typescript
+HTTP GET "/signalk/v2/api/resources/symbols/dive-site"
+```
+
+---
+
+## Symbol Resource Shape
+
+Each symbol entry in the collection contains:
+
+| Field         | Required | Description                                                              |
+| ------------- | -------- | ------------------------------------------------------------------------ |
+| `uuid`        | ✓        | Immutable symbol identifier                                              |
+| `alias`       | ✓        | Array of one or more canonical `namespace:id` references                |
+| `name`        | ✓        | Human-readable name                                                      |
+| `mediaType`   | ✓        | Asset media type — `image/svg+xml`                                       |
+| `url`         | ✓        | URL of the primary symbol asset                                          |
+| `$source`     | ✓        | Provider plugin id (Signal K resource response metadata)                 |
+| `timestamp`   | ✓        | ISO 8601 last-modified timestamp (resource response metadata)            |
+| `description` |          | Human-readable description                                               |
+| `roles`       |          | Intended usage categories (see _Roles_ below)                            |
+| `tags`        |          | Free-form search/filter keywords                                         |
+| `scale`       |          | Recommended OpenLayers icon scale for map-marker rendering               |
+| `anchor`      |          | Recommended anchor point `[x, y]` in pixels from the top-left of the SVG |
+| `gpxType`     |          | Mapping to a GPX waypoint `<type>` value (see _GPX mapping_ below)       |
+| `gpxSym`      |          | Mapping to a GPX waypoint `<sym>` value (see _GPX mapping_ below)        |
+
+The object key in the collection must equal the symbol's `uuid`.
+
+### Roles
+
+The `roles` array uses an advisory vocabulary. Known values:
+
+| Role                | Meaning                                     |
+| ------------------- | ------------------------------------------- |
+| `note`              | Used as a chart note / annotation marker    |
+| `waypoint`          | Used as a navigation waypoint               |
+| `map-marker`        | Displayed at a specific position on a chart |
+| `region`            | Associated with a geographic region         |
+| `button`            | Used as a UI button icon                    |
+| `alert`             | Used in alert or alarm contexts             |
+| `logbook`           | Used in logbook entries                     |
+| `vector-style-icon` | Used as an icon in a vector map style       |
+
+Consumers should ignore unknown role values. A symbol may have multiple roles.
+
+### `scale` and `anchor`
+
+For symbols intended as chart markers (`note`, `waypoint`, `map-marker` roles),
+providers should supply `scale` and `anchor`. When present, these follow the
+OpenLayers `Icon` style convention:
+
+```text
+displayed width  = SVG width  × scale
+displayed height = SVG height × scale
+anchor position  = [anchorX, anchorY] in source pixels from the SVG top-left
+```
+
+The `anchor` point is the pixel that consumer apps pin to the geographic
+location on the chart. Without these values a consumer can still render the
+symbol, but size and placement will be renderer-default rather than precise.
+
+### GPX mapping
+
+`gpxType` and `gpxSym` are optional free-form strings that relate a symbol to a
+GPX waypoint's `<type>` and `<sym>` elements. They let a symbol-aware consumer:
+
+- **On GPX import** — choose a symbol whose `gpxType` / `gpxSym` matches the
+  imported waypoint's `<type>` / `<sym>`, instead of falling back to a default
+  icon.
+- **On GPX export** — write the symbol's `gpxType` / `gpxSym` back into the
+  exported waypoint so the mapping round-trips.
+
+Matching semantics (case sensitivity, `type` vs. `sym` precedence) are left to
+the consumer. Providers should emit these fields only when they carry a value.
+
+### Deferred fields
+
+The following fields are intentionally omitted from this specification:
+
+- `variants` — alternate light/dark/selected/alert assets.
+- `assets` — renderer-specific assets such as PNG fallbacks or sprite entries.
+- `license` / `attribution` — for future shared symbol libraries.
+- `symbolSet` — grouping of related symbols.
+- `size` — nominal display size (consumers can infer this from the SVG `viewBox`).
+
+---
+
+## Symbol Resolution
+
+A symbol is matched through its aliases. A reference is one of: a `uuid`, a
+qualified alias (`namespace:id`), or an unqualified local id.
+
+### Qualified reference — `fsk:dive-site`
+
+Resolve to the symbol that carries that exact alias, in **any** namespace. If
+none, providers should return a 404 error. Consumers should display a fallback
+symbol. Do not silently substitute a different alias's symbol. A consumer renders
+a resolvable qualified reference even when its namespace is not one the consumer
+adopts (see _Rendering versus adoption_ below), because the symbol asset is
+shared across apps.
+
+### Unqualified reference — `dive-site`
+
+Resolve to the symbol carrying an alias with that `id`. If more than one symbol
+carries an alias with the same id, the reference is ambiguous; consumers should
+prefer a qualified alias to avoid this. Providers should throw a 400 error.
+
+### Explicit default reference — `default:dive-site`
+
+Resolve only within the consumer's built-in symbols, ignoring all external
+providers.  Providers should never store a symbol with the namespace `default`
+
+### Rendering versus adoption
+
+Rendering and adoption are separate concerns. A consumer **renders** any
+qualified `namespace:id` reference it can resolve, in any namespace, because the
+symbol asset is shared across apps: a note or waypoint another app stored as
+`binnacle:dive-site` or `garmin:anchor` still draws. A consumer never drops a
+stored symbol just because another vendor wrote it.
+
+A consumer **adopts** only the namespaces meaningful to it. Adoption governs
+overrides and what the consumer's pickers offer, not whether a reference renders:
+
+- **Its own vendor namespace** (e.g. `fsk` for Freeboard-SK) — a symbol whose
+  alias is `<vendor>:<built-in-id>` **replaces** that consumer's built-in icon
+  of the same id, so a bare reference to that id renders the override. For
+  example, Freeboard replaces its `marina` icon only when a symbol carries an
+  `fsk:marina` alias.
+- **`custom`** — a symbol with a `custom:<id>` alias is offered as an additional
+  user-defined symbol in the consumer's pickers.
+- **All other namespaces are not adopted**: they never override a built-in and
+  are never offered in a picker, but a stored reference to one still renders by
+  its exact alias.
+- **`default`** stays reserved for the consumer's own built-in, even when an
+  override exists.
+
+A single symbol may carry several of these aliases at once (e.g. both
+`custom:dive-flag` and `fsk:dive-site`), so it can be both a named user symbol
+and a built-in override.
+
+---
+
+## Referencing Symbols from Other Resources
+
+A symbol-aware consumer can interpret existing fields such as
+`properties.skIcon` as symbol references using the same `namespace:id` form.
+
+Preferred reference form (string):
+
+```text
+custom:dive-flag
+```
+
+When a user selects an external provider's symbol, consumers persist a qualified
+alias (`namespace:id`) so the reference stays stable.
+
+When a user selects one of the consumer app's own built-in icons from a picker,
+the consumer persists the **unqualified** id (not `default:id`), so a future
+external symbol can override it (by carrying the consumer's vendor alias for that
+id). The consumer persists `default:id` only when the user explicitly chooses
+the built-in despite an override existing.
+
+---
+
+## Provider Behavior
+
+A plugin registers as a symbol provider using the existing Resource Provider API:
+
+```js
+app.registerResourceProvider({
+  type: 'symbols',
+  methods: {
+    listResources, // return all symbols keyed by uuid
+    getResource, // return one symbol by uuid, alias, or unqualified id
+    setResource, // may reject for read-only providers
+    deleteResource // may reject for read-only providers
+  }
+})
+```
+
+All four methods must be implemented because the Resource Provider API requires
+them — a read-only provider may reject `setResource` and `deleteResource`.
+
+The provider should:
+
+- Return collection entries keyed by each symbol's `uuid`.
+- Accept a `uuid`, a qualified alias `namespace:id`, or an unqualified local id
+  for single-resource lookups.
+- For unqualified id lookups, succeed only when exactly one symbol carries an
+  alias with that id; reject ambiguous lookups.
+- Serve SVG assets at a URL accessible to read-only consumers. Note: the Signal
+  K server gates every `/plugins/*` route behind admin authentication regardless
+  of `allow_readonly`. A provider that wants its asset `url` to be loadable by
+  read-only consumers should serve assets from a path **outside** `/plugins`
+  (e.g. `/signalk/<plugin-name>/symbols/...`).
+- Sanitize and validate any user-supplied SVG before storage and serving.
+- Use stable ids so consumer references to symbols remain valid over time.
+
+---
+
+## Consumer Behavior
+
+A consumer application may:
+
+- Fetch `/signalk/v2/api/resources/symbols` during startup.
+- Build a local index of every alias by `namespace:id`, so any stored reference
+  renders regardless of namespace. Separately adopt only the namespaces
+  meaningful to it: its own vendor code (whose `<vendor>:<id>` aliases override
+  the built-in `<id>`, and so are also indexed by bare id) and `custom` (offered
+  as user symbols). Do not override a built-in or offer a picker entry from any
+  other namespace.
+- Register compatible SVG assets with its icon and/or map rendering system.
+- Use `scale` and `anchor` when rendering symbols as map markers.
+- Filter icon selectors by `roles` by default, with a "show all" option.
+- Resolve existing fields like `properties.skIcon` as symbol references.
+- Ignore symbols it cannot safely or usefully render.
+- Display a deterministic fallback symbol when a reference cannot be resolved.
+- Ignore unknown fields and unsupported future extensions.
+
+---
+
+## Security
+
+SVG can carry executable or risky content. Both providers and consumers should
+be defensive.
+
+**Providers** should:
+
+- Sanitize all SVG before storage — remove `<script>`, event-handler
+  attributes, `<foreignObject>`, and external references.
+- Enforce a file-size limit on uploaded assets.
+- Serve assets with `Content-Type: image/svg+xml`.
+
+**Consumers** should:
+
+- Validate the `mediaType` field before registering a symbol.
+- Avoid injecting unsanitized SVG directly into the DOM.
+- Prefer safe loading mechanisms (e.g. `<img src="...">`) where practical.
+- Fall back gracefully when an asset URL fails to load.
+
+---
+
+## Non-Goals
+
+- This does not define a Freeboard-specific extension system.
+- This does not require every Signal K application to use the same icon
+  renderer.
+- This does not require symbols to be bundled into the Signal K server core.
+- This does not define a full cartographic portrayal system.
+- This does not replace S-57/ENC symbol catalogs.
+- Mapbox/MapLibre sprite metadata, PNG sprite generation, and S-57/ENC native
+  portrayal are out of scope.
+
+---
+
+## Reference Implementation
+
+[`signalk-symbol-manager`](https://github.com/joelkoz/signalk-symbol-manager)
+is the reference implementation of this API. It provides:
+
+- A `symbols` resource provider serving user-managed SVG symbols.
+- A built-in Signal K web app for creating, editing, and managing symbols.
+- Starter templates (POI note marker, Flag, Waypoint, Blank canvas).
+- SVG sanitization, map-marker metadata (`scale` / `anchor`), and a
+  Freeboard-accurate preview.

--- a/docs/freeboard/freeboard-plotter-ext-support.md
+++ b/docs/freeboard/freeboard-plotter-ext-support.md
@@ -1,0 +1,118 @@
+# Freeboard-SK: Plotter Extension Host Support
+
+Freeboard-SK is the **reference host** for the Signal K *Plotter Extensions API* —
+the mechanism by which a Signal K server plugin contributes UI (panels, widgets,
+buttons) and behaviour into a chartplotter web app through sandboxed iframes that
+talk to the host over a small JSON-RPC message bus.
+
+This document is an implementation reference for the **host side** in
+Freeboard-SK. The host-agnostic contracts it implements live in:
+
+- [`../api/plotter-extensions-api.md`](../api/plotter-extensions-api.md) — the API
+  (capabilities, methods, events) any conforming host exposes.
+- [`../api/plotter_extension_provider_plugins.md`](../api/plotter_extension_provider_plugins.md)
+  — the "using the APIs" guide for plugin authors who *provide* extensions.
+
+The wire contract (the JSON-RPC-over-`postMessage` bus) is the
+[`signalk-plotterext-bus`](https://www.npmjs.com/package/signalk-plotterext-bus)
+package; Freeboard depends on it (`^0.7.1`) and imports its host entry point
+(`signalk-plotterext-bus/host`).
+
+## How the host works
+
+- **Discovery.** Extensions are advertised as `plotterExtensions` resources
+  (`/signalk/v2/api/resources/plotterExtensions`). `PlotterExtensionService`
+  reads the manifests, keeps the compatible ones, and drives the UI from them.
+- **One connection per context.** Each live extension iframe (panel, widget, or a
+  headless background runtime) gets its own `HostConnection` over a
+  `windowPort`. The host answers the extension's method calls and relays events
+  the extension has subscribed to.
+- **No host-side enable/disable.** Extension availability is controlled entirely
+  on the server (plugin install + enable). Presence in the `plotterExtensions`
+  collection is the enablement signal.
+- **Capability negotiation.** The host advertises `HOST_API_VERSION = '1'` and a
+  `HOST_CAPABILITIES` set; an extension declares what it `requires` and the host
+  only mounts it when compatible.
+
+### Capabilities Freeboard advertises (`HOST_CAPABILITIES`)
+
+`widgets`, `panels.iframe`, `buttons`, `signalk.stream`, `signalk.put`, `units`,
+`map`, `resources`, `resources.filter`, `routes`, `background.iframe`, `ui`.
+
+(The authoritative list is `HOST_CAPABILITIES` in
+`src/app/modules/plotterext/types.ts`.)
+
+## The `routes` capability
+
+`routes` lets an extension create and edit routes on the chart — e.g. an
+auto-router that reshapes a drawn route around land. Freeboard is both the
+reference host for the capability and a first-class user of the underlying model
+in its own native route UI.
+
+### The visible-route model
+
+Routes the user is working with live in an in-memory **visible set**, managed by
+`RouteBufferRegistry`. A route in the set is addressed by an opaque `routeId` and
+carries two flags:
+
+- **`saved`** — backed by a stored `routes` resource on the server.
+- **`dirty`** — has edits not yet persisted.
+
+So a route is one of: an unsaved **draft** (`saved:false`), a clean mirror of a
+stored route (`saved:true, dirty:false`), or a stored route with pending edits
+(`saved:true, dirty:true`).
+
+### Methods
+
+`route.list`, `route.create` (≥2 points), `route.show(ref)`, `route.get`,
+`route.replace(routeId, points)`, `route.save(routeId, {name?, description?,
+dialog?})`, `route.hide`, `route.delete`. Geometry is always edited **whole**
+(`route.replace`) — there is no per-point CRUD; routes are small and the host's
+native editing yields whole coordinate arrays, so whole-replace is the practical
+shape (see the API spec for the rationale).
+
+### Events (`route.**`)
+
+`route.visible`, `route.dirty`, `route.saved`, `route.hidden`. **`route.dirty` is
+the conformance floor**: every content change emits it, so a follower can stay in
+sync with a single "on `route.dirty`, re-`route.get`" loop without tracking who
+changed what. Events fire for *every* change regardless of origin — an extension
+command, the user's native editing, or another extension.
+
+### Error reasons
+
+Failures reject with a stable `error.data.reason`: `routes.unknownId`,
+`routes.badRequest`, `routes.badRef`, `routes.saveFailed` (server rejected a
+persist — distinct from the user-cancel `routes.saveCancelled`),
+`routes.deleteFailed`, `routes.notSupported`.
+
+### The Freeboard route UX built on this
+
+- Drawing a route creates an editable **amber draft** you review/adjust on the
+  chart before saving, instead of going straight to a save dialog.
+- **Tap-to-edit** a live route; the route popover and info panel offer **Save /
+  Edit / Delete** consistently (drafts get a quick Delete/discard; server-backed
+  actions like Start / Route Points / Show Notes are hidden for unsaved drafts).
+- Saving keeps the route on the map (it isn't consumed), and per-point
+  names/descriptions plus the route description round-trip through save.
+- Freeboard mirrors its own displayed/edited routes into the visible set, so
+  extensions observe native edits as `route.*` events too.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `src/app/modules/plotterext/plotterext.service.ts` | host service: discovery, per-iframe `HostConnection`, method dispatch, event bridging |
+| `src/app/modules/plotterext/route-buffer.registry.ts` | the `routeId → buffer` visible-set registry (`saved`/`dirty`/`rev`, events) |
+| `src/app/modules/plotterext/route-methods.ts` | the `route.*` method handlers + param validation |
+| `src/app/modules/plotterext/types.ts` | `HOST_API_VERSION`, `HOST_CAPABILITIES`, manifest types |
+| `src/app/modules/map/fb-map.component.ts` + `app.component.ts` | native route draw/modify/delete bridged into the registry |
+
+## See also
+
+- [`../api/plotter-extensions-api.md`](../api/plotter-extensions-api.md) — the
+  host-agnostic API contract.
+- [`../api/plotter_extension_provider_plugins.md`](../api/plotter_extension_provider_plugins.md)
+  — the guide for plugin authors providing extensions.
+- [`signalk-plotterext-bus`](https://www.npmjs.com/package/signalk-plotterext-bus)
+  — the wire-format/message-bus package (the protocol contract).

--- a/docs/freeboard/freeboard-symbol-support.md
+++ b/docs/freeboard/freeboard-symbol-support.md
@@ -1,0 +1,204 @@
+# Freeboard-SK: Custom Map Symbol Support
+
+How Freeboard-SK consumes **custom map symbols** published by a Signal K server
+and uses them in place of (or in addition to) its built-in icons.
+
+This document is both an end-user feature guide and an implementation reference
+for agents working on the symbol code. The host-agnostic resource contract it
+builds on is [`../api/symbols-api.md`](../api/symbols-api.md) — read that for the
+`symbols` resource type, schema, and provider API; this document covers only what
+Freeboard-SK does with it.
+
+Applies to Freeboard-SK `2.24.0-beta.1` and later (the symbol-consumer work).
+
+---
+
+## What it does
+
+Freeboard-SK can display custom artwork for notes, waypoints, vessels, aids to
+navigation, and route markers — a blue dive flag instead of the default marker, a
+custom boat icon for your own vessel, branded buoys — without rebuilding
+Freeboard. Custom symbols are discovered from the server at startup, offered in
+the note and waypoint icon pickers, and rendered on the chart. GPX import/export
+is symbol-aware so symbol choices survive a round trip.
+
+There is nothing to enable: Freeboard uses custom symbols automatically when they
+are available, and behaves exactly as before when they are not.
+
+## Requirement: a symbol provider plugin
+
+Custom symbols require a **symbol provider plugin** on the Signal K server.
+Freeboard consumes whatever symbols the server publishes at
+`/signalk/v2/api/resources/symbols`; it does not create or store them. With no
+provider installed, only the built-in icons are used.
+
+The reference provider is
+[`signalk-symbol-manager`](https://www.npmjs.com/package/signalk-symbol-manager),
+which lets you upload, edit, and organize symbols through its own web app. Any
+plugin that publishes symbols in the standard way works.
+
+## How overriding works
+
+Each symbol has a short **id** (e.g. `dive-site`) in a **namespace** (e.g.
+`user`), giving a canonical reference `<namespace>:<id>` (e.g. `user:dive-site`).
+There are two override mechanisms:
+
+1. **Per-feature `skIcon` (user-assigned).** Notes and waypoints store a
+   user-chosen icon in `feature.properties.skIcon`. The value may be a bare
+   built-in id (`dive-site`) or a qualified ref (`user:dive-site`). At render
+   time it resolves **external-first**, so creating a symbol whose id matches a
+   built-in transparently overrides it everywhere that built-in is used — no need
+   to re-edit existing notes/waypoints.
+2. **Well-known marker ids (global).** Some markers are chosen by the app from
+   data, not picked per feature (AIS type, route-vertex role, own vessel). These
+   are overridden by creating a symbol whose **id matches a reserved well-known
+   id** (below). The override is global — every marker of that kind uses it.
+
+In the pickers, a custom version of a built-in **replaces** the built-in entry
+(you see one entry, not two). A **"Show all symbols"** toggle reveals everything
+— every custom symbol plus the original built-ins — so you can still pick the
+original. If you explicitly pick a built-in this way, Freeboard persists the
+unqualified id and won't silently swap in a custom version later.
+
+**Roles.** A symbol's optional `roles` array (`note`, `waypoint`, …) controls
+only where it is *offered* in the pickers, keeping each picker tidy. Roles do
+**not** affect map rendering — a symbol overrides a marker whenever its id
+matches, regardless of roles. "Show all symbols" ignores the role filter.
+
+**Rotation.** Markers that rotate to a heading/bearing keep rotating when
+overridden: AIS vessels and AtoNs rotate to `orientation`, route waypoint markers
+to segment bearing, own vessel to `heading`. External symbols are built with
+`rotateWithView=false`; the rendering paths set `rotateWithView=true` so
+overrides behave like the built-ins.
+
+## Where custom symbols can be used
+
+| Area | Custom symbols? |
+|------|-----------------|
+| Note markers | Yes |
+| Waypoint markers (the **Waypoints** category) | Yes |
+| Own vessel | Yes |
+| AIS vessels | Yes |
+| Aids to Navigation (AtoNs) | Yes |
+| Route start / turn / end markers | Yes |
+| Specialized waypoint types (start pin, start boat, sightings, alarms, pseudo-AtoN) | No — keep built-in icons |
+| Region area shading | No |
+| Moored-vessel dots | No |
+
+## Overridable id reference
+
+To replace a built-in, create a custom symbol with the matching id.
+
+**Note / waypoint POI icons** (notes, and waypoint icons in the **Waypoints**
+category):
+
+```
+anchorage   boatramp   bridge      business    dam
+dive-site   ferry      hazard      inlet       lock
+marina      dock       turning-basin           radio-call-point
+transhipment-dock      notice-to-mariners      diver-down
+navigation-structure   fuel        tunnel      waterway-guage
+```
+
+**Generic waypoint marker:** `waypoint` (the default for the Waypoints category).
+
+**Own vessel:** `vessel-self` (rotates to heading; upright when position is fixed
+/ no heading).
+
+**AIS vessel icons** (by ship class/state; rotate to `orientation`):
+
+```
+ais_active   ais_highspeed   ais_special   ais_passenger   ais_cargo
+ais_tanker   ais_other       ais_inactive  ais_buddy       ais_self
+```
+
+(`ais_self` is the *focused* AIS target, **not** your own boat — that is
+`vessel-self`.)
+
+**Aids to Navigation** — each is a *real* (physical) and *virtual* (AIS-only)
+form, `real-…` / `virtual-…` (matching the built-in SVG basenames; rotate to
+`orientation`):
+
+```
+real-north  / virtual-north         real-east   / virtual-east
+real-south  / virtual-south         real-west   / virtual-west
+real-port   / virtual-port          real-starboard / virtual-starboard
+real-danger / virtual-danger        real-safe   / virtual-safe
+real-special / virtual-special      real-basestation / virtual-basestation
+real-weatherStation / virtual-weatherStation
+real-aton   / virtual-aton          (generic / fallback AtoN)
+```
+
+**Route markers:** `route-start`, `route-waypoint` (cloned per segment, rotated
+to bearing), `route-end`.
+
+The route, own-vessel, AIS, and AtoN markers are chosen automatically by
+Freeboard rather than picked per feature, so they override **globally**: create a
+symbol with the matching id and every marker of that kind uses it.
+
+## What is NOT overridable (and why)
+
+| Target | Reason |
+|--------|--------|
+| **Specialized waypoint types** (`start-pin`, `start-boat`, `whale`, `pob`, `pseudoaton`) | Only the `waypoint` type resolves overrides; these render their built-in icon, and their picker categories show built-ins only. |
+| **Region polygons** (e.g. a `hazard` area) | Rendered as an OL area fill/stroke `Style`, not a point icon. Belongs to the future `mapStyles` resource provider. |
+| **Moored AIS vessels** | Rendered as a small colored `Circle` dot (`AIS_MOORED_STYLE_IDS`), not an icon. |
+
+## GPX import / export
+
+A symbol may declare a **`gpxSym`** (GPX `<sym>`) and **`gpxType`** (GPX
+`<type>`) so symbol choices survive GPX round-trips.
+
+- **Import** (`gpxload-dialog` → `transformWaypoint`): for each imported waypoint
+  with a `<sym>`, match in order: (1) a symbol whose `gpxSym` equals the file's
+  `<sym>`, else (2) a symbol whose local **id** equals the `<sym>`. On a match,
+  the waypoint is stored as `type: "waypoint"` with `skIcon` set to the symbol's
+  canonical `namespace:id`. No match → default waypoint marker. Matching is exact
+  and case-sensitive, and uses only `<sym>` (not `<type>`).
+- **Export** (`sk2gpx` → `packageWaypoint`): a `type: "waypoint"` waypoint whose
+  `skIcon` resolves to an external symbol writes that symbol's `gpxType` → `<type>`
+  and `gpxSym` → `<sym>` (each only when present). Built-in icons, `default:` pins,
+  and non-`waypoint` types export as before.
+
+## Implementation notes (for agents)
+
+When `SymbolService` loads, each symbol is registered twice:
+
+1. With **Angular Material** under `namespace:id` (for selectors and `<mat-icon>`).
+2. With **`MapImageRegistry`** as a map-marker definition under **both**
+   `namespace:id` and the bare `id` (the bare id is an alias; the first namespace
+   registered for a given bare id wins). The registry uses the symbol's `scale`
+   and `anchor` when present; absent, placement/size are best-effort renderer
+   defaults.
+
+Consumption rules Freeboard follows (per the symbol resource contract):
+
+- Fetch `/signalk/v2/api/resources/symbols` at startup / resource init.
+- Resolve `feature.properties.skIcon` external-first; support `default:id` to
+  force a built-in. **Persist the unqualified id** when the user picks a built-in
+  from a picker (so a future provider can override that name); persist the
+  canonical `namespace:id` when the user picks an external symbol (so the choice
+  is stable even if another provider later defines the same local id); persist
+  `default:id` only when the user explicitly requests the default namespace.
+- Filter pickers by `roles` by default; offer a "Show all" control that ignores
+  the filter. Continue supporting all built-in icon names for backward compat.
+  Use a deterministic fallback icon when resolution fails; ignore symbols that
+  cannot be rendered.
+
+Key render/resolution paths: `getSymbol()` (note map marker), `getWaypoint()`
+(waypoint map marker — only the `waypoint` type resolves overrides),
+`resolveDisplayIcon()` (dialog/selector), and the shared `setRotation()` helper.
+
+## Behavior without a provider
+
+If no provider is installed (or it publishes no symbols): all pickers and the
+chart use the built-in icons unchanged; "Show all symbols" shows the built-ins;
+GPX import falls back to default markers; GPX export writes whatever the waypoint
+already carried.
+
+## See also
+
+- [`../api/symbols-api.md`](../api/symbols-api.md) — the host-agnostic `symbols`
+  resource type, schema, and provider API.
+- [`signalk-symbol-manager`](https://www.npmjs.com/package/signalk-symbol-manager)
+  — the reference symbol provider plugin.

--- a/docs/signalk/extension-model.md
+++ b/docs/signalk/extension-model.md
@@ -1,0 +1,68 @@
+# The Signal K Extension Model
+
+General background for anyone working on a Signal K server extension — a plugin, a
+webapp, or a package that is both. Freeboard-SK itself is a `signalk-webapp`, so
+this explains how the server discovers and serves it (and how the plugins it works
+alongside are loaded).
+
+> **Already know how Signal K loads plugins and webapps?** Skip this file. It's
+> here so contributors new to the Signal K ecosystem don't have to reverse-engineer
+> it.
+
+## "Plugin" vs "webapp" vs "extension"
+
+In casual use, **"plugin"** often means *any npm package the Signal K server
+recognizes and loads*, whatever it provides. This document uses **extension** as
+that umbrella term and reserves **plugin** for the server-side capability
+specifically. The capabilities are independent flags; one package may carry any
+combination.
+
+## Discovery
+
+The server scans every package in its `node_modules` (installed from npm, or
+symlinked for local dev) and reads the **Signal K keywords** in each
+`package.json`. The keywords are composable capability flags; what the server does
+with a package depends on which it finds:
+
+- **`signalk-node-server-plugin`** — server-side code with a `start`/`stop`
+  lifecycle and a config `schema`. The server `require()`s and starts it.
+- **`signalk-webapp`** — a standalone UI, served as static files, mounted at
+  `/<package-name>/` and shown in the admin Webapps launcher.
+- **`signalk-embeddable-webapp`** — a UI other apps can embed.
+- **`signalk-category-<name>`** — App Store category placement.
+
+A standalone webapp needs **no** server-side code — no `index.js`, no lifecycle.
+A package may be both a plugin and a webapp (Freeboard-SK ships a small helper
+plugin alongside its webapp, for example).
+
+## Webapp serving and the asset base-path rule
+
+For a package with a webapp keyword, the server serves `<package>/public/` when
+that directory exists, otherwise the package root, mounted at `/<package-name>/`.
+A build that emits to `public/` is served as-is.
+
+Because the webapp is served under `/<package-name>/` (not `/`), its **production
+build must set that base path** or its asset URLs 404 — the page loads but its
+CSS/JS do not. The setting depends on the bundler:
+
+- **Angular** (Freeboard-SK): the build sets the base href to the mount point.
+- **Vite:** `base: command === 'build' ? '/<package-name>/' : '/'` (keep `/` for
+  the standalone dev server).
+
+Other bundlers have an equivalent public-path setting.
+
+## Service worker / PWA
+
+If the app ships a service worker and is served over a secure context (HTTPS or
+`http://localhost`), a rebuild changes the cached assets, so a hard refresh may be
+needed to pick them up. Over plain `http` on a LAN address the service worker is
+inactive.
+
+## Why this matters across environments
+
+The discovery/serving model is **the same on every Signal K server**. Only *where*
+the server and its `node_modules` live differs — a source checkout for local dev
+versus an installed server on a device. Getting a dev build of an extension in
+front of a running server is covered in
+[`local-dev-environment.md`](local-dev-environment.md); packaging it for npm and
+the App Store is in [`plugin-publishing.md`](plugin-publishing.md).

--- a/docs/signalk/local-dev-environment.md
+++ b/docs/signalk/local-dev-environment.md
@@ -1,0 +1,98 @@
+# A Local Signal K Development Environment
+
+How to run a Signal K server locally and get a development build of an extension
+(plugin or webapp) in front of it. This is general Signal K knowledge, useful when
+testing Freeboard-SK or any extension against a real server.
+
+> **Already run a local Signal K server and link dev modules into it?** Skip this
+> file.
+
+Read [`extension-model.md`](extension-model.md) first — it explains how the server
+discovers packages and serves webapps; this file is just the mechanics of wiring a
+dev checkout into a running server.
+
+## Run a Signal K server locally
+
+The canonical instructions live in the
+[signalk-server `CONTRIBUTING.md`](https://github.com/SignalK/signalk-server/blob/master/CONTRIBUTING.md).
+In short, from a `signalk-server` checkout:
+
+```sh
+npm install
+npm run build:all
+npm start          # server at http://localhost:3000
+```
+
+### Sample data (no hardware needed)
+
+Start the server replaying recorded marine data so the data stream, vessel
+position, AIS, etc. are populated:
+
+```sh
+bin/n2k-from-file     # NMEA 2000 sample data
+bin/nmea-from-file    # NMEA 0183 sample data
+```
+
+The data is then available via the REST API at
+`http://localhost:3000/signalk/v1/api/` and the WebSocket stream.
+
+## Link a dev extension into the server
+
+The server loads extensions from its `node_modules` (see
+[`extension-model.md`](extension-model.md)). For local development you symlink your
+dev checkout in, so the server loads your working copy.
+
+### A server plugin — `npm link`
+
+```sh
+# in your plugin's directory
+npm link
+
+# in the server's directory
+npm link <your-plugin-package-name>
+```
+
+Run the server with debug output scoped to your plugin:
+
+```sh
+DEBUG=<your-plugin-package-name> npm start
+```
+
+### A webapp (or any extension package) — direct symlink
+
+A webapp needs no lifecycle code; the server serves its built `public/` at
+`/<package-name>/`. Link the checkout and build it:
+
+```sh
+# from the server's node_modules, point the package name at your checkout
+ln -s ../../path/to/<your-webapp> <your-webapp-package-name>
+
+# build so the server can serve it (output must land in public/, with the
+# asset base path set to the mount point — see extension-model.md)
+cd path/to/<your-webapp> && npm run build
+```
+
+(`npm link <your-webapp-package-name>` from the server directory works too; it
+routes through the global npm registry instead of a direct filesystem link.)
+
+## Iterating
+
+- **App source change:** rebuild (`npm run build`) and refresh the browser — the
+  symlink picks up the new `public/` automatically; no re-link and no server
+  restart for asset changes.
+- **New linked module, or a change to `package.json` keywords / a plugin
+  manifest:** restart the server so it re-scans `node_modules`.
+- **A standalone bundler dev server** (e.g. `ng serve` / `vite` with hot reload)
+  is great for rapid UI work in isolation, but that instance is **cross-origin**
+  and is *not* the in-server webapp — server auth, the data stream, and
+  same-origin APIs behave differently than when launched from the Webapps
+  launcher. Use it for fast iteration; verify the real behaviour through the
+  in-server build.
+
+## Common gotcha: plugins start disabled
+
+A newly installed/linked **plugin defaults to disabled**. The first time you run a
+dev plugin and "nothing happens," confirm it's enabled in the server admin UI
+(*Server → Plugin Config*). This is the single most common false alarm in plugin
+dev. (Webapps don't have an enable step — they appear in the Webapps launcher once
+discovered.)

--- a/docs/signalk/plugin-publishing.md
+++ b/docs/signalk/plugin-publishing.md
@@ -1,0 +1,156 @@
+# Publishing a Signal K Plugin / Webapp
+
+Reference for packaging a Signal K extension for npm and the App Store. General
+Signal K knowledge — Freeboard-SK itself is published by its maintainers, but the
+same rules apply to any plugin or webapp you build alongside it.
+
+> **Already published Signal K packages?** Skip this file.
+
+Authoritative upstream:
+[Signal K App Store publishing docs](https://demo.signalk.org/documentation/Developing/Plugins/Publishing_to_The_AppStore.html).
+See [`extension-model.md`](extension-model.md) for how the server discovers and
+serves what you publish.
+
+## `package.json` essentials
+
+```jsonc
+{
+  "name": "@scope/my-plugin",
+  "version": "1.0.0",
+  "description": "Short description shown in App Store search",
+  "keywords": [
+    "signalk-node-server-plugin",   // and/or signalk-webapp, signalk-embeddable-webapp
+    "signalk-category-utility"
+  ],
+  "files": ["dist", "public", "docs/screenshots", "CHANGELOG.md"],
+  "signalk": {
+    "displayName": "My Plugin",
+    "appIcon": "src/assets/icons/icon-192x192.png",
+    "screenshots": ["./docs/screenshots/1_main.jpg"],
+    "appstore": { "categories": ["utility"], "author": "…", "description": "…" }
+  }
+}
+```
+
+- **`keywords`** are the capability flags the server reads on discovery (see
+  [`extension-model.md`](extension-model.md)). A package may carry any combination.
+- **`files`** is the tarball whitelist — prefer an explicit list over relying on
+  `.npmignore`. `README.md`, `package.json`, and `LICENSE` are always included.
+- **Asset base path for webapps:** the production build must set the base to
+  `/<package-name>/` or assets 404 — see [`extension-model.md`](extension-model.md).
+
+### The `appIcon` two-checks trap
+
+The declared `appIcon` path must satisfy **two independent** `plugin-ci` checks,
+and this is what bites people:
+
+1. **Source-path check** — the file must exist in a *fresh git checkout*. A
+   build-output path like `public/assets/icon.png` **fails** whenever `public/` is
+   gitignored (the clone has no `public/` until something builds it).
+2. **Tarball check** — the path must appear in `npm pack --dry-run`, i.e. be
+   covered by `files`.
+
+So point `appIcon` at a **committed source asset** and whitelist that exact file
+in `files`. Both are warnings (not build failures), but clean them up. Verify:
+`npm pack --dry-run | grep icon` **and** `git ls-files <path>`.
+
+## CI and release workflows
+
+**`ci.yml`** — call the shared Signal K reusable workflow (this runs the matrix
+that the App Store registry credits):
+
+```yaml
+jobs:
+  test:
+    uses: SignalK/signalk-server/.github/workflows/plugin-ci.yml@master
+    with:
+      build-command: 'npm run build:all'   # override if your build differs
+      test-command: 'npm run test:ci'
+```
+
+**`release_on_tag.yml`** — on a `v*` tag, create a GitHub Release with
+`generate_release_notes: true` and `npm publish --provenance --access public`.
+Embed `alpha`/`beta`/`rc` in the tag (e.g. `v2.0.0-beta.1`) to mark a pre-release
+and publish to the matching npm dist-tag. `NPM_TOKEN` must be an Actions secret;
+for repos in the `SignalK` org, the org admin manages it.
+
+## What appears in the App Store "Changelog" tab
+
+The Changelog tab does **not** primarily read your `CHANGELOG.md`. The server
+builds it in priority order:
+
+1. **GitHub Releases** (preferred) — the repo's release notes, rendered to Markdown.
+2. **`CHANGELOG.md` from the npm tarball** — fallback for packages not on GitHub.
+3. A synthesized placeholder otherwise.
+
+Because the release workflow uses `generate_release_notes: true`, the GitHub
+Release notes are GitHub's auto-generated **list of merged PR titles since the
+previous tag**. So the chain is:
+
+> **PR title → GitHub auto-generated Release notes (on `v*` tag) → App Store Changelog tab.**
+
+Consequences:
+
+- **A PR title is literally a line in the App Store changelog.** Write crisp,
+  user-facing titles and keep the `type(scope): subject` convention — the
+  Changelog tab colour-codes by prefix (`feat` / `fix` / breaking).
+- **One logical change per PR** — each PR is one changelog entry; a mega-PR
+  collapses a release into one vague line.
+- **Still ship `CHANGELOG.md`** — but only because it's a registry *scoring* input
+  (below), not what the Changelog tab displays for a GitHub-hosted package.
+
+## Registry scoring (0–100)
+
+The App Store scores plugins via `signalk-plugin-registry` (installs from the npm
+tarball; tests from a fresh git clone):
+
+| Check | Points |
+|---|---|
+| npm install succeeds | 20 |
+| Plugin loads (no crash on require) | 15 |
+| Plugin activates (`start()` runs) | 15 |
+| Exposes a JSON schema | 5 |
+| Tests pass (source clone → `npm test`) | 25 |
+| No high-severity npm audit findings | 20 |
+| Penalty: no CHANGELOG in tarball | −5 |
+| Penalty: no screenshots | −5 |
+| Penalty: no Signal K plugin-CI workflow | −10 |
+
+Best-score-wins — a transient failure can't lower a previously passing score.
+
+### Recurring gotchas
+
+1. **Undeclared runtime dependency (−35).** A module `require()`d at load/activate
+   that's only in `devDependencies` works locally but fails in the registry
+   sandbox (`Cannot find module`). Move it to `dependencies`.
+2. **`file:` devDependency breaks source tests (−25+).** The registry clones
+   fresh — a `file:../sibling` path won't resolve. Publish the sibling and
+   reference it by semver.
+3. **CHANGELOG must be in `files`** — the registry checks the tarball, not the git
+   repo.
+4. **plugin-CI −10, order matters.** The penalty clears only when a CI run
+   referencing the shared workflow exists on the **exact commit SHA** published to
+   npm: commit+push `ci.yml` → bump version → publish.
+5. **Native addons fail under noexec `/tmp`.** Any native `.node` addon loaded at
+   startup fails with `ERR_DLOPEN_FAILED` in the sandbox. Lazy-load it inside the
+   handler that needs it (`sharp`, `better-sqlite3`, etc.).
+6. **Screenshots:** JPEG, ≤1280×800 px, ≤500 KB; list in `signalk.screenshots[]`
+   **and** `files`; reference them in `README.md` via absolute GitHub raw URLs so
+   they render on npmjs.com.
+
+## Serving browser UI / iframe assets
+
+- **Never** serve UI under `/plugins/<id>/*` via `registerWithRouter` — the server
+  gates all of `/plugins` behind admin auth, breaking read-only users.
+- `signalk-webapp` / `signalk-embeddable-webapp` auto-mounts `public/` at
+  `/<package-name>/` and lists it in the Webapps launcher — use only for
+  standalone-launchable apps.
+- For assets that must be public but **not** in the launcher (e.g. an
+  iframe-embedded extension UI), self-mount a static route in `start(app)`,
+  namespaced by package name:
+
+```js
+app.use('/my-plugin-assets', require('express').static(path.join(__dirname, '../public')))
+```
+
+`express` is provided by the server — no extra dependency needed.


### PR DESCRIPTION
Seeds a documentation set for both human contributors and AI coding agents. Documentation only — no code changes.

- **`AGENTS.md`** (+ `CLAUDE.md`) — the entry point: repo layout, build/test/run (incl. why `build:web`/`test:ci` exist), code-quality, contribution standards, project-specific gotchas, and DeepWiki warm-up.
- **`CONTRIBUTING.md`** + **`.github/pull_request_template.md`** — the human on-ramp and a PR scaffold (what problem / how it works / how tested).
- **`docs/api/`** — host-agnostic API specs (Plotter Extensions, Symbols).
- **`docs/freeboard/`** — Freeboard implementation notes (the plotter-extension host incl. the `routes` capability; custom map symbols).
- **`docs/signalk/`** — general Signal K onboarding (extension model, local dev, plugin publishing), kept standalone so experienced contributors can skip them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a standardized pull request template to help keep changes focused and well-described.
  * Added contributor and AI-assistant guidance, including development, build, test, and review expectations.
  * Expanded documentation for Signal K extensions, symbols, local development, and plugin publishing.
  * Added Freeboard-SK guidance for plotter extension support and custom map symbol behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->