### PR TITLE
fix(ais): orient AIS vessel icons to heading instead of COG

### DIFF
--- a/src/app/modules/skstream/skstream.facade.spec.ts
+++ b/src/app/modules/skstream/skstream.facade.spec.ts
@@ -1,0 +1,37 @@
+import { expect, describe, it } from 'vitest';
+import { SKStreamFacade } from './skstream.facade';
+import { SKVessel } from '../skresources/resource-classes';
+
+// AIS icons rotate by `orientation`. A crabbing target's heading and COG differ,
+// so the icon must follow heading, with COG only as a fallback when no heading
+// is reported. Guards the precedence in parseVesselOther against a silent
+// reorder (#415).
+describe('SKStreamFacade.parseVesselOther — AIS target orientation', () => {
+  // Exercise the real (private) method without the heavy DI constructor.
+  const orientationOf = (v: SKVessel): number => {
+    const facade = Object.create(SKStreamFacade.prototype) as unknown as {
+      app: unknown;
+      parseVesselOther: (targets: Map<string, SKVessel>) => void;
+    };
+    facade.app = { useMagnetic: false, data: { vessels: {} } };
+    facade.parseVesselOther(new Map([['ais', v]]));
+    return v.orientation;
+  };
+
+  const vessel = (props: Partial<SKVessel>): SKVessel =>
+    Object.assign(new SKVessel(), props);
+
+  it('prefers true heading when both heading and COG are present', () => {
+    expect(
+      orientationOf(vessel({ headingTrue: Math.PI / 4, cogTrue: 1.658 }))
+    ).toBe(Math.PI / 4);
+  });
+
+  it('falls back to COG when no heading is reported', () => {
+    expect(
+      orientationOf(
+        vessel({ headingTrue: null, headingMagnetic: null, cogTrue: 1.658 })
+      )
+    ).toBe(1.658);
+  });
+});

--- a/src/app/modules/skstream/skstream.facade.ts
+++ b/src/app/modules/skstream/skstream.facade.ts
@@ -400,10 +400,10 @@ export class SKStreamFacade {
         : value.wind.twd;
 
       value.orientation =
-        value.cogTrue ??
         value.headingTrue ??
-        value.cogMagnetic ??
         value.headingMagnetic ??
+        value.cogTrue ??
+        value.cogMagnetic ??
         0;
     });
   }


### PR DESCRIPTION
## What problem does this solve?

AIS boats can be drawn pointing the wrong way. If a target is crabbing, where its heading and its course over ground aren't lined up (think of a ferry getting pushed sideways by current), the icon follows COG instead of heading. So the bow ends up pointing along the track rather than where the boat is actually facing. The IEC 62288 display standard orients the icon by heading for exactly this reason.

Closes #415 

## How does it work?

`parseVesselOther()` was picking COG over heading when it set the icon's `orientation`. I just flipped that to prefer heading, and only fall back to COG when there's no heading at all. Targets that never send heading (plenty of Class B units) look exactly the same as before. The COG vector is still drawn as the dashed line, so now you can see the crab as the angle between the hull and that line.

One note... `parseVesselOther` hardcodes this order and ignores the `preferredPaths.heading` setting, which oddly defaults to COG too. I left it as a plain fix, but if you'd rather have orientation follow that setting, I'm happy to redo it that way.

## How was this tested?

Spun up a local Signal K server, fed it a crabbing target at heading 45° / COG 95°, and pointed Freeboard at it. Before the fix the boat and its popover heading sat at 95°; after, both snap to 45°, while the COG vector keeps pointing east.

### Before
<img width="620" height="693" alt="before" src="https://github.com/user-attachments/assets/8e684aa2-607d-42bf-8315-f394589b75f4" />

### After
<img width="509" height="608" alt="after" src="https://github.com/user-attachments/assets/55807063-9fea-474f-91ff-2056435b0614" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vessel orientation selection by adjusting fallback precedence, prioritizing heading data (true, then magnetic) before course-over-ground values when other heading fields are missing.
* **Tests**
  * Added coverage for AIS target orientation precedence to ensure correct behavior across combinations of reported heading and course-over-ground data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->