### PR TITLE
fix(plotterext): free a widget's anchor cell when its extension is removed

### DIFF
--- a/src/app/modules/plotterext/plotterext.occupancy.spec.ts
+++ b/src/app/modules/plotterext/plotterext.occupancy.spec.ts
@@ -1,0 +1,102 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MatDialog } from '@angular/material/dialog';
+import { SignalKClient } from 'signalk-client-angular';
+
+import { PlotterExtensionService } from './plotterext.service';
+import { RouteBufferRegistry } from './route-buffer.registry';
+import { AppFacade } from '../../app.facade';
+import { SKResourceService } from '../skresources/resources.service';
+import { MapService } from '../map/ol/lib/map.service';
+import {
+  HOST_API_VERSION,
+  PlacedWidget,
+  PlotterExtensionManifest
+} from './types';
+
+// Regression coverage for #433: a placement whose providing extension is gone
+// (disabled / uninstalled / renamed) must not keep its anchor cell occupied.
+// The cell renders empty (filtered out of activeWidgets), so it must also be
+// long-pressable again — i.e. cellOccupied() must report it free.
+describe('PlotterExtensionService occupancy (#433)', () => {
+  const liveExt = 'live-ext';
+  const orphanExt = 'gone-ext';
+
+  const manifest: PlotterExtensionManifest = {
+    name: liveExt,
+    apiVersion: HOST_API_VERSION,
+    widgets: [
+      {
+        id: 'gauge',
+        title: 'Gauge',
+        type: 'iframe',
+        url: 'w.html',
+        size: '1x1'
+      }
+    ]
+  };
+
+  const livePlacement: PlacedWidget = {
+    instanceId: 'i-live',
+    extension: liveExt,
+    widget: 'gauge',
+    anchor: 'tr',
+    col: 3,
+    row: 0
+  };
+  // Same shape, but its extension has no (longer a) manifest.
+  const orphanPlacement: PlacedWidget = {
+    instanceId: 'i-orphan',
+    extension: orphanExt,
+    widget: 'gauge',
+    anchor: 'tr',
+    col: 0,
+    row: 0
+  };
+
+  let service: PlotterExtensionService;
+  let widgets: PlacedWidget[];
+
+  beforeEach(() => {
+    widgets = [livePlacement, orphanPlacement];
+    const appStub = {
+      config: { plotterExtensions: { widgets } },
+      debug: () => {}
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        PlotterExtensionService,
+        RouteBufferRegistry,
+        { provide: AppFacade, useValue: appStub },
+        { provide: SignalKClient, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: SKResourceService, useValue: { routes: signal([]) } },
+        { provide: MapService, useValue: {} }
+      ]
+    });
+    service = TestBed.inject(PlotterExtensionService);
+
+    // Only the live extension's manifest is present; the orphan's is gone.
+    service.manifests.set({ [liveExt]: manifest });
+    // Exercise the real filter that drives the overlay.
+    (
+      service as unknown as { refreshActiveWidgets(): void }
+    ).refreshActiveWidgets();
+  });
+
+  it('drops the orphaned placement from the rendered set', () => {
+    expect(service.activeWidgets().map((p) => p.instanceId)).toEqual([
+      'i-live'
+    ]);
+  });
+
+  it('reports the orphaned placement’s cell as free so it stays long-pressable', () => {
+    expect(service.cellOccupied('tr', { col: 0, row: 0 })).toBe(false);
+  });
+
+  it('still reports the live placement’s cell as occupied', () => {
+    expect(service.cellOccupied('tr', { col: 3, row: 0 })).toBe(true);
+  });
+});

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -1013,13 +1013,19 @@ export class PlotterExtensionService {
     return this.app.config.plotterExtensions.widgets;
   }
 
-  /** Occupancy map of an anchor area (sized per ANCHOR_GRID): occupied[row][col]. */
+  /**
+   * Occupancy map of an anchor area (sized per ANCHOR_GRID): occupied[row][col].
+   * Driven by `activeWidgets()` (not the raw `placements()`) so it agrees with
+   * what the overlay renders: an orphaned placement — one whose extension is
+   * disabled, uninstalled, or renamed — is not drawn and must not block its
+   * cell, otherwise the empty-looking cell stays un-longpressable (#433).
+   */
   private occupancy(anchor: AnchorId): boolean[][] {
     const { cols, rows } = ANCHOR_GRID[anchor];
     const occupied = Array.from({ length: rows }, () =>
       Array.from({ length: cols }, () => false)
     );
-    for (const placed of this.placements()) {
+    for (const placed of this.activeWidgets()) {
       if (placed.anchor !== anchor) continue;
       const def = this.widgetDef(placed.extension, placed.widget);
       const size = parseSize(def?.size ?? '1x1');


### PR DESCRIPTION
## Why

When a plotter-extension widget is placed and the providing plugin later becomes
unavailable (disabled, uninstalled, or renamed), its anchor cell became
**dead**: the cell rendered empty, but press-and-hold no longer offered the
"Add widget" picker, so nothing could be placed there.

Rendering and occupancy disagreed about a stale placement. The overlay renders
the **filtered** `activeWidgets()` (placements whose extension is present,
compatible, and still declares the widget), so an orphaned placement is not
drawn. But `occupancy()` iterated the **raw** `placements()`, and the
`def?.size ?? '1x1'` fallback still marked the cell occupied — so
`cellOccupied()` returned `true` and the press-and-hold handler bailed before
opening the picker.

## How

Base `occupancy()` on `activeWidgets()` instead of the raw `placements()`, so
occupancy agrees with what the overlay renders. An orphaned placement no longer
blocks its cell, and the empty-looking area is long-pressable again. The
persisted placement is retained, so the widget reappears in place if the plugin
is re-enabled.

Adds a co-located regression spec (`plotterext.occupancy.spec.ts`) that fails
before the change and passes after.

Closes #433


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where inactive or missing widgets could still block occupied cells, improving add-widget and long-press behavior.
  * Occupancy now reflects only currently active widgets, preventing stale placements from affecting the UI.

* **Tests**
  * Added regression coverage to verify active widgets are counted correctly and orphaned placements do not mark cells as occupied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->