### PR TITLE
docs(lessons): add phase-organized dev lessons-learned log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,31 +102,35 @@ continue that. The bar below is what "done correctly" means here.
   When updating with upstream: `git fetch && git rebase origin/master`, force-push.
 - **CodeRabbit** reviews PRs automatically — address its comments, then it's ready
   for maintainer review.
+- **Share what you learned — keep the lessons log alive.** If working on your PR
+  surfaced something non-obvious about developing FSK locally (a toolchain trap, a
+  test-setup gotcha, a platform or hardware quirk), add it to
+  [`docs/freeboard/DEV-LESSONS-LEARNED.md`](docs/freeboard/DEV-LESSONS-LEARNED.md)
+  so the next contributor doesn't rediscover it. The bar is *non-obvious and
+  reusable*, **not** *universal*: lessons that apply to a whole class of setups are
+  welcome — just scope them with the condition that makes them relevant ("If you're
+  developing on Windows, …", "If your charts live on a Raspberry Pi microSD, …").
+  Skip anything truly unique to your one machine. Add it in its own small
+  `docs(lessons): …` PR. When an existing entry has gone **wrong or stale** — the
+  tooling or code moved, or it's genuinely unclear — fix or prune it the same way:
+  verify it actually misleads first (it bit you, or you checked it against current
+  code/tooling), then correct it (or remove it if obsolete) with a one-line note on
+  what changed. Don't reword on suspicion or for style — the bar for editing is the
+  same as for adding.
 
-## Hard-won knowledge (read this — it saves time and tokens)
+## Hard-won knowledge → read the lessons log
 
-Non-obvious facts about this project that took real effort to discover:
+The non-obvious, time-wasting traps that took real effort to discover live in
+[`docs/freeboard/DEV-LESSONS-LEARNED.md`](docs/freeboard/DEV-LESSONS-LEARNED.md),
+grouped by the **phase of work** they bite in. **Read it — skipping it wastes real
+time and tokens.** As you enter each phase, (re-)read the matching section:
 
-- **`ng build` / `ng test` don't exit** (esbuild keeps the loop alive) → use
-  `npm run build:web` / `npm run test:ci`, never the raw Angular commands, for
-  anything that must terminate. (This is why those wrappers exist.)
-- **A PR title is literally a line in the App Store Changelog.** The chain is: *PR
-  title → GitHub auto-generated release notes (on a `v*` tag) → App Store Changelog
-  tab*, colour-coded by `feat`/`fix`/breaking prefix. This is the real reason the
-  title convention and one-change-per-PR rules matter so much. (Details:
-  [`docs/signalk/plugin-publishing.md`](docs/signalk/plugin-publishing.md).)
-- **CodeRabbit reviews the PR *branch*, not the merged result.** It diffs against
-  the merge-base and reads context from the head branch — so if `master` moved
-  after you branched, CR (and CI) reason about a stale tree. **Rebase onto current
-  `master` before relying on a re-review**, or it may flag issues already fixed
-  elsewhere.
-- **Angular signals in `effect()`:** reading *and* writing the same signal inside an
-  effect creates a feedback loop. Read the current value non-reactively (e.g. a
-  plain getter / snapshot method) when an effect also mutates that state.
-- **Build outputs are gitignored** (`public/`, `plugin/`); the server serves
-  `public/` at the package mount point. See
-  [`docs/signalk/extension-model.md`](docs/signalk/extension-model.md) for the
-  base-path rule.
+- *reading / exploring the code* · *coding* · *testing* · *building & running
+  locally* · *submitting a PR* — plus *environment-specific* lessons scoped by
+  condition (Windows, Raspberry Pi microSD, …).
+
+Hit a new trap? Add it back — see *Share what you learned* under
+*Contributing — PR standards* above.
 
 ## DeepWiki (warm up your context)
 
@@ -148,6 +152,10 @@ the code. Use the DeepWiki MCP (or the web URLs) before guessing at architecture
   `routes` capability).
 - [`freeboard-symbol-support.md`](docs/freeboard/freeboard-symbol-support.md) — how
   Freeboard consumes custom map symbols.
+- [`DEV-LESSONS-LEARNED.md`](docs/freeboard/DEV-LESSONS-LEARNED.md) — the lessons
+  log: non-obvious, repo-specific traps grouped by work phase (reading, coding,
+  testing, building, PR). The *Hard-won knowledge* section above points here; read
+  the section matching your current phase.
 
 **Host-agnostic API specs** (`docs/api/`):
 - [`plotter-extensions-api.md`](docs/api/plotter-extensions-api.md) — the Plotter

--- a/docs/freeboard/DEV-LESSONS-LEARNED.md
+++ b/docs/freeboard/DEV-LESSONS-LEARNED.md
@@ -1,0 +1,162 @@
+# Dev lessons learned
+
+Non-obvious, repo-specific traps that cost real time (and, for AI agents, real
+tokens) to discover the hard way — captured so the next person pays the cost once,
+here. This is the durable companion to [`AGENTS.md`](../../AGENTS.md): that file
+points you here at each phase of work; this file holds the detail.
+
+Entries are grouped by the **phase of work** they bite in. When you enter a phase,
+read its section. Each entry is a short `### heading`, then **the trap** and **what
+to do instead**.
+
+To add an entry, see *Share what you learned* in the
+[Contributing standards](../../AGENTS.md) — the bar and scoping rules live there, so
+they stay in one place.
+
+---
+
+## When reading / exploring the code
+
+_No entries yet — add one when something here bites you._
+
+---
+
+## When coding
+
+### Reading and writing the same signal inside `effect()` loops
+
+**The trap.** An `effect()` that both reads a signal and writes it creates a
+feedback loop — the write re-triggers the effect, which writes again.
+
+**What to do instead.** Read the current value **non-reactively** (a plain getter
+or snapshot method) when the same effect also mutates that state, so the read
+doesn't register a reactive dependency.
+
+---
+
+## When testing
+
+### `ng test` / `ng build` don't exit
+
+**The trap.** The esbuild-based `ng test` and `ng build` complete successfully but
+then fail to terminate — a lingering esbuild service keeps the event loop alive. In
+CI that hangs the job to its timeout even though everything passed.
+
+**What to do instead.** Use the exit-safe wrappers — `npm run test:ci` and
+`npm run build:web` — never the raw Angular commands, for anything that must
+terminate (CI, scripts, an agent verifying a change). Plain `npm test` stays as the
+local watch command. (This is why those wrappers exist; see *Build, test, run* in
+`AGENTS.md`.)
+
+### Running a single spec file: you can't (with bare vitest)
+
+**The trap.** To iterate quickly on one test, the obvious move is
+`npx vitest run src/app/.../foo.spec.ts`. It fails with
+`Cannot find package 'src/app/...'`, because the `src/` path alias is **not**
+resolved by a standalone vitest run — `vitest-base.config.ts` defines no
+`resolve.alias` and no tsconfig-paths plugin. Rewriting the spec to use relative
+imports doesn't rescue you either: the moment the spec imports anything from the
+app graph, that code's own **transitive** `src/…` imports fail the same way.
+
+**Why.** The `src/` alias is supplied by the Angular build pipeline (tsconfig
+`paths`), which only applies when tests run through `ng test`. The vitest config the
+project ships is intentionally minimal and assumes that pipeline.
+
+**What to do instead.** Run tests through the exit-safe wrapper:
+
+```bash
+npm run test:ci      # = ng test, with the force-exit wrapper
+```
+
+This resolves the alias correctly — but it runs the **whole** suite; there is no
+fast single-file or `-t <name>` filter. Practical consequences:
+
+- Budget for full-suite runs while iterating on a single new spec.
+- **Red→green-verifying a regression test costs two full-suite runs** — once with
+  the fix reverted (expect the new test to fail), once restored (expect it to
+  pass). Plan for it; don't try to shortcut it with `npx vitest`.
+
+### Unit-testing a DI-heavy service whose constructor calls `effect()`
+
+**The trap.** Services like `PlotterExtensionService` inject a large facade
+(`AppFacade`) plus several other collaborators, and call `effect()` in their
+constructor. You can't just `new` the class in a spec: `effect()` requires an
+Angular injection context, and the facade is far too heavy to hand-build. Going the
+other way — bootstrapping the full app via `TestBed` with real providers — drags in
+the entire dependency graph and is slow and brittle.
+
+**What to do instead.** Use `TestBed` purely as an injection context, and stub each
+constructor dependency with a minimal `useValue`:
+
+```ts
+TestBed.configureTestingModule({
+  providers: [
+    PlotterExtensionService,
+    RouteBufferRegistry,                                  // cheap real class — fine
+    { provide: AppFacade, useValue: { config: { plotterExtensions: { widgets } }, debug: () => {} } },
+    { provide: SignalKClient, useValue: {} },
+    { provide: MatDialog, useValue: {} },
+    { provide: SKResourceService, useValue: { routes: signal([]) } },
+    { provide: MapService, useValue: {} }
+  ]
+});
+const service = TestBed.inject(PlotterExtensionService);
+```
+
+`TestBed.inject()` supplies the injection context `effect()` needs, and the stubs
+keep the graph tiny. Only stub what the constructor (and the code under test)
+actually touches — e.g. an `effect()` that reads `skres.routes()` needs that to be a
+callable signal returning `[]`. Drive the real logic via public signals
+(`service.manifests.set(...)`) and, where it earns its keep, a narrowly-cast call to
+a private method to exercise the genuine code path rather than faking its output.
+
+> Import path: in a spec, import collaborators with **relative** paths
+> (`../../app.facade`), not the `src/` alias — see *Running a single spec file*.
+
+---
+
+## When building & running locally
+
+### Build outputs are gitignored
+
+**The trap.** `public/` (the webapp) and `plugin/` (the compiled helper) are build
+outputs and are **gitignored** — they won't be in a clean checkout.
+
+**What to do instead.** Build them with `npm run build:web` / `npm run build:helper`
+(or `build:all`). The server serves `public/` at the package mount point; see
+[`docs/signalk/extension-model.md`](../signalk/extension-model.md) for the base-path
+rule.
+
+---
+
+## When submitting a PR
+
+### A PR title is literally a line in the App Store Changelog
+
+**The trap.** Freeboard's App Store "Changelog" tab is generated from PR titles, not
+from any hand-written changelog.
+
+**What to do instead.** Treat the title as a release note. The chain is *PR title →
+GitHub auto-generated release notes (on a `v*` tag) → App Store Changelog tab*,
+colour-coded by `feat`/`fix`/breaking prefix. This is the real reason the
+`type(scope):` title convention and one-change-per-PR rule matter so much. (Details:
+[`docs/signalk/plugin-publishing.md`](../signalk/plugin-publishing.md).)
+
+### CodeRabbit reviews the PR branch, not the merged result
+
+**The trap.** CodeRabbit diffs against the merge-base and reads context from the
+head branch — so if `master` moved after you branched, CR (and CI) reason about a
+stale tree and may flag issues already fixed elsewhere.
+
+**What to do instead.** Rebase onto current `master` before relying on a re-review
+(`git fetch && git rebase origin/master`, force-push).
+
+---
+
+## Environment-specific
+
+Lessons that apply to a class of setups rather than everyone. Scope each by the
+condition that makes it relevant (e.g. *"If you're developing on Windows, …"*, *"If
+your charts live on a Raspberry Pi microSD, …"*).
+
+_No entries yet — add one when a platform or hardware quirk bites you._


### PR DESCRIPTION
## Why

Some non-obvious, repo-specific traps cost real time to discover the hard way and
aren't written down anywhere. This establishes a durable, community-maintained log
so the next contributor (or AI agent) pays that cost once — and wires it into
AGENTS.md so it's actually read at the moment it matters.

## What

Adds `docs/freeboard/DEV-LESSONS-LEARNED.md` — the home for hard-won knowledge,
grouped by the **phase of work** each trap bites in: *reading / exploring*,
*coding*, *testing*, *building & running locally*, *submitting a PR*, and
*environment-specific*.

AGENTS.md's *Hard-won knowledge* section becomes a short pointer that tells you to
re-read the matching section as you enter each phase. (AGENTS.md is always in an
agent's context; this log is loaded on demand — so the trigger lives in AGENTS.md,
the detail lives here.)

Seeded with the existing hard-won items, re-homed by phase, plus two new testing
lessons:

- **Running a single spec: you can't with bare vitest** — `npx vitest run <file>`
  can't resolve the `src/` alias (relative imports don't help — transitive app
  imports still use it); only `ng test` / `npm run test:ci` resolves it, and it runs
  the whole suite, so red→green-verifying a regression test costs two full-suite
  runs.
- **Unit-testing a DI-heavy service whose constructor calls `effect()`** — use
  TestBed purely as an injection context with minimal `useValue` stubs.

The convention for keeping the log alive — non-obvious + reusable, environment-
specific lessons welcome when scoped by condition ("If you're on Windows, …", "If
your charts live on a Raspberry Pi microSD, …") — lives in one place: AGENTS.md's
*Contributing* standards.

@coderabbitai ignore
