### PR TITLE
chore(ci): format existing files and enable prettier check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,4 @@ jobs:
     with:
       build-command: 'npm run build:all'
       test-command: 'npm run test:ci'
+      format-check-command: 'npm run format:check'

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build": "ng build",
     "test": "ng test",
     "format": "prettier --ignore-path .gitignore --write \"src/**/*.+(ts|html)\"",
+    "format:check": "prettier --ignore-path .gitignore --check \"src/**/*.+(ts|html)\"",
     "format:helper": "prettier --ignore-path .gitignore --write \"helper/**/*.+(ts|html)\"",
     "format:all": "npm run format && npm run format:helper",
     "build:helper": "tsc -p tsconfig-helper.json",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -994,7 +994,9 @@
                         )
                       "
                     >
-                      <mat-icon>{{ entry.button.icon || 'extension' }}</mat-icon>
+                      <mat-icon>{{
+                        entry.button.icon || 'extension'
+                      }}</mat-icon>
                     </button>
                     <br />&nbsp;<br />
                   </div>

--- a/src/app/modules/icons/app.icons.ts
+++ b/src/app/modules/icons/app.icons.ts
@@ -22,13 +22,15 @@ import { RESERVED_DEFAULT_NS } from './symbol-ref';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let _symbolRegistry: any = null;
 
-export const setSymbolRegistry = (registry: {
-  resolveDisplayIcon(ref: string): AppIconDef | null;
-  getExternalNoteIcons(showAll: boolean): Array<{ id: string; name: string }>;
-  getExternalWaypointIcons(showAll: boolean): AppIconDef[];
-  hasExternalVersion(id: string): boolean;
-  getGpxMapping(ref: string): { gpxType?: string; gpxSym?: string } | null;
-} | null): void => {
+export const setSymbolRegistry = (
+  registry: {
+    resolveDisplayIcon(ref: string): AppIconDef | null;
+    getExternalNoteIcons(showAll: boolean): Array<{ id: string; name: string }>;
+    getExternalWaypointIcons(showAll: boolean): AppIconDef[];
+    hasExternalVersion(id: string): boolean;
+    getGpxMapping(ref: string): { gpxType?: string; gpxSym?: string } | null;
+  } | null
+): void => {
   _symbolRegistry = registry;
 };
 
@@ -100,7 +102,10 @@ export const getSvgList = (): Array<{ id: string; path: string }> => {
   addToList(WaypointIcons);
   addToList(AtoNsType1);
   // Fallback icon for unresolvable symbol references
-  svgList.push({ id: 'no-such-symbol', path: './assets/img/no-such-symbol.svg' });
+  svgList.push({
+    id: 'no-such-symbol',
+    path: './assets/img/no-such-symbol.svg'
+  });
   return svgList;
 };
 
@@ -411,32 +416,33 @@ export const selListWaypointIcons = (
     icons: Array<AppIconDef>;
   }
 > => {
-  const iconList: Record<string, { group: string; icons: Array<AppIconDef> }> = {
-    waypoint: {
-      group: 'Waypoints',
-      icons: [getResourceIcon('waypoints', 'waypoint')]
-    },
-    pseudoaton: {
-      group: 'Pseudo AtoN',
-      icons: [getResourceIcon('waypoints', 'pseudoaton')]
-    },
-    whale: {
-      group: 'Sightings',
-      icons: [getResourceIcon('waypoints', 'whale')]
-    },
-    pob: {
-      group: 'Alarms',
-      icons: [getResourceIcon('waypoints', 'pob')]
-    },
-    'start-boat': {
-      group: 'Start Boat',
-      icons: [getResourceIcon('waypoints', 'start-boat')]
-    },
-    'start-pin': {
-      group: 'Start Pin',
-      icons: [getResourceIcon('waypoints', 'start-pin')]
-    }
-  };
+  const iconList: Record<string, { group: string; icons: Array<AppIconDef> }> =
+    {
+      waypoint: {
+        group: 'Waypoints',
+        icons: [getResourceIcon('waypoints', 'waypoint')]
+      },
+      pseudoaton: {
+        group: 'Pseudo AtoN',
+        icons: [getResourceIcon('waypoints', 'pseudoaton')]
+      },
+      whale: {
+        group: 'Sightings',
+        icons: [getResourceIcon('waypoints', 'whale')]
+      },
+      pob: {
+        group: 'Alarms',
+        icons: [getResourceIcon('waypoints', 'pob')]
+      },
+      'start-boat': {
+        group: 'Start Boat',
+        icons: [getResourceIcon('waypoints', 'start-boat')]
+      },
+      'start-pin': {
+        group: 'Start Pin',
+        icons: [getResourceIcon('waypoints', 'start-pin')]
+      }
+    };
 
   iconList.waypoint.icons = iconList.waypoint.icons.concat(
     PoiIcons.files.map((file: string) => {
@@ -456,7 +462,8 @@ export const selListWaypointIcons = (
     const builtins = getBuiltinIconIds();
     // Overrides of a built-in are already shown via the resolved built-in/POI
     // entry above, so exclude them here to avoid listing the same id twice.
-    const isNewId = (i: AppIconDef) => !shadowsBuiltin(i.svgIcon ?? '', builtins);
+    const isNewId = (i: AppIconDef) =>
+      !shadowsBuiltin(i.svgIcon ?? '', builtins);
 
     // Waypoint-role external symbols with a new id (no built-in counterpart).
     const wptSymbols = _symbolRegistry
@@ -483,7 +490,8 @@ export const selListWaypointIcons = (
       const replacedDefaults = waypointBuiltinIds
         .filter((id) => _symbolRegistry.hasExternalVersion(id))
         .map((id) => ({ svgIcon: id, name: id }));
-      iconList.waypoint.icons = iconList.waypoint.icons.concat(replacedDefaults);
+      iconList.waypoint.icons =
+        iconList.waypoint.icons.concat(replacedDefaults);
     }
   }
 

--- a/src/app/modules/icons/symbol-ref.ts
+++ b/src/app/modules/icons/symbol-ref.ts
@@ -6,9 +6,7 @@ export const RESERVED_DEFAULT_NS = 'default';
  * Parse a symbol reference into namespace and id components.
  * Splits on the FIRST colon only — namespace must not contain colons.
  */
-export const parseRef = (
-  ref: string
-): { namespace?: string; id: string } => {
+export const parseRef = (ref: string): { namespace?: string; id: string } => {
   const idx = ref.indexOf(':');
   if (idx === -1) {
     return { id: ref };
@@ -40,9 +38,11 @@ export const isRenderableSymbol = (sym: {
   if (!url) return false;
   // Reject data: and javascript: schemes
   const lower = url.toLowerCase().trimStart();
-  if (lower.startsWith('data:') || lower.startsWith('javascript:')) return false;
+  if (lower.startsWith('data:') || lower.startsWith('javascript:'))
+    return false;
   // Reject absolute URLs (any scheme) and protocol-relative URLs — both can
   // point to other origins once trusted via bypassSecurityTrustResourceUrl().
-  if (/^[a-z][a-z0-9+.-]*:/i.test(lower) || lower.startsWith('//')) return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(lower) || lower.startsWith('//'))
+    return false;
   return true;
 };

--- a/src/app/modules/icons/symbols.service.ts
+++ b/src/app/modules/icons/symbols.service.ts
@@ -6,7 +6,12 @@ import { SignalKClient } from 'signalk-client-angular';
 import { AppFacade } from 'src/app/app.facade';
 import { SymbolResource, SymbolRole } from 'src/app/types/symbols';
 import { MapImageRegistry } from '../map/ol/lib/map-image-registry.service';
-import { isQualified, isDefaultNs, isRenderableSymbol, parseRef } from './symbol-ref';
+import {
+  isQualified,
+  isDefaultNs,
+  isRenderableSymbol,
+  parseRef
+} from './symbol-ref';
 import { AppIconDef, getBuiltinIconIds } from './app.icons';
 
 export const FALLBACK_ICON = 'no-such-symbol';
@@ -35,7 +40,9 @@ interface IndexedSymbol {
 /** Interface for the module-level hook used by pure functions in app.icons.ts */
 export interface SymbolRegistryLike {
   resolveDisplayIcon(ref: string): AppIconDef | null;
-  resolveMapMarker(ref: string): { path: string; scale?: number; anchor?: [number, number] } | null;
+  resolveMapMarker(
+    ref: string
+  ): { path: string; scale?: number; anchor?: [number, number] } | null;
   getExternalNoteIcons(showAll: boolean): Array<{ id: string; name: string }>;
   getExternalWaypointIcons(showAll: boolean): Array<AppIconDef>;
   hasExternalVersion(id: string): boolean;
@@ -79,7 +86,8 @@ export class SymbolService implements SymbolRegistryLike {
       )) as Record<string, unknown>;
 
       if (!result || typeof result !== 'object') {
-        if (isDevMode()) console.debug('[SymbolService] No symbols returned from server.');
+        if (isDevMode())
+          console.debug('[SymbolService] No symbols returned from server.');
         return;
       }
 
@@ -172,12 +180,16 @@ export class SymbolService implements SymbolRegistryLike {
     if (isDefaultNs(ref)) {
       // Force built-in: strip "default:" prefix.
       const { id } = parseRef(ref);
-      return this.builtinIds.has(id) ? { svgIcon: id } : { svgIcon: FALLBACK_ICON };
+      return this.builtinIds.has(id)
+        ? { svgIcon: id }
+        : { svgIcon: FALLBACK_ICON };
     }
 
     if (isQualified(ref)) {
       // Qualified external reference (custom:id or fsk:id).
-      return this.byRef.has(ref) ? { svgIcon: ref } : { svgIcon: FALLBACK_ICON };
+      return this.byRef.has(ref)
+        ? { svgIcon: ref }
+        : { svgIcon: FALLBACK_ICON };
     }
 
     // Bare id: an fsk override replaces the built-in, else the built-in itself.
@@ -293,7 +305,8 @@ export class SymbolService implements SymbolRegistryLike {
       s.alias.length === 0 ||
       s.alias.some((a) => !isAliasRef(a))
     ) {
-      if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": no alias.`);
+      if (isDevMode())
+        console.debug(`[SymbolService] Skipping symbol "${key}": no alias.`);
       return false;
     }
     // scale/anchor feed map markers directly — reject non-finite/malformed.
@@ -309,7 +322,10 @@ export class SymbolService implements SymbolRegistryLike {
       return false;
     }
     if (!isRenderableSymbol(s as { mediaType: string; url: string })) {
-      if (isDevMode()) console.debug(`[SymbolService] Skipping symbol "${key}": not renderable.`);
+      if (isDevMode())
+        console.debug(
+          `[SymbolService] Skipping symbol "${key}": not renderable.`
+        );
       return false;
     }
     return true;

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -962,7 +962,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
     if (this.overlay().type === 'route') {
       const rid = this.overlay().id;
       this.mapInteract.measurementCoords = this.routeBuffers.has(rid)
-        ? (this.routeBuffers.get(rid)!.points.map((p) => p.position) as LineString)
+        ? (this.routeBuffers
+            .get(rid)!
+            .points.map((p) => p.position) as LineString)
         : this.skres.fromCache('routes', rid)[1].feature.geometry.coordinates;
     }
     if (featureType === 'anchor') {

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -18,13 +18,7 @@
 //
 // Map/resource host APIs (buttons, filters, map.*) belong to phase 3.
 
-import {
-  Injectable,
-  computed,
-  effect,
-  isDevMode,
-  signal
-} from '@angular/core';
+import { Injectable, computed, effect, isDevMode, signal } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { firstValueFrom } from 'rxjs';
 import { SignalKClient } from 'signalk-client-angular';
@@ -670,7 +664,12 @@ export class PlotterExtensionService {
       });
     }
     for (const buf of this.routeRegistry.all()) {
-      if (buf.saved && !buf.dirty && buf.href && !displayedHrefs.has(buf.href)) {
+      if (
+        buf.saved &&
+        !buf.dirty &&
+        buf.href &&
+        !displayedHrefs.has(buf.href)
+      ) {
         this.routeRegistry.delete(buf.routeId, true);
       }
     }

--- a/src/app/modules/plotterext/route-buffer.registry.spec.ts
+++ b/src/app/modules/plotterext/route-buffer.registry.spec.ts
@@ -184,7 +184,10 @@ describe('RouteBufferRegistry', () => {
   it('exposes a reactive live() signal that tracks create/replace/delete', () => {
     const reg = new RouteBufferRegistry();
     expect(reg.live()).toEqual([]);
-    const { routeId } = reg.create({ name: 'A', points: [{ position: [0, 0] }] });
+    const { routeId } = reg.create({
+      name: 'A',
+      points: [{ position: [0, 0] }]
+    });
     expect(reg.live()).toHaveLength(1);
     expect(reg.live()[0].routeId).toBe(routeId);
     reg.replace(routeId, [{ position: [1, 1] }, { position: [2, 2] }]);

--- a/src/app/modules/plotterext/route-methods.ts
+++ b/src/app/modules/plotterext/route-methods.ts
@@ -95,7 +95,9 @@ export function createRouteMethods(
         !Number.isFinite(pos[0]) ||
         !Number.isFinite(pos[1])
       ) {
-        throw badRequest('each route point needs a numeric [lon, lat] position');
+        throw badRequest(
+          'each route point needs a numeric [lon, lat] position'
+        );
       }
       requireOptString((p as RoutePoint).name, 'point name');
       requireOptString((p as RoutePoint).description, 'point description');
@@ -115,7 +117,11 @@ export function createRouteMethods(
       requireOptString(name, 'name');
       requireOptString(description, 'description');
       const validPoints = requireValidPoints(points);
-      const buffer = registry.create({ name, description, points: validPoints });
+      const buffer = registry.create({
+        name,
+        description,
+        points: validPoints
+      });
       return { routeId: buffer.routeId, rev: buffer.rev };
     },
 

--- a/src/app/modules/radar/radar-api.service.ts
+++ b/src/app/modules/radar/radar-api.service.ts
@@ -116,7 +116,9 @@ export class RadarAPIService {
 
   private testForWebGL(): boolean {
     if (typeof OffscreenCanvas === 'undefined') {
-      console.warn('[FreeBoardSK] OffscreenCanvas not available — WebGL radar display disabled');
+      console.warn(
+        '[FreeBoardSK] OffscreenCanvas not available — WebGL radar display disabled'
+      );
       return false;
     }
     let gl = new OffscreenCanvas(10, 10).getContext('webgl2');

--- a/src/app/modules/skresources/components/notes/note-dialog.html
+++ b/src/app/modules/skresources/components/notes/note-dialog.html
@@ -245,7 +245,7 @@
               [hideIcon]="true"
               [checked]="showAllIcons()"
               (change)="onShowAllToggle($event.checked)"
-              style="font-size: 10pt; margin-left: 8px; vertical-align: middle;"
+              style="font-size: 10pt; margin-left: 8px; vertical-align: middle"
             >
               Show all symbols
             </mat-slide-toggle>

--- a/src/app/modules/skresources/components/notes/relatednotes-dialog.html
+++ b/src/app/modules/skresources/components/notes/relatednotes-dialog.html
@@ -42,7 +42,9 @@
           <mat-card-title-group>
             <mat-card-title>{{n[1].name}}</mat-card-title>
             @if(n[1].properties?.skIcon) {
-            <mat-icon [svgIcon]="n[1].properties?.skIcon | resolveSkIcon"></mat-icon>
+            <mat-icon
+              [svgIcon]="n[1].properties?.skIcon | resolveSkIcon"
+            ></mat-icon>
             } @else {
             <mat-icon class="icon-accent">local_offer</mat-icon>
             }

--- a/src/app/modules/skresources/components/routes/route-panel.html
+++ b/src/app/modules/skresources/components/routes/route-panel.html
@@ -47,8 +47,7 @@
           <mat-icon>edit</mat-icon>
           EDIT
         </button>
-        }
-        &nbsp; @if (this.app.data.activeRoute !== id()) {
+        } &nbsp; @if (this.app.data.activeRoute !== id()) {
         <button
           mat-button
           [disabled]="interacting() || isUnsaved()"
@@ -112,8 +111,7 @@
       "
     >
       <div style="font-weight: bold; font-size: larger; padding-bottom: 5px">
-        {{ _route()?.name }}
-        @if (isUnsaved()) {
+        {{ _route()?.name }} @if (isUnsaved()) {
         <span style="color: gray; font-style: italic">&nbsp;(unsaved)</span>
         }
       </div>

--- a/src/app/modules/skresources/components/waypoints/waypoint-dialog.ts
+++ b/src/app/modules/skresources/components/waypoints/waypoint-dialog.ts
@@ -170,7 +170,9 @@ interface DialogData {
             <div style="font-size: 10pt;display:flex;flex-wrap:wrap">
               <div>
                 <div>
-                  <div style="display:flex;align-items:center;flex-wrap:wrap;gap:4px;">
+                  <div
+                    style="display:flex;align-items:center;flex-wrap:wrap;gap:4px;"
+                  >
                     <mat-chip-listbox
                       selectable
                       (change)="handleWptTypeChange($event.value)"
@@ -311,7 +313,9 @@ export class WaypointDialog {
       }
     }
 
-    this.iconsForSelection.set(this.wptOptions[this.wptType]?.icons ?? this.wptOptions['waypoint'].icons);
+    this.iconsForSelection.set(
+      this.wptOptions[this.wptType]?.icons ?? this.wptOptions['waypoint'].icons
+    );
     this.wptDescription = this.data.waypoint.description ?? '';
     this.wptReadOnly = this.data.waypoint.feature.properties?.readOnly ?? false;
     const coords = this.data.waypoint.feature.geometry.coordinates ?? [0, 0];
@@ -379,7 +383,9 @@ export class WaypointDialog {
     this.showAllIcons.set(checked);
     this.rebuildIconOptions(checked);
     // Stay on the current category (only the Waypoints chip shows the toggle).
-    const currentGroup = this.wptOptions[this.wptType] ? this.wptType : 'waypoint';
+    const currentGroup = this.wptOptions[this.wptType]
+      ? this.wptType
+      : 'waypoint';
     this.iconsForSelection.set(this.wptOptions[currentGroup].icons);
   }
 


### PR DESCRIPTION
## What problem does this solve?

The shared `plugin-ci` workflow added a **Check formatting** step (prettier 3.8.3).
Several files already on `master` don't pass it, so the new check was non-blocking.
This is pre-existing formatting debt exposed by the CI refactor — no regressions
were introduced.

## How does it work?

- Runs `npm run format` (prettier `--write` over `src/**/*.+(ts|html)`) to bring
  all 13 affected files clean
- Adds a `format:check` npm script (`prettier --check` over the same glob)
- Passes `format-check-command: 'npm run format:check'` in `ci.yml` so the step
  is now blocking
- Adds `.gitattributes` (`* text=auto eol=lf`) to ensure consistent LF line endings
  on Windows checkouts, required for the prettier check to pass there

## How was it tested?

- `npm run format:check` runs clean locally after the reformatting pass
- CI matrix (Linux/macOS/arm64/Windows × Node 22 & 24) all green

Closes #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized text file line endings across the project.
  * Added automated formatting checks to the CI pipeline and npm scripts.

* **Style**
  * Updated several templates and TypeScript files for cleaner formatting and consistent layout.

* **Tests**
  * Kept test coverage aligned with the updated formatting style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->