### PR TITLE
fix(course): use route.distance for route DTG in kilometer units

### DIFF
--- a/src/app/modules/course/course.service.spec.ts
+++ b/src/app/modules/course/course.service.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { beforeEach, describe, it, expect } from 'vitest';
+
+import { CourseService } from './course.service';
+import { SignalKClient } from 'signalk-client-angular';
+import { AppFacade } from 'src/app/app.facade';
+import { SKResourceService, SKVessel } from '../skresources';
+import { Convert } from 'src/app/lib/convert';
+import { DistanceUnitDef } from 'src/app/types';
+
+/**
+ * Minimal harness to drive parseSelf() with a chosen distance unit. The course
+ * calc fields used are `distance` (to next point) and `route.distance`
+ * (remaining along the whole route); they must map to courseData.dtg and
+ * courseData.route.dtg respectively.
+ */
+function setup(distanceUnit: DistanceUnitDef) {
+  const app = {
+    config: { units: { distance: distanceUnit } },
+    useMagnetic: false
+  };
+  TestBed.configureTestingModule({
+    providers: [
+      CourseService,
+      { provide: SignalKClient, useValue: {} },
+      { provide: AppFacade, useValue: app },
+      { provide: SKResourceService, useValue: { routes: signal(null) } }
+    ]
+  });
+  return TestBed.inject(CourseService);
+}
+
+function vesselWith(distance: number, routeDistance: number): SKVessel {
+  return {
+    courseCalcs: { distance, 'route.distance': routeDistance }
+  } as unknown as SKVessel;
+}
+
+describe('CourseService route DTG (#414)', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('derives route.dtg from route.distance, not the next-point distance (km)', () => {
+    const service = setup('kilometer');
+    // 200 m to next point, 5000 m remaining on the route.
+    service.parseSelf(vesselWith(200, 5000));
+
+    const c = service.courseData();
+    expect(c.dtg).toBeCloseTo(0.2, 6); // next-point DTG: 200 m
+    expect(c.route.dtg).toBeCloseTo(5.0, 6); // route DTG: 5000 m — not 0.2
+    expect(c.route.dtg).not.toBeCloseTo(c.dtg as number, 6);
+  });
+
+  it('derives route.dtg from route.distance (nautical miles)', () => {
+    const service = setup('naut-mile');
+    service.parseSelf(vesselWith(200, 5000));
+
+    const c = service.courseData();
+    expect(c.dtg).toBeCloseTo(Convert.transform(200, 'm', 'naut-mile'), 6);
+    expect(c.route.dtg).toBeCloseTo(
+      Convert.transform(5000, 'm', 'naut-mile'),
+      6
+    );
+  });
+});

--- a/src/app/modules/course/course.service.ts
+++ b/src/app/modules/course/course.service.ts
@@ -406,7 +406,7 @@ export class CourseService {
     if (typeof v.courseCalcs['route.distance'] !== 'undefined') {
       c.route.dtg =
         this.app.config.units.distance === 'kilometer'
-          ? v.courseCalcs.distance / 1000
+          ? v.courseCalcs['route.distance'] / 1000
           : Convert.transform(
               v.courseCalcs['route.distance'],
               'm',


### PR DESCRIPTION
When following a route with distance units set to **kilometers**, the route
DTG in the course bar mirrored the next-point (waypoint) DTG instead of the
remaining distance along the whole route.

The kilometer branch of the `route.dtg` calculation divided
`courseCalcs.distance` (distance to next point) rather than
`courseCalcs['route.distance']` (remaining route distance). The
nautical-mile branch was already correct, so this only affected km/m users —
which is why the adjacent `route.ttg` / `route.eta` values were right while
route DTG was wrong (see the report's screenshot: point 7 of 34, route DTG ==
waypoint DTG == 1.1 km).

Adds a co-located unit test covering both the kilometer and nautical-mile
paths; the kilometer assertion fails on the previous code and passes with the
fix.

Closes #414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected route distance calculations so the displayed remaining route distance now uses the proper source value.
  * Fixed kilometer and nautical mile conversions to ensure route DTG is shown accurately.
  * Added tests covering both metric and nautical-mile scenarios to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->