### PR TITLE
fix(charts): render resource-provider charts that omit a type field

### DIFF
--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -177,16 +177,10 @@
       >
       </fb-tilelayer-vector>
     } @else if (
-      c[0] === 'openstreetmap' || c[1].type?.toLowerCase() === 'tilelayer'
+      c[0] === 'openstreetmap' ||
+      c[1].type?.toLowerCase() === 'tilelayer' ||
+      !c[1]?.type
     ) {
-      <fb-tilelayer-raster
-        [zIndex]="10 + idx"
-        [chart]="c"
-        [overZoomTiles]="overZoomTiles"
-        [mapMaxZoom]="app.MAP_ZOOM_EXTENT.max"
-      >
-      </fb-tilelayer-raster>
-    } @else {
       <fb-tilelayer-raster
         [zIndex]="10 + idx"
         [chart]="c"

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -186,6 +186,14 @@
         [mapMaxZoom]="app.MAP_ZOOM_EXTENT.max"
       >
       </fb-tilelayer-raster>
+    } @else {
+      <fb-tilelayer-raster
+        [zIndex]="10 + idx"
+        [chart]="c"
+        [overZoomTiles]="overZoomTiles"
+        [mapMaxZoom]="app.MAP_ZOOM_EXTENT.max"
+      >
+      </fb-tilelayer-raster>
     }
   }
 


### PR DESCRIPTION
Chart resource providers serve tiles without a `type` property in the resource JSON.  Without a fallback branch Freeboard renders those charts as nothing — they are invisible on the map.                                                                                                                                       
                                                                                                                                                                                              
This change adds an explicit `@else if (!c[1]?.type)` branch that renders type-less charts via `fb-tilelayer-raster`, restoring                                                                                                                         visibility for any provider-based chart layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map rendering so raster tile layers now display correctly in cases where chart type information is missing.
  * Reduced the chance of blank or incomplete map content by adding a fallback rendering path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->