### PR TITLE
docs(signalk): document unit preferences for value display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,11 @@ for running a local Signal K server to develop against.
 - **Logging.** Use `console.warn` (not `console.error`) for *recoverable*
   feature-detection failures, and `this.app.debug()` for internal state tracing —
   not `console.log`.
+- **Displaying values → honor unit preferences.** When adding or changing UI that
+  displays a numeric value from Signal K, prefer the server's Unit Preferences
+  (`displayUnits` in path metadata) over a hard-coded conversion, so the value follows
+  the user's chosen units. See
+  [`docs/signalk/unit-preferences.md`](docs/signalk/unit-preferences.md).
 - **Tests.** New behaviour needs tests where the test infrastructure supports it
   (`*.spec.ts`, run via `npm run test:ci`). Test behaviour, not implementation.
 
@@ -173,3 +178,6 @@ it*:
   local server and linking a dev build into it.
 - [`plugin-publishing.md`](docs/signalk/plugin-publishing.md) — packaging for npm
   and the App Store.
+- [`unit-preferences.md`](docs/signalk/unit-preferences.md) — the server's Unit
+  Preferences system: consuming `displayUnits` metadata so UI values honor the user's
+  chosen units. Read before adding/changing any UI that displays a value.

--- a/docs/signalk/unit-preferences.md
+++ b/docs/signalk/unit-preferences.md
@@ -1,0 +1,125 @@
+# Signal K Unit Preferences
+
+General background for anyone building a UI that **displays numeric values coming
+from Signal K**. Signal K Server has a **Unit Preferences** system that centralises
+the user's preferred display units on the server. A unit-preferences–aware client
+reads those preferences from path metadata and renders values accordingly, so it does
+**not** need to maintain its own unit settings or hard-code conversions.
+
+> **Already know the Unit Preferences `displayUnits` contract?** Skip this file. It's
+> here so contributors don't reinvent unit handling or reverse-engineer the metadata.
+
+## Why this matters for Freeboard
+
+Freeboard has historically converted units client-side via
+[`src/app/lib/convert.ts`](../../src/app/lib/convert.ts) (the `Convert` class) with a
+fixed table of SI-base → target formulas. That still works, but it is **independent of
+the user's server-side unit preferences** — the same user can set "knots" once in the
+Server Admin UI and have every compatible app honor it.
+
+**When you add or change UI that displays a value to the user, prefer the server's
+`displayUnits` metadata over a hard-coded conversion.** The value then follows the
+user's chosen units automatically, and updates if they change their preference — with
+no app-side settings and no code change.
+
+## How it works
+
+The user configures preferences once in **Server Admin → Server → Configuration →
+Settings → Unit Preferences**: either a **preset** (e.g. _Nautical (Metric)_,
+_Imperial (US)_) or per-category / per-path overrides. Preferences are stored
+**per user**; anonymous clients get the server's global default preset.
+
+Preferences are expressed by **category**, not per path. Every numeric path is assigned
+a category (`speed`, `distance`, `depth`, `temperature`, `angle`, `pressure`,
+`volume`, `electrical.*`, `percentage`, …), each with a known SI **base unit**
+(`speed` → `m/s`, `depth` → `m`, `temperature` → `K`, `angle` → `rad`, …). The active
+preset maps each category to a **target unit**. Setting `speed` to knots therefore
+applies to boat speed, wind speed, and every other `speed` path at once.
+
+## The developer contract: `displayUnits` in `meta`
+
+When a path has an applicable preference, the server adds a **`displayUnits`** object to
+that path's metadata:
+
+```json
+{
+  "units": "m/s",
+  "description": "Speed over ground",
+  "displayName": "SOG",
+  "displayUnits": {
+    "category": "speed",
+    "targetUnit": "kn",
+    "formula": "value * 1.94384",
+    "inverseFormula": "value / 1.94384",
+    "symbol": "kn",
+    "displayFormat": "0.0"
+  }
+}
+```
+
+`displayUnits` gives you everything needed to render the value:
+
+| Field            | Use                                                                       |
+| ---------------- | ------------------------------------------------------------------------- |
+| `category`       | The unit category the path belongs to (`speed`, `depth`, …).              |
+| `targetUnit`     | The unit the user wants to see (`kn`).                                    |
+| `formula`        | A [Math.js](https://mathjs.org/) expression, SI → target. `value` is the raw value. |
+| `inverseFormula` | Math.js expression, target → SI. Use it when converting **user input** back to SI. |
+| `symbol`         | Symbol to show next to the value (`kn`).                                  |
+| `displayFormat`  | Optional format pattern for consistency (e.g. `"0.0"` = one decimal).     |
+
+`formula` / `inverseFormula` are **Math.js expression strings**, not numbers — evaluate
+them with a Math.js–compatible evaluator (`value` bound to the raw SI value). Do not
+`eval()` them. If `displayUnits` is **absent**, the user has no preference for that path;
+fall back to the base `units` (and, in Freeboard, the existing `Convert` behavior).
+
+## Getting the metadata
+
+Two ways to obtain `displayUnits`:
+
+**WebSocket (recommended)** — add `sendMeta: 'all'` to a subscription. Meta is sent once
+with the first delta for each path, and again only if it changes, so no separate fetch is
+needed:
+
+```javascript
+ws.send(
+  JSON.stringify({
+    context: 'vessels.self',
+    subscribe: [
+      { path: 'navigation.speedOverGround', policy: 'instant', sendMeta: 'all' }
+    ]
+  })
+)
+```
+
+The delta then carries a `meta` object (with `displayUnits`) alongside the `value`.
+
+**REST** — fetch the path's metadata directly:
+
+```
+GET /signalk/v1/api/vessels/self/navigation/speedOverGround/meta
+```
+
+## Consuming it
+
+1. **Get value + metadata** — subscribe with `sendMeta: 'all'` (preferred), or poll REST
+   and fetch `.../meta` separately.
+2. **Check for `displayUnits`** — present ⇒ the user has a preference for this path.
+3. **Convert** — evaluate `formula` with the raw SI value bound to `value`.
+4. **Display** — show the result with `symbol`, formatted per `displayFormat`.
+
+Because the preference lives on the server, changing it (e.g. knots → km/h) updates every
+aware client with no code change.
+
+## REST endpoints (reference)
+
+The system also exposes configuration endpoints under `/signalk/v1/unitpreferences/` —
+`config`, `categories`, `definitions`, `presets`, `presets/:name`, `active`,
+`default-categories`, and the custom-definition/category/preset variants. Most UIs only
+need the `displayUnits` metadata above; these endpoints are for inspecting or managing
+the preference configuration itself.
+
+## Authoritative docs
+
+- End-user guide: <https://demo.signalk.io/admin/#/documentation/Guides/Unit_Preferences.html>
+- Developer guide: <https://demo.signalk.io/admin/#/documentation/Developing/Unit_Preferences.html>


### PR DESCRIPTION
## Why

Freeboard converts units client-side via the `Convert` class (`src/app/lib/convert.ts`), independent of the Signal K server's per-user **Unit Preferences**. New UI that displays a value should honor the user's server-side preference instead, so it follows their chosen units (and any later change) with no app-side settings.

## What

Agent/developer documentation only — no code change:

- Add `docs/signalk/unit-preferences.md` — the `displayUnits` metadata contract, unit categories/base units, REST + `sendMeta:'all'` delivery, and the consume-and-convert pattern.
- `AGENTS.md` — a Code-quality guardrail and a Documentation-index entry pointing to the new doc.

@coderabbitai ignore