### PR TITLE
feat(units): support per-path display units in formatValueForDisplay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,14 @@ for running a local Signal K server to develop against.
 - **Logging.** Use `console.warn` (not `console.error`) for *recoverable*
   feature-detection failures, and `this.app.debug()` for internal state tracing —
   not `console.log`.
+- **Displaying values → `formatValueForDisplay()`.** Render every user-facing numeric
+  value through `app.formatValueForDisplay(value, sourceUnit, { path })`. It applies the
+  user's unit preferences — a per-path server override (`meta.displayUnits`) when a
+  `path` is given, otherwise the category preset — and returns the value with its
+  symbol. Pass `path` whenever the value maps to a Signal K path; derived/computed
+  values omit it. Don't call `Convert` directly for display — `Convert` is the pure
+  primitive for geometry and numeric math only. See
+  [`docs/signalk/unit-preferences.md`](docs/signalk/unit-preferences.md).
 - **Tests.** New behaviour needs tests where the test infrastructure supports it
   (`*.spec.ts`, run via `npm run test:ci`). Test behaviour, not implementation.
 
@@ -173,3 +181,6 @@ it*:
   local server and linking a dev build into it.
 - [`plugin-publishing.md`](docs/signalk/plugin-publishing.md) — packaging for npm
   and the App Store.
+- [`unit-preferences.md`](docs/signalk/unit-preferences.md) — displaying values in the
+  user's preferred units via `formatValueForDisplay()`. Read before adding or changing
+  any UI that shows a numeric value.

--- a/docs/signalk/unit-preferences.md
+++ b/docs/signalk/unit-preferences.md
@@ -1,0 +1,91 @@
+# Unit Preferences & Value Display
+
+How Freeboard displays numeric values in the units the user wants. **The rule is
+simple: render every user-facing value through `AppFacade.formatValueForDisplay()`.**
+This document explains what that funnel does and why you should never hand-roll unit
+conversion or call `Convert` directly for display.
+
+> **Just need the rule?** Use
+> `app.formatValueForDisplay(value, sourceUnit, { path })` for anything shown to the
+> user. The rest of this file is the *why*.
+
+## The funnel: `formatValueForDisplay()`
+
+`AppFacade.formatValueForDisplay(value, sourceUnit, options?)` (in
+[`src/app/app.facade.ts`](../../src/app/app.facade.ts)) takes a value **in its Signal K
+SI base unit** and returns a display string in the user's preferred unit, with symbol.
+
+```ts
+formatValueForDisplay(
+  value: number,
+  sourceUnit: SI_BASE_UNIT,
+  options?: {
+    path?: string;      // Signal K path this value came from, if any
+    category?: string;  // 'depth' | 'length' disambiguation for metre values
+    noSymbol?: boolean; // return the number only, no unit symbol
+    precision?: number; // decimal places (default 1)
+  }
+): string
+```
+
+**Resolution order:**
+
+1. **Per-path override** — if `options.path` is given *and* the server has published a
+   per-path display unit for it (`meta.displayUnits`, cached on the facade), that unit
+   wins. This is what lets two paths in the same category display differently (e.g.
+   wind speed in m/s while boat speed is in knots).
+2. **Category preset** — otherwise the value is converted using the active
+   category/source-unit preference (`config.units`, aligned from the server's active
+   preset).
+
+**Always pass `path` when the value maps to a Signal K path.** Derived or computed
+values that have no path simply omit it and get the category preset — that's why `path`
+is optional, and why adding it never breaks an existing caller.
+
+## Do not call `Convert` directly for display
+
+`Convert` ([`src/app/lib/convert.ts`](../../src/app/lib/convert.ts)) is a **pure,
+stateless** SI→target math table. It knows nothing about paths, categories, or the
+user's preferences. It is the primitive the funnel (and geometry code) build on — use
+it for **numeric math and geometry** (bearings, ranges, chart styling), **not** for
+formatting a value to show the user. Displaying via `Convert` + a hard-coded target
+unit bypasses the user's per-path and category preferences.
+
+## Where the preferences come from (server side)
+
+The user configures units once in **Server Admin → Server → Configuration → Settings →
+Unit Preferences** — a preset (e.g. _Nautical (Metric)_) plus optional per-category and
+per-path overrides, stored **per user**. Freeboard reads them two ways:
+
+- **Category preset** — `fetchUnitPrefsFromSKServer()` gets
+  `/signalk/v1/unitpreferences/active` and `alignUnitPrefs()` maps it into
+  `config.units`. Category-level (all speeds, all depths, …).
+- **Per-path override** — the server adds a `displayUnits` object to a path's metadata
+  (`meta.displayUnits`), delivered over the WebSocket stream with `sendMeta: 'all'` or
+  via REST `GET .../<path>/meta`. Its shape (`SKPathDisplayUnits`):
+
+  ```json
+  {
+    "category": "speed",
+    "targetUnit": "kn",
+    "formula": "value * 1.94384",
+    "inverseFormula": "value / 1.94384",
+    "symbol": "kn",
+    "displayFormat": "0.0"
+  }
+  ```
+
+  Cache it via `setPathDisplayUnits(path, displayUnits)`; the funnel reads it via
+  `getPathDisplayUnits(path)`. Today the funnel consumes only `targetUnit` and `symbol`
+  (converting via `Convert`). The `formula`/`inverseFormula`
+  ([Math.js](https://mathjs.org/) strings for units outside `Convert`'s table) and
+  `displayFormat` fields are part of the server contract but **not yet consumed** —
+  reserved for future use.
+
+Because preferences live on the server, changing one updates every value in Freeboard
+that is displayed through the funnel — no per-app settings, no code change.
+
+## Authoritative server docs
+
+- End-user guide: <https://demo.signalk.io/admin/#/documentation/Guides/Unit_Preferences.html>
+- Developer guide: <https://demo.signalk.io/admin/#/documentation/Developing/Unit_Preferences.html>

--- a/src/app/app.facade.spec.ts
+++ b/src/app/app.facade.spec.ts
@@ -1,0 +1,110 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import '@vitest/web-worker';
+import { AppFacade } from './app.facade';
+
+describe('AppFacade.formatValueForDisplay', () => {
+  let app: AppFacade;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    app = TestBed.inject(AppFacade);
+  });
+
+  it('uses the category preset when no path is supplied (speed → kn)', () => {
+    expect(app.formatValueForDisplay(1, 'm/s', { precision: 2 })).toBe(
+      '1.94kn'
+    );
+  });
+
+  it('applies a per-path displayUnits override in place of the category preset', () => {
+    app.setPathDisplayUnits('environment.wind.speedApparent', {
+      category: 'speed',
+      targetUnit: 'm/s',
+      symbol: 'm/s'
+    });
+    expect(
+      app.formatValueForDisplay(1, 'm/s', {
+        path: 'environment.wind.speedApparent',
+        precision: 1
+      })
+    ).toBe('1.0m/s');
+  });
+
+  it('omits the symbol when noSymbol is set on a per-path override', () => {
+    app.setPathDisplayUnits('navigation.speedOverGround', {
+      category: 'speed',
+      targetUnit: 'm/s',
+      symbol: 'm/s'
+    });
+    expect(
+      app.formatValueForDisplay(1, 'm/s', {
+        path: 'navigation.speedOverGround',
+        noSymbol: true
+      })
+    ).toBe('1.0');
+  });
+
+  it('derives the symbol from the target unit when the override omits one', () => {
+    app.setPathDisplayUnits('environment.wind.speedTrue', {
+      category: 'speed',
+      targetUnit: 'km/h'
+    });
+    expect(
+      app.formatValueForDisplay(1, 'm/s', {
+        path: 'environment.wind.speedTrue',
+        precision: 1
+      })
+    ).toBe('3.6km/h');
+  });
+
+  it('falls back to the category preset when the override target unit is unknown', () => {
+    app.setPathDisplayUnits('some.path', {
+      category: 'speed',
+      targetUnit: 'not-a-unit',
+      symbol: 'zz'
+    });
+    const withPath = app.formatValueForDisplay(1, 'm/s', {
+      path: 'some.path',
+      precision: 2
+    });
+    expect(withPath).toBe(
+      app.formatValueForDisplay(1, 'm/s', { precision: 2 })
+    );
+  });
+
+  it('uses the category preset for a path that has no override', () => {
+    expect(
+      app.formatValueForDisplay(1, 'm/s', {
+        path: 'navigation.speedThroughWater',
+        precision: 2
+      })
+    ).toBe('1.94kn');
+  });
+
+  it('formats a ratio override like the category preset (0-1 → %)', () => {
+    app.setPathDisplayUnits('tanks.fuel.0.currentLevel', {
+      category: 'percentage',
+      targetUnit: 'percent',
+      symbol: '%'
+    });
+    const opts = { path: 'tanks.fuel.0.currentLevel', precision: 1 };
+    expect(app.formatValueForDisplay(0.5, 'ratio', opts)).toBe(
+      app.formatValueForDisplay(0.5, 'ratio', { precision: 1 })
+    );
+    expect(app.formatValueForDisplay(0.5, 'ratio', opts)).toBe('50.0%');
+  });
+
+  it('shows an out-of-range ratio override raw, matching the preset', () => {
+    app.setPathDisplayUnits('tanks.fuel.0.currentLevel', {
+      category: 'percentage',
+      targetUnit: 'percent',
+      symbol: '%'
+    });
+    expect(
+      app.formatValueForDisplay(1.5, 'ratio', {
+        path: 'tanks.fuel.0.currentLevel'
+      })
+    ).toBe(app.formatValueForDisplay(1.5, 'ratio', {}));
+  });
+});

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -29,6 +29,7 @@ import {
   IAppConfig,
   LineString,
   SKServerUnitPrefs,
+  SKPathDisplayUnits,
   TemperatureUnitDef,
   DepthUnitDef,
   SpeedUnitDef,
@@ -130,7 +131,11 @@ export class AppFacade extends InfoService {
   }
 
   public serverConfig = {
-    unitPreferences: signal<SKServerUnitPrefs>(undefined)
+    unitPreferences: signal<SKServerUnitPrefs>(undefined),
+    // Per-path display-unit overrides keyed by Signal K path (server
+    // `meta.displayUnits`). Populated from path metadata; consumed by
+    // formatValueForDisplay() when a path is supplied.
+    pathDisplayUnits: signal<Record<string, SKPathDisplayUnits>>({})
   };
 
   // controls map zoom limits
@@ -521,6 +526,25 @@ export class AppFacade extends InfoService {
         }
       });
     });
+  }
+
+  /**
+   * Returns the per-path display-unit override for a Signal K path, or undefined
+   * when the server has published none for it.
+   */
+  public getPathDisplayUnits(path: string): SKPathDisplayUnits | undefined {
+    return this.serverConfig.pathDisplayUnits()[path];
+  }
+
+  /**
+   * Store the per-path display-unit override for a Signal K path (from the path's
+   * `meta.displayUnits`).
+   */
+  public setPathDisplayUnits(path: string, displayUnits: SKPathDisplayUnits) {
+    this.serverConfig.pathDisplayUnits.update((m) => ({
+      ...m,
+      [path]: displayUnits
+    }));
   }
 
   /**
@@ -1007,12 +1031,19 @@ export class AppFacade extends InfoService {
 
   /** returns a formatted string containing the value (converted to the preferred units)
    * and units. (e.g. 12.5 knots, 8.8 m/s)
-   * Numbers are fixed to 1 decimal point unless precision is specified
+   * Numbers are fixed to 1 decimal point unless precision is specified.
+   *
+   * When `options.path` is supplied and the server has published a per-path
+   * display-unit override for it (`meta.displayUnits`), that override takes
+   * precedence over the category preset — so a path can display in a different
+   * unit than others in its category. Otherwise the category / source-unit
+   * preset is used.
    */
   formatValueForDisplay(
     value: number,
     sourceUnit: SI_BASE_UNIT,
     options?: {
+      path?: string;
       category?: string;
       noSymbol?: boolean;
       precision?: number;
@@ -1022,6 +1053,40 @@ export class AppFacade extends InfoService {
       const precision = options?.precision ?? 1;
       let symbol = '';
       let nv: string;
+
+      const displayUnits = options?.path
+        ? this.getPathDisplayUnits(options.path)
+        : undefined;
+      if (displayUnits) {
+        try {
+          // Ratios format like the category preset (0-1 → %, out-of-range shown raw)
+          // rather than a plain unit transform, so keep parity here.
+          nv =
+            sourceUnit === 'ratio'
+              ? this.formatNumericDisplay(
+                  Math.abs(value) <= 1 ? value * 100 : value,
+                  Math.abs(value) <= 1 ? precision : 4
+                )
+              : this.formatNumericDisplay(
+                  Convert.transform(
+                    value,
+                    sourceUnit,
+                    displayUnits.targetUnit as TARGET_UNIT
+                  ),
+                  precision
+                );
+          symbol =
+            displayUnits.symbol ??
+            Convert.getSymbol(displayUnits.targetUnit as TARGET_UNIT);
+          return `${nv}${options?.noSymbol ? '' : symbol}`;
+        } catch {
+          // Malformed server-published displayUnits (e.g. unknown targetUnit) —
+          // warn and fall back to the category preset.
+          console.warn(
+            `formatValueForDisplay: invalid displayUnits for path "${options.path}" — falling back to category preset.`
+          );
+        }
+      }
 
       if (sourceUnit === 'K') {
         symbol = Convert.getSymbol(this.config.units.temperature);

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -291,3 +291,22 @@ export type SKUnitCategory = {
   displayFormat: string;
   symbol: string;
 };
+
+/**
+ * Per-path display-unit override as published by the Signal K server in a path's
+ * metadata (`meta.displayUnits`). Carries the user's preferred unit for that
+ * specific path, which can differ from the category preset (e.g. wind speed in m/s
+ * while boat speed is in knots).
+ *
+ * `formatValueForDisplay()` currently consumes `targetUnit` and `symbol`. The
+ * `formula`/`inverseFormula` (Math.js) and `displayFormat` fields are part of the
+ * server contract but not yet consumed — reserved for future use.
+ */
+export type SKPathDisplayUnits = {
+  category: string;
+  targetUnit: string;
+  formula?: string;
+  inverseFormula?: string;
+  symbol?: string;
+  displayFormat?: string;
+};


### PR DESCRIPTION
## Why

Freeboard applies the server's unit preferences at the **category** level only (all speeds, all depths, …). It can't yet honor a **per-path** override — e.g. wind speed in m/s while boat speed is in knots (#304) — which the server expresses via `meta.displayUnits`.

## What

Extend the existing display funnel `AppFacade.formatValueForDisplay()` with an optional `path`:

- When `path` is supplied **and** a per-path `displayUnits` override is cached for it, that override wins; otherwise the current category preset applies.
- `path` is optional, so all existing callers and derived (path-less) values are unaffected — no behavior change until per-path overrides are populated.
- Adds the `SKPathDisplayUnits` type, a `pathDisplayUnits` cache with `get/setPathDisplayUnits()` accessors, and unit tests.

Also adds contributor guidance (`AGENTS.md` + `docs/signalk/unit-preferences.md`): display user-facing values through the funnel, not `Convert` directly (`Convert` stays the pure primitive for geometry/numeric math).

This is the foundation; wiring the cache to live path metadata (`sendMeta: 'all'`) and the #304 fix follow separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-path display unit preferences, so numeric values can now follow more specific unit settings when shown in the UI.
  * Improved value formatting so user-facing numbers can respect path-specific overrides, symbol choices, and formatting options.

* **Documentation**
  * Expanded guidance on how numeric values are displayed and how unit preferences are resolved.

* **Tests**
  * Added coverage for formatting behavior across default, override, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->