### PR TITLE
feat(units): honor per-path display units for wind speed

### DIFF
--- a/src/app/app.facade.spec.ts
+++ b/src/app/app.facade.spec.ts
@@ -1,7 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
 import '@vitest/web-worker';
 import { AppFacade } from './app.facade';
+import { SignalKClient } from 'signalk-client-angular';
 
 describe('AppFacade.formatValueForDisplay', () => {
   let app: AppFacade;
@@ -106,5 +108,97 @@ describe('AppFacade.formatValueForDisplay', () => {
         path: 'tanks.fuel.0.currentLevel'
       })
     ).toBe(app.formatValueForDisplay(1.5, 'ratio', {}));
+  });
+});
+
+describe('AppFacade per-path display units (#304)', () => {
+  const windMeta = {
+    displayUnits: { category: 'speed', targetUnit: 'm/s', symbol: 'm/s' }
+  };
+
+  const mockClient = (getImpl: (url: string) => unknown) => ({
+    get: vi.fn(getImpl),
+    setAppId: vi.fn(),
+    setAppVersion: vi.fn()
+  });
+
+  const setup = (getImpl: (url: string) => unknown) => {
+    TestBed.configureTestingModule({
+      providers: [{ provide: SignalKClient, useValue: mockClient(getImpl) }]
+    });
+    return TestBed.inject(AppFacade);
+  };
+
+  it('caches wind display units from the server when server prefs are on', () => {
+    const app = setup((url) =>
+      of(url.includes('speedApparent') ? {} : windMeta)
+    );
+    app.config.units.useServerPrefs = true;
+    app.config.units.preferredPaths.tws = 'environment.wind.speedTrue';
+
+    app.refreshPathDisplayUnits();
+
+    expect(
+      app.getPathDisplayUnits('environment.wind.speedTrue')?.targetUnit
+    ).toBe('m/s');
+    // Wind speed now displays in m/s while boat speed stays the preset (kn).
+    expect(
+      app.formatValueForDisplay(1, 'm/s', {
+        path: 'environment.wind.speedTrue'
+      })
+    ).toBe('1.0m/s');
+    expect(app.formatValueForDisplay(1, 'm/s', {})).toBe('1.9kn');
+  });
+
+  it('clears the cache and does not fetch when server prefs are off', () => {
+    const client = mockClient(() => of(windMeta));
+    TestBed.configureTestingModule({
+      providers: [{ provide: SignalKClient, useValue: client }]
+    });
+    const app = TestBed.inject(AppFacade);
+    const getSpy = client.get;
+    app.setPathDisplayUnits(
+      'environment.wind.speedTrue',
+      windMeta.displayUnits
+    );
+    app.config.units.useServerPrefs = false;
+
+    app.refreshPathDisplayUnits();
+
+    expect(getSpy).not.toHaveBeenCalled();
+    expect(
+      app.getPathDisplayUnits('environment.wind.speedTrue')
+    ).toBeUndefined();
+  });
+
+  it('evicts a cached override when the server no longer publishes one', () => {
+    const app = setup(() => of({}));
+    app.config.units.useServerPrefs = true;
+    app.setPathDisplayUnits(
+      'environment.wind.speedTrue',
+      windMeta.displayUnits
+    );
+
+    app.fetchPathDisplayUnits('environment.wind.speedTrue');
+
+    expect(
+      app.getPathDisplayUnits('environment.wind.speedTrue')
+    ).toBeUndefined();
+  });
+
+  it('does not re-add an override if server prefs were turned off mid-fetch', () => {
+    const app = setup(() => of(windMeta));
+    app.setPathDisplayUnits(
+      'environment.wind.speedTrue',
+      windMeta.displayUnits
+    );
+    // Simulate the toggle flipping off before the (synchronous mock) response.
+    app.config.units.useServerPrefs = false;
+
+    app.fetchPathDisplayUnits('environment.wind.speedTrue');
+
+    expect(
+      app.getPathDisplayUnits('environment.wind.speedTrue')
+    ).toBeUndefined();
   });
 });

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -360,9 +360,68 @@ export class AppFacade extends InfoService {
     this.signalk.get('/signalk/v1/unitpreferences/active').subscribe({
       next: (res: SKServerUnitPrefs) => {
         this.serverConfig.unitPreferences.set(res);
+        this.refreshPathDisplayUnits();
       },
       error: () => {
         this.debug('No server unit preferences...using fallback!');
+      }
+    });
+  }
+
+  /**
+   * Paths whose per-path display-unit override (`meta.displayUnits`) Freeboard
+   * honors so they can display in a different unit than their category preset.
+   * Currently wind speed only (see issue #304): the true-wind path is the user's
+   * preferred TWS path.
+   */
+  /**
+   * True-wind path used as the per-path display-unit cache key and lookup. Shared
+   * with display consumers (e.g. the vessel popover) so the key always matches.
+   */
+  public twsDisplayUnitPath(): string {
+    return this.config.units.preferredPaths.tws ?? 'environment.wind.speedTrue';
+  }
+
+  private displayUnitPaths(): string[] {
+    return [this.twsDisplayUnitPath(), 'environment.wind.speedApparent'];
+  }
+
+  /**
+   * Refresh the per-path display-unit cache from the server. Only applied when
+   * the user has opted into server unit preferences; otherwise the cache is
+   * cleared so display falls back to the category preset.
+   */
+  public refreshPathDisplayUnits() {
+    if (!this.config.units.useServerPrefs) {
+      this.serverConfig.pathDisplayUnits.set({});
+      return;
+    }
+    this.displayUnitPaths().forEach((path) => this.fetchPathDisplayUnits(path));
+  }
+
+  /**
+   * Fetch a path's per-path display-unit override (`meta.displayUnits`) from the
+   * server and cache it. Paths with no published override are left uncached and
+   * fall back to the category preset.
+   */
+  public fetchPathDisplayUnits(path: string) {
+    const p = path.split('.').join('/');
+    this.signalk.get(`/signalk/v1/api/vessels/self/${p}/meta`).subscribe({
+      next: (meta: { displayUnits?: SKPathDisplayUnits }) => {
+        // Re-check useServerPrefs: it may have been turned off while this
+        // request was in flight (a stale response must not re-add an override).
+        if (
+          this.config.units.useServerPrefs &&
+          meta?.displayUnits?.targetUnit
+        ) {
+          this.setPathDisplayUnits(path, meta.displayUnits);
+        } else {
+          this.clearPathDisplayUnits(path);
+        }
+      },
+      error: () => {
+        this.debug(`No display units for path: ${path}`);
+        this.clearPathDisplayUnits(path);
       }
     });
   }
@@ -545,6 +604,19 @@ export class AppFacade extends InfoService {
       ...m,
       [path]: displayUnits
     }));
+  }
+
+  /**
+   * Remove the cached per-path display-unit override for a Signal K path, so it
+   * reverts to the category preset.
+   */
+  public clearPathDisplayUnits(path: string) {
+    this.serverConfig.pathDisplayUnits.update((m) => {
+      if (!(path in m)) return m;
+      const next = { ...m };
+      delete next[path];
+      return next;
+    });
   }
 
   /**

--- a/src/app/modules/map/popovers/vessel-popover.component.ts
+++ b/src/app/modules/map/popovers/vessel-popover.component.ts
@@ -201,9 +201,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
               >
             </div>
             <div style="flex: 1 1 auto;text-align:right;">
-              {{ app.formatSpeed(vessel().wind.tws, true) }}&nbsp;{{
-                app.formattedSpeedUnits
-              }}
+              {{ windSpeed(vessel().wind.tws, app.twsDisplayUnitPath()) }}
             </div>
           </div>
           <div>
@@ -213,8 +211,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
               <span style="font-weight:bold;"> Wind (A):</span>
             </div>
             <div style="flex: 1 1 auto;text-align:right;">
-              {{ app.formatSpeed(vessel().wind.aws, true) }}&nbsp;{{
-                app.formattedSpeedUnits
+              {{
+                windSpeed(vessel().wind.aws, 'environment.wind.speedApparent')
               }}
             </div>
           </div>
@@ -253,6 +251,17 @@ export class VesselPopoverComponent {
   protected app = inject(AppFacade);
   protected buddies = inject(Buddies);
   private destroyRef = inject(DestroyRef);
+
+  /**
+   * Format a wind speed (m/s) for display, honoring the per-path unit override
+   * for `path` so wind speed can use a different unit than boat speed (#304).
+   * Returns '--' when the value is unavailable.
+   */
+  protected windSpeed(value: number, path: string): string {
+    return Number.isFinite(value)
+      ? this.app.formatValueForDisplay(value, 'm/s', { path })
+      : '--';
+  }
 
   constructor() {
     effect(() => {


### PR DESCRIPTION
## Why

Wind speed and boat speed could only share a single speed unit. In some locales they differ — e.g. boat speed in knots, wind speed in m/s (#304).

## What

The Signal K server publishes a per-path display-unit override in a path's metadata (`meta.displayUnits`). Freeboard now reads it for the wind speed paths and, when the user has opted into server unit preferences (`useServerPrefs`), displays wind speed (TWS/AWS) through the existing `formatValueForDisplay` funnel with its path — so wind speed can use a different unit than boat speed.

- `fetchPathDisplayUnits(path)` fetches and caches a path's `meta.displayUnits`; `refreshPathDisplayUnits()` refreshes the wind paths (preferred TWS path + `speedApparent`) when unit prefs load. Gated on `useServerPrefs`; falls back to the category preset when no override is published.
- Vessel-popover TWS/AWS render via the funnel (replacing the shared `formattedSpeedUnits` read); boat speed is unchanged.

Scope is limited to wind speed per the issue. Verified via unit tests (fetch/cache, eviction, `useServerPrefs` gating, and per-path formatting).

Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-path display unit overrides, so values can follow server-provided preferences on a path-by-path basis.
  * Wind speeds in vessel popovers now use path-aware formatting, improving consistency with configured units.

* **Tests**
  * Expanded test coverage for server-published unit overrides, including caching, updates, disabled preferences, and cache cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->