### PR TITLE
feat(map): add per-vessel AIS track display

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -627,7 +627,8 @@ export function initData(): FBAppData {
       active: null,
       closest: [],
       prefAvailablePaths: {}, // preference paths available from source,
-      flagged: [] // flagged ais targets
+      flagged: [], // flagged ais targets
+      showTrack: [] // ais targets to display track for (session-only)
     },
     aircraft: new Map(), // received AIS aircraft data
     atons: new Map(), // received AIS AtoN data

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -9,6 +9,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Subject } from 'rxjs';
 
 import { InfoService, IndexedDB, AppInfoDef } from './lib/services';
+import { isTrackShown, toggleTrackSelection } from './lib/vessel-track';
 
 import {
   AlertDialog,
@@ -779,6 +780,19 @@ export class AppFacade extends InfoService {
       st.push(pt);
       return st;
     });
+  }
+
+  /** Whether the AIS vessel's individual track is displayed (session-only) */
+  isVesselTrackShown(id: string): boolean {
+    return isTrackShown(this.data.vessels.showTrack, id);
+  }
+
+  /** Toggle display of an AIS vessel's individual track on the map (session-only) */
+  toggleVesselTrack(id: string) {
+    this.data.vessels.showTrack = toggleTrackSelection(
+      this.data.vessels.showTrack,
+      id
+    );
   }
 
   /** Calculate the position to center the map.

--- a/src/app/lib/vessel-track.spec.ts
+++ b/src/app/lib/vessel-track.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isTrackShown,
+  toggleTrackSelection,
+  shouldRenderTrack
+} from './vessel-track';
+
+describe('isTrackShown', () => {
+  it('is true only when the id is in the selection', () => {
+    expect(isTrackShown(['vessels.a'], 'vessels.a')).toBe(true);
+    expect(isTrackShown(['vessels.a'], 'vessels.b')).toBe(false);
+  });
+
+  it('is false for an empty or missing selection', () => {
+    expect(isTrackShown([], 'vessels.a')).toBe(false);
+    expect(isTrackShown(undefined as unknown as string[], 'vessels.a')).toBe(
+      false
+    );
+  });
+});
+
+describe('toggleTrackSelection', () => {
+  it('adds an id that is not present', () => {
+    expect(toggleTrackSelection([], 'vessels.a')).toEqual(['vessels.a']);
+  });
+
+  it('removes an id that is present', () => {
+    expect(
+      toggleTrackSelection(['vessels.a', 'vessels.b'], 'vessels.a')
+    ).toEqual(['vessels.b']);
+  });
+
+  it('is idempotent when toggled twice', () => {
+    const once = toggleTrackSelection([], 'vessels.a');
+    const twice = toggleTrackSelection(once, 'vessels.a');
+    expect(twice).toEqual([]);
+  });
+
+  it('returns a new array reference (never mutates the input)', () => {
+    const input = ['vessels.a'];
+    const added = toggleTrackSelection(input, 'vessels.b');
+    const removed = toggleTrackSelection(input, 'vessels.a');
+    expect(added).not.toBe(input);
+    expect(removed).not.toBe(input);
+    expect(input).toEqual(['vessels.a']); // unchanged
+  });
+});
+
+describe('shouldRenderTrack', () => {
+  it('renders every vessel when show-all is on, regardless of selection', () => {
+    expect(shouldRenderTrack('vessels.a', true, [])).toBe(true);
+    expect(shouldRenderTrack('vessels.a', true, ['vessels.b'])).toBe(true);
+  });
+
+  it('renders only selected vessels when show-all is off', () => {
+    expect(shouldRenderTrack('vessels.a', false, ['vessels.a'])).toBe(true);
+    expect(shouldRenderTrack('vessels.a', false, ['vessels.b'])).toBe(false);
+    expect(shouldRenderTrack('vessels.a', false, [])).toBe(false);
+  });
+});

--- a/src/app/lib/vessel-track.ts
+++ b/src/app/lib/vessel-track.ts
@@ -1,0 +1,35 @@
+/**
+ * Helpers for the session-only set of AIS vessels whose track is displayed
+ * individually (independent of the global `aisShowTrack` "show all tracks" setting).
+ *
+ * The set is a plain `string[]` of vessel ids. Toggle helpers return a NEW array
+ * so that Angular's OnPush change detection sees an input reference change.
+ */
+
+/** True when the vessel id is in the display-track selection. */
+export function isTrackShown(selected: string[], id: string): boolean {
+  return Array.isArray(selected) && selected.includes(id);
+}
+
+/**
+ * Add the id if absent, remove it if present. Always returns a new array
+ * (never mutates the input) so bound inputs re-fire change detection.
+ */
+export function toggleTrackSelection(selected: string[], id: string): string[] {
+  const current = Array.isArray(selected) ? selected : [];
+  return current.includes(id)
+    ? current.filter((v) => v !== id)
+    : [id, ...current];
+}
+
+/**
+ * Whether a vessel's track should be rendered: always when "show all" is on,
+ * otherwise only when the vessel is in the individual selection.
+ */
+export function shouldRenderTrack(
+  id: string,
+  showAll: boolean,
+  selected: string[]
+): boolean {
+  return showAll || isTrackShown(selected, id);
+}

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -225,9 +225,14 @@
   }
 
   <!-- AIS target tracks -->
-  @if (app.config.ui.showAisTargets && app.config.vessels.aisShowTrack) {
+  @if (
+    app.config.ui.showAisTargets &&
+    (app.config.vessels.aisShowTrack || app.data.vessels.showTrack.length > 0)
+  ) {
     <ais-targets-track
       [tracks]="app.data.vessels.aisTracks"
+      [showAll]="app.config.vessels.aisShowTrack"
+      [selectedIds]="app.data.vessels.showTrack"
       [tracksMinZoom]="10"
       targetContext="vessels"
       [updateIds]="skstream.aisStatus().updated"

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets-track.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets-track.component.ts
@@ -11,6 +11,7 @@ import { MultiLineString } from 'ol/geom';
 import { MapComponent } from '../map.component';
 import { fromLonLatArray, mapifyCoords } from '../util';
 import { AISBaseLayerComponent } from './ais-base.component';
+import { shouldRenderTrack } from 'src/app/lib/vessel-track';
 
 // ** Signal K AIS targets track  **
 @Component({
@@ -25,6 +26,8 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
   @Input() tracksMinZoom = 10;
   @Input() override mapZoom = 10;
   @Input() showTracks = true;
+  @Input() showAll = true; // render tracks for all targets (global aisShowTrack)
+  @Input() selectedIds: string[] = []; // targets to render individually when !showAll
 
   constructor(
     protected override mapComponent: MapComponent,
@@ -42,6 +45,9 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
     super.ngOnChanges(changes);
     if (this.layer) {
       const keys = Object.keys(changes);
+      if (keys.includes('showAll') || keys.includes('selectedIds')) {
+        this.reloadTracks();
+      }
       if (
         keys.includes('tracks') &&
         changes['tracks'].previousValue.size === 0
@@ -76,6 +82,11 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
     return this.mapZoom >= this.tracksMinZoom;
   }
 
+  // render every target's track when showAll, else only the individually selected ones
+  protected override okToRenderTarget(id: string): boolean {
+    return shouldRenderTrack(id, this.showAll, this.selectedIds);
+  }
+
   reloadTracks() {
     if (!this.tracks || !this.source) {
       return;
@@ -104,7 +115,7 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
                 this.addTrackWithId(id);
               }
             }
-          } else {
+          } else if (f) {
             this.source.removeFeature(f);
           }
         }

--- a/src/app/modules/map/popovers/vessel-popover.component.ts
+++ b/src/app/modules/map/popovers/vessel-popover.component.ts
@@ -92,6 +92,26 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
               <mat-icon>clear_all</mat-icon>
             </button>
           }
+          @if (!isSelf()) {
+            @let trackShown = app.isVesselTrackShown(vessel().id);
+            <span
+              [matTooltip]="
+                app.config.vessels.aisShowTrack
+                  ? 'Turn off &quot;Show All&quot; to enable'
+                  : trackShown
+                    ? 'Hide vessel track'
+                    : 'Show vessel track'
+              "
+            >
+              <button
+                mat-icon-button
+                (click)="toggleTrack()"
+                [disabled]="app.config.vessels.aisShowTrack"
+              >
+                <mat-icon>{{ trackShown ? 'layers_clear' : 'route' }}</mat-icon>
+              </button>
+            </span>
+          }
         </div>
         <div style="text-align:right;">
           <button
@@ -364,6 +384,10 @@ export class VesselPopoverComponent {
           }
         );
     }
+  }
+
+  toggleTrack() {
+    this.app.toggleVesselTrack(this.vessel().id);
   }
 
   toggleFlag() {

--- a/src/app/modules/skresources/components/ais/aislist.html
+++ b/src/app/modules/skresources/components/ais/aislist.html
@@ -176,6 +176,25 @@
               <mat-icon>center_focus_strong</mat-icon>
               CENTER
             </button>
+            @let trackShown = app.isVesselTrackShown(r[0]);
+            <span
+              [matTooltip]="
+                app.config.vessels.aisShowTrack
+                  ? 'Turn off &quot;Show All&quot; to enable'
+                  : trackShown
+                    ? 'Hide vessel track'
+                    : 'Show vessel track'
+              "
+            >
+              <button
+                mat-button
+                (click)="app.toggleVesselTrack(r[0])"
+                [disabled]="app.config.vessels.aisShowTrack"
+              >
+                <mat-icon>{{ trackShown ? 'layers_clear' : 'route' }}</mat-icon>
+                {{ trackShown ? 'UNTRACK' : 'TRACK' }}
+              </button>
+            </span>
             <div>
               <button
                 mat-icon-button

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -270,6 +270,7 @@ export interface FBAppData {
     closest: string[];
     prefAvailablePaths: { [key: string]: string }; // preference paths available from source
     flagged: string[];
+    showTrack: string[]; // ais targets to display track for (session-only, independent of aisShowTrack)
   };
   aircraft: Map<string, SKAircraft>; // received AIS aircraft data
   atons: Map<string, SKAtoN>; // received AIS AtoN data


### PR DESCRIPTION
Adds the ability to display an **individual** AIS vessel's track, rather than only
the all-or-nothing "show tracks for all vessels" setting.

Users reported that showing every vessel's track is too cluttered when they only
want to follow one boat. This lets them pick specific vessels.

**How it works**
- A session-only selection set (`app.data.vessels.showTrack`) drives display,
  mirroring the existing `flagged` pattern — nothing is persisted to config.
- With the global "show all tracks" setting **on**, all tracks render as before.
  With it **off**, only the selected vessels' tracks render.
- Toggle a vessel's track from either the **vessel popover** (on the map) or the
  **vessels list**, sharing the same selection.
- The track layer mounts whenever the global toggle is on *or* at least one vessel
  is individually selected.

Track data continues to come from the server tracks plugin (already fetched
per-vessel), so no server-side change is required.

Selection logic is extracted to a small pure helper (`src/app/lib/vessel-track.ts`)
with unit tests.

Closes #374


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a vessel track visibility toggle in vessel details and AIS lists.
  * You can now show selected vessel tracks for the current session, with support for viewing all tracks or only chosen ones.
  * Map overlays now respect track visibility settings and update dynamically when selections change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->