### PR TITLE
feat(plotterext): add fsk-mcp agent bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ large, often non-technical user base, so changes warrant extra care.
 | `src/app/` | the Angular webapp; feature areas under `src/app/modules/` (`map`, `skresources`, `plotterext`, `autopilot`, `radar`, `weather`, `gpx`, `settings`, …) |
 | `helper/` | the companion server plugin (TypeScript) |
 | `scripts/` | build/test wrappers (`build-web.mjs`, `test-ci.mjs`) — see *Build/test* |
+| `dev-tools/` | developer-only tooling, **never shipped** (excluded by the package `files` whitelist, and not an npm workspace). e.g. `fsk-mcp/` — an MCP bridge that lets an agent drive a running Freeboard (see *Build, test, run*) |
 | `docs/` | the documentation set this file indexes |
 | `public/` | build output: the webapp (served by the SK server at `/@signalk/freeboard-sk/`) — gitignored |
 | `plugin/` | build output: the compiled helper plugin — gitignored |
@@ -53,6 +54,25 @@ Signal K server in the browser URL. To target a specific server while running
 `src/app/app.facade.ts`. This applies in **development mode only**. See
 [`docs/signalk/local-dev-environment.md`](docs/signalk/local-dev-environment.md)
 for running a local Signal K server to develop against.
+
+### Driving Freeboard from an agent — `dev-tools/fsk-mcp`
+
+To have your agent control a running Freeboard directly while debugging — set the
+map view, inspect and edit routes, push resource filters, read live data — install
+the bundled MCP bridge in [`dev-tools/fsk-mcp/`](dev-tools/fsk-mcp/). It exposes the
+Plotter Extensions host API as MCP tools, so "put the chart here at this zoom, then
+tell me what's rendered" becomes a tool call instead of a manual click-through. The
+one-time wiring (link the plugin, enable it, point your agent at the MCP endpoint)
+is in [`docs/dev-tools/fsk-mcp.md`](docs/dev-tools/fsk-mcp.md); it's dev-only and
+never shipped.
+
+**Keep it in sync with the host API.** When you add or change a Plotter Extensions
+host API method (the `map.*` / `route.*` / `resources.*` / … surface in
+[`docs/api/plotter-extensions-api.md`](docs/api/plotter-extensions-api.md)), add or
+update the matching tool in `dev-tools/fsk-mcp/src/tools.js` so agents can exercise
+the new behaviour. (`fsk_call` already reaches any method generically; the curated
+tools exist for clean, discoverable schemas — that file is the single place they
+live.)
 
 ## Code quality
 
@@ -184,3 +204,8 @@ it*:
 - [`unit-preferences.md`](docs/signalk/unit-preferences.md) — displaying values in the
   user's preferred units via `formatValueForDisplay()`. Read before adding or changing
   any UI that shows a numeric value.
+
+**Developer tooling** (`docs/dev-tools/`):
+- [`fsk-mcp.md`](docs/dev-tools/fsk-mcp.md) — one-time setup for the `dev-tools/fsk-mcp`
+  MCP bridge that lets an agent drive a running Freeboard-SK (map view, routes,
+  filters, live data) during debugging. Read once when wiring it up.

--- a/dev-tools/fsk-mcp/.gitignore
+++ b/dev-tools/fsk-mcp/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+public
+*.log
+.DS_Store

--- a/dev-tools/fsk-mcp/README.md
+++ b/dev-tools/fsk-mcp/README.md
@@ -1,0 +1,47 @@
+# fsk-mcp — agent bridge for Freeboard-SK (dev only)
+
+A small Signal K server plugin that lets an AI coding agent **drive a running
+Freeboard-SK** during development — set the map view, inspect and edit routes,
+query resources and push display filters — by exposing the Plotter Extensions
+host API as [MCP](https://modelcontextprotocol.io/) tools.
+
+```text
+agent ──MCP/HTTP──► fsk-mcp plugin ──WebSocket──► background runtime ──host bus──► Freeboard-SK
+        (:3013/mcp)   (Signal K server)            (hidden iframe in the FSK tab)
+```
+
+A browser page can't listen on a port, but it can dial out: the plugin's
+WebSocket server is what the Freeboard-loaded background runtime connects back
+to, so commands flow agent → plugin → runtime → host API and results return the
+same way.
+
+It is **not host-specific** — it drives whatever Plotter Extensions host is
+running — but it lives here because Freeboard-SK is the reference host and the
+primary thing you'll debug with it.
+
+> **Dev tool only.** This is a remote-control channel with no real auth beyond
+> "on your machine." It is excluded from the published `@signalk/freeboard-sk`
+> package (the `files` whitelist ships only build outputs) and must never be
+> enabled on a production/boat server. Bind it to `127.0.0.1` (the default).
+
+## Quick start
+
+```sh
+cd dev-tools/fsk-mcp && npm install          # builds the runtime into public/
+# then npm link it into your local Signal K server and enable it
+```
+
+Full setup — linking into a local server, enabling the plugin, and wiring the
+MCP endpoint into your agent — is in
+[`docs/dev-tools/fsk-mcp.md`](../../docs/dev-tools/fsk-mcp.md).
+
+## Layout
+
+| Path                 | What                                                                          |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `plugin/index.js`    | plugin entry: resource provider, asset serving, HTTP server (WS bridge + MCP) |
+| `src/manifest.js`    | the `plotterExtensions` manifest (one background runtime)                     |
+| `src/bridge-hub.js`  | WebSocket hub: session registry + call relay                                  |
+| `src/mcp-http.js`    | MCP server over Streamable HTTP                                               |
+| `src/tools.js`       | the MCP tool surface — **keep in sync with the host API**                     |
+| `src/web/runtime.js` | the browser-side bridge (bundled into `public/`)                              |

--- a/dev-tools/fsk-mcp/package-lock.json
+++ b/dev-tools/fsk-mcp/package-lock.json
@@ -1,0 +1,1676 @@
+{
+  "name": "fsk-mcp",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fsk-mcp",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ws": "^8.21.0"
+      },
+      "devDependencies": {
+        "esbuild": "^0.24.0",
+        "signalk-plotterext-bus": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signalk-plotterext-bus": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.7.3.tgz",
+      "integrity": "sha512-QTriWGmhUR8TKNr1b+Htmay907fPlCD7slwoybsJn0Zaa6mAO+QuFYtEEG3N8pP1q/N1o113Vz8Bu9IFzgjjHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/dev-tools/fsk-mcp/package.json
+++ b/dev-tools/fsk-mcp/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "fsk-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Dev-only Signal K plugin that bridges an MCP client (AI agent) to a running Freeboard-SK instance, letting the agent drive the chart plotter (map view, routes, resource filters, live data) directly during development. Never shipped in the @signalk/freeboard-sk package.",
+  "keywords": [
+    "signalk-node-server-plugin"
+  ],
+  "license": "Apache-2.0",
+  "main": "plugin/index.js",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "prepare": "node scripts/build.mjs",
+    "test": "node --test \"test/**/*.test.js\""
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ws": "^8.21.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0",
+    "signalk-plotterext-bus": "^0.7.3"
+  }
+}

--- a/dev-tools/fsk-mcp/plugin/index.js
+++ b/dev-tools/fsk-mcp/plugin/index.js
@@ -1,0 +1,316 @@
+// fsk-mcp — a dev-only Signal K plugin that lets an AI agent drive a running
+// Freeboard-SK (or any Plotter Extensions host) during development.
+//
+// Chain:  agent  --MCP/HTTP-->  this plugin  --WebSocket-->  background runtime
+//         (iframe in the Freeboard tab)  --host bus-->  the chart plotter.
+//
+// The plugin does four things on start():
+//   1. Registers the `plotterExtensions` manifest declaring one headless
+//      background runtime (served from public/runtime.html).
+//   2. Serves that runtime's assets at /plotterext/fsk-mcp/ (public, non-admin,
+//      same mechanism the reference extensions use).
+//   3. Serves bridge-config.json so the runtime learns the WS port (+ token).
+//   4. Starts a standalone HTTP server on a configurable port hosting the
+//      WebSocket bridge (/bridge) and the MCP endpoint (/mcp).
+//
+// It is NEVER shipped in @signalk/freeboard-sk (the package `files` whitelist
+// excludes dev-tools/). Install it into a local server only for development —
+// see docs/dev-tools/fsk-mcp.md.
+
+const path = require('path');
+const http = require('http');
+
+const { BridgeHub } = require('../src/bridge-hub');
+const { createMcpHttpHandler } = require('../src/mcp-http');
+const { PLUGIN_ID, ASSET_BASE, buildManifest } = require('../src/manifest');
+
+const pkg = require('../package.json');
+
+const PUBLIC_DIR = path.join(__dirname, '..', 'public');
+
+const DEFAULT_PORT = 3013;
+const DEFAULT_HOST = '127.0.0.1';
+const BRIDGE_PATH = '/bridge';
+const MCP_PATH = '/mcp';
+
+module.exports = (app) => {
+  let running = false;
+  let providerRegistered = false;
+  let assetsMounted = false;
+
+  // Bumped on every start()/stop(). Async server bring-up captures the value at
+  // entry and bails if it changes underneath it — so a rapid stop→start (e.g. a
+  // config save restarts the plugin) can't leave a stale server bound.
+  let generation = 0;
+
+  let hub = null;
+  let mcp = null;
+  let httpServer = null;
+  let serverClosing = null; // resolves when a torn-down server has released its port
+  let config = { port: DEFAULT_PORT, host: DEFAULT_HOST, token: '' };
+
+  const debug = (msg) => app.debug(`${PLUGIN_ID}: ${msg}`);
+
+  // Returns true when the runtime assets are (or will be) reachable: either
+  // mounted here, or there is no Express app to mount on (a minimal/test host,
+  // where the browser runtime isn't exercised). Returns false only when mounting
+  // was expected but failed — the caller must then not advertise the extension.
+  const mountAssets = () => {
+    if (assetsMounted) return true;
+    if (typeof app.use !== 'function' || typeof app.get !== 'function') {
+      return true;
+    }
+    try {
+      const serveStatic = require('express').static;
+      // bridge-config.json is dynamic (carries the runtime-configured
+      // port/token), so register it before the static mount.
+      app.get(`${ASSET_BASE}/bridge-config.json`, (_req, res) => {
+        res.json({
+          port: config.port,
+          path: BRIDGE_PATH,
+          token: config.token || undefined
+        });
+      });
+      app.use(ASSET_BASE, serveStatic(PUBLIC_DIR));
+      assetsMounted = true;
+      debug(`assets served at ${ASSET_BASE}`);
+      return true;
+    } catch (err) {
+      app.error(
+        `${PLUGIN_ID}: cannot serve ${ASSET_BASE}: ${err?.message ?? err}`
+      );
+      return false;
+    }
+  };
+
+  const registerProvider = () => {
+    if (providerRegistered) return;
+    if (typeof app.registerResourceProvider !== 'function') {
+      app.error(`${PLUGIN_ID}: server has no resource provider registry`);
+      return;
+    }
+    app.registerResourceProvider({
+      type: 'plotterExtensions',
+      methods: {
+        listResources: async () =>
+          running ? { [PLUGIN_ID]: buildManifest() } : {},
+        getResource: async (id) => {
+          if (!running || id !== PLUGIN_ID) {
+            throw new Error(`No such plotterExtensions resource: ${id}`);
+          }
+          return buildManifest();
+        },
+        setResource: async () => {
+          throw new Error(`${PLUGIN_ID} is a read-only provider`);
+        },
+        deleteResource: async () => {
+          throw new Error(`${PLUGIN_ID} is a read-only provider`);
+        }
+      }
+    });
+    providerRegistered = true;
+  };
+
+  // Bring the servers up entirely in local variables and only publish them to
+  // the shared hub/mcp/httpServer at the very end, once this generation still
+  // owns the plugin. That way an overlapping start/stop can never make one
+  // generation tear down another generation's live server.
+  const startServers = async () => {
+    const myGeneration = generation;
+    const superseded = () => !running || myGeneration !== generation;
+
+    const localHub = new BridgeHub({
+      logger: debug,
+      token: config.token || null
+    });
+    const localMcp = await createMcpHttpHandler({
+      hub: localHub,
+      logger: debug,
+      version: pkg.version,
+      token: config.token || null,
+      host: config.host,
+      port: config.port
+    });
+    // Close only what this generation built — never the shared references.
+    const abandonLocals = (server) => {
+      localMcp.close();
+      localHub.close();
+      if (server) {
+        try {
+          server.close();
+        } catch {
+          /* not listening */
+        }
+      }
+    };
+
+    if (superseded()) {
+      // stop()/restart happened while the ESM MCP SDK was importing.
+      abandonLocals();
+      return;
+    }
+
+    const localServer = http.createServer((req, res) => {
+      const url = req.url || '/';
+      if (
+        url === MCP_PATH ||
+        url.startsWith(`${MCP_PATH}?`) ||
+        url.startsWith(`${MCP_PATH}/`)
+      ) {
+        localMcp.handle(req, res);
+      } else {
+        res.writeHead(404, { 'content-type': 'text/plain' });
+        res.end('fsk-mcp: not found\n');
+      }
+    });
+    localHub.attach(localServer, BRIDGE_PATH); // handles WS upgrades on BRIDGE_PATH
+
+    // Wait for a previous instance's server to finish releasing the port before
+    // binding — a quick stop→start (e.g. a config save) otherwise races EADDRINUSE.
+    if (serverClosing) {
+      await serverClosing;
+      if (superseded()) {
+        abandonLocals(localServer);
+        return;
+      }
+    }
+
+    try {
+      await new Promise((resolve, reject) => {
+        localServer.once('error', reject);
+        localServer.listen(config.port, config.host, () => {
+          localServer.off('error', reject);
+          resolve();
+        });
+      });
+    } catch (err) {
+      abandonLocals(localServer); // e.g. EADDRINUSE — clean up this generation
+      throw err; // surfaced by start()'s (generation-guarded) catch
+    }
+
+    // Keep a permanent handler: a later async server error (EMFILE, socket
+    // failures) with no listener is an uncaught exception that would take the
+    // whole Signal K process down.
+    localServer.on('error', (err) => {
+      app.error(
+        `${PLUGIN_ID}: bridge/MCP server error: ${err?.message ?? err}`
+      );
+    });
+
+    if (superseded()) {
+      abandonLocals(localServer); // stopped/restarted while binding
+      return;
+    }
+
+    // We still own the plugin: publish and go live.
+    hub = localHub;
+    mcp = localMcp;
+    httpServer = localServer;
+    const wildcard = config.host === '0.0.0.0' || config.host === '::';
+    app.setPluginStatus(
+      wildcard
+        ? `MCP + bridge listening on port ${config.port} (bound to ${config.host} — connect via this host's address)`
+        : `MCP on http://${config.host}:${config.port}${MCP_PATH}, bridge on ws://${config.host}:${config.port}${BRIDGE_PATH}`
+    );
+    debug(
+      `listening on ${config.host}:${config.port} (mcp ${MCP_PATH}, bridge ${BRIDGE_PATH})`
+    );
+  };
+
+  const teardown = () => {
+    if (mcp) mcp.close();
+    if (hub) hub.close();
+    if (httpServer) {
+      const closing = httpServer;
+      serverClosing = new Promise((resolve) => {
+        try {
+          closing.close(() => resolve());
+        } catch {
+          resolve();
+        }
+      });
+    }
+    mcp = null;
+    hub = null;
+    httpServer = null;
+  };
+
+  return {
+    id: PLUGIN_ID,
+    name: 'FSK MCP Bridge (dev)',
+    description:
+      'Dev-only: exposes an MCP server that drives a running Freeboard-SK for agent-assisted debugging. Not for production installs.',
+    schema: () => ({
+      type: 'object',
+      properties: {
+        port: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 65535,
+          title: 'Bridge / MCP port',
+          description:
+            'Port for the WebSocket bridge and MCP endpoint (kept off 3000).',
+          default: DEFAULT_PORT
+        },
+        host: {
+          type: 'string',
+          title: 'Bind address',
+          description:
+            'Interface to bind. 127.0.0.1 (default) keeps it local to this machine; use 0.0.0.0 only on a trusted dev LAN, and set a token.',
+          default: DEFAULT_HOST
+        },
+        token: {
+          type: 'string',
+          title: 'Shared token (optional)',
+          description:
+            'If set, guards both the WebSocket bridge and the MCP endpoint (agents send it as "Authorization: Bearer <token>"). A light guard for non-loopback binds — it is delivered to the runtime via the public bridge-config.json, so it is not a strong secret; prefer binding to 127.0.0.1.',
+          default: ''
+        }
+      }
+    }),
+
+    start(options) {
+      running = true;
+      generation += 1;
+      const myGeneration = generation;
+      config = {
+        port: Number(options?.port) || DEFAULT_PORT,
+        host: options?.host || DEFAULT_HOST,
+        token: options?.token || ''
+      };
+      if (!mountAssets()) {
+        // Assets couldn't be served, so a runtime Freeboard loaded could never
+        // fetch its page. Don't advertise the extension at all.
+        running = false;
+        app.setPluginError(
+          `cannot serve extension assets — ${PLUGIN_ID} disabled`
+        );
+        return;
+      }
+      registerProvider();
+      // Server bring-up is async (ESM MCP SDK import + listen); don't block the
+      // server's start(). Surface failures as plugin status rather than crashing.
+      startServers().catch((err) => {
+        // startServers cleaned up its own local instances; just report — and
+        // only if this is still the active generation.
+        if (myGeneration !== generation) return;
+        // Stop advertising the extension: with no bridge behind it, a runtime
+        // Freeboard loaded would only fail to connect. listResources() gates on
+        // `running`, so this removes fsk-mcp from the plotterExtensions set.
+        running = false;
+        app.error(
+          `${PLUGIN_ID}: failed to start bridge/MCP server: ${err?.message ?? err}`
+        );
+        app.setPluginError(`bridge/MCP server failed: ${err?.message ?? err}`);
+      });
+      debug('started');
+    },
+
+    stop() {
+      running = false;
+      generation += 1;
+      teardown();
+      debug('stopped');
+    }
+  };
+};

--- a/dev-tools/fsk-mcp/scripts/build.mjs
+++ b/dev-tools/fsk-mcp/scripts/build.mjs
@@ -1,0 +1,46 @@
+// Bundle the browser-side background runtime into public/, which the plugin
+// serves as a static route at /plotterext/fsk-mcp/. Mirrors the reference
+// extensions' build (esbuild -> IIFE bundle + a generated HTML shell).
+//
+// NB: all progress goes to stderr. Signal K's "verify npm pack" step parses
+// `npm pack --json` from stdout, and npm may run prepare scripts even with
+// --ignore-scripts; keeping stdout clean avoids breaking that JSON. (fsk-mcp
+// is never packed, but the habit is cheap and correct.)
+
+import { build } from 'esbuild';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pub = join(root, 'public');
+mkdirSync(join(pub, 'js'), { recursive: true });
+
+await build({
+  entryPoints: [join(root, 'src/web/runtime.js')],
+  bundle: true,
+  format: 'iife',
+  outdir: join(pub, 'js'),
+  sourcemap: true,
+  target: ['es2020'],
+  logLevel: 'info'
+});
+
+writeFileSync(
+  join(pub, 'runtime.html'),
+  `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>fsk-mcp runtime</title>
+</head>
+<body>
+<!-- Headless background runtime: no UI. Bridges the fsk-mcp plugin's
+     WebSocket to the host chartplotter's Plotter Extensions API. -->
+<script src="js/runtime.js"></script>
+</body>
+</html>
+`
+);
+
+console.error('fsk-mcp: public/ runtime built');

--- a/dev-tools/fsk-mcp/src/bridge-hub.js
+++ b/dev-tools/fsk-mcp/src/bridge-hub.js
@@ -1,0 +1,243 @@
+// The WebSocket hub (Signal K server side).
+//
+// Each connected Freeboard-SK tab loads the background runtime, which dials in
+// here. One WS connection == one "session". The hub tracks sessions, relays
+// host-API calls to a chosen session, and matches replies back to their caller
+// by correlation id. This is the pure transport/relay layer — it knows nothing
+// about MCP or about which host methods exist.
+
+const { WebSocketServer } = require('ws');
+const { randomUUID } = require('node:crypto');
+
+const HEARTBEAT_MS = 30000;
+const HELLO_TIMEOUT_MS = 15000;
+
+class BridgeHub {
+  constructor({ logger, token, callTimeoutMs = 15000 } = {}) {
+    this.log = logger || (() => {});
+    this.token = token || null;
+    this.callTimeoutMs = callTimeoutMs;
+    this.connections = new Set(); // every live socket, pre- and post-hello
+    this.sessions = new Map(); // sessionId -> session (only after a valid hello)
+    this.order = []; // sessionIds oldest -> newest
+    this.wss = null;
+    this.heartbeat = null;
+  }
+
+  attach(httpServer, path = '/bridge') {
+    this.wss = new WebSocketServer({ server: httpServer, path });
+    // ws re-emits the http server's 'error' (e.g. EADDRINUSE) on the wss; with
+    // no listener that is an uncaught exception that would crash the process.
+    this.wss.on('error', (err) =>
+      this.log(`bridge: WebSocket server error: ${err?.message ?? err}`)
+    );
+    this.wss.on('connection', (ws) => this._onConnection(ws));
+    this.heartbeat = setInterval(() => this._sweep(), HEARTBEAT_MS);
+    if (this.heartbeat.unref) this.heartbeat.unref();
+  }
+
+  _onConnection(ws) {
+    const session = {
+      id: randomUUID(),
+      ws,
+      hello: null,
+      pending: new Map(),
+      connectedAt: new Date().toISOString(),
+      alive: true,
+      helloTimer: null
+    };
+    // Track the socket immediately so the heartbeat sweep and shutdown reach a
+    // client that upgrades but never sends `hello`; drop it if it stays silent.
+    this.connections.add(session);
+    session.helloTimer = setTimeout(() => {
+      if (!session.hello) {
+        this.log(`bridge: closing socket that never sent hello`);
+        try {
+          ws.close(4002, 'no hello');
+        } catch {
+          /* already closing */
+        }
+      }
+    }, HELLO_TIMEOUT_MS);
+    if (session.helloTimer.unref) session.helloTimer.unref();
+
+    ws.on('message', (data) => this._onMessage(session, data));
+    ws.on('close', () => this._onClose(session));
+    ws.on('error', () => {}); // 'close' follows; cleanup happens there
+    ws.on('pong', () => {
+      session.alive = true;
+    });
+  }
+
+  _onMessage(session, data) {
+    let msg;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      return;
+    }
+    // JSON.parse('null' | '5' | 'true') succeeds but yields a non-object;
+    // dereferencing .type on those would throw out of the message handler.
+    if (!msg || typeof msg !== 'object') return;
+    if (msg.type === 'hello') this._onHello(session, msg);
+    else if (msg.type === 'result' || msg.type === 'error')
+      this._onReply(session, msg);
+    else if (msg.type === 'pong') session.alive = true;
+  }
+
+  _onHello(session, msg) {
+    if (session.helloTimer) {
+      clearTimeout(session.helloTimer);
+      session.helloTimer = null;
+    }
+    // Ignore a repeat hello on an already-registered socket — re-registering
+    // would duplicate the session id in `this.order`.
+    if (session.hello) return;
+    if (this.token && msg.token !== this.token) {
+      this.log(`bridge: rejecting session ${session.id} (bad token)`);
+      try {
+        session.ws.close(4001, 'unauthorized');
+      } catch {
+        /* already closing */
+      }
+      return;
+    }
+    session.hello = {
+      host: msg.host,
+      hostVersion: msg.hostVersion,
+      apiVersion: msg.apiVersion,
+      capabilities: Array.isArray(msg.capabilities) ? msg.capabilities : [],
+      context: msg.context
+    };
+    this.sessions.set(session.id, session);
+    this.order.push(session.id);
+    this.log(
+      `bridge: session ${session.id} connected ` +
+        `(host=${msg.host}@${msg.hostVersion}, ${session.hello.capabilities.length} caps)`
+    );
+  }
+
+  _onReply(session, msg) {
+    const pending = session.pending.get(msg.id);
+    if (!pending) return;
+    session.pending.delete(msg.id);
+    clearTimeout(pending.timer);
+    if (msg.type === 'result') {
+      pending.resolve(msg.result);
+    } else {
+      const err = new Error(msg.error?.message || 'host API error');
+      err.reason = msg.error?.reason;
+      pending.reject(err);
+    }
+  }
+
+  _onClose(session) {
+    this.connections.delete(session);
+    if (session.helloTimer) clearTimeout(session.helloTimer);
+    const known = this.sessions.delete(session.id);
+    this.order = this.order.filter((id) => id !== session.id);
+    for (const pending of session.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('bridge session closed'));
+    }
+    session.pending.clear();
+    if (known) this.log(`bridge: session ${session.id} closed`);
+  }
+
+  _sweep() {
+    // Iterate every socket (including pre-hello) so a dead one is always reaped.
+    for (const session of this.connections) {
+      if (!session.alive) {
+        try {
+          session.ws.terminate();
+        } catch {
+          /* ignore */
+        }
+        continue;
+      }
+      session.alive = false;
+      try {
+        session.ws.ping();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  listSessions() {
+    return this.order.map((id) => {
+      const s = this.sessions.get(id);
+      return {
+        session: id,
+        host: s.hello?.host,
+        hostVersion: s.hello?.hostVersion,
+        apiVersion: s.hello?.apiVersion,
+        capabilities: s.hello?.capabilities ?? [],
+        connectedAt: s.connectedAt
+      };
+    });
+  }
+
+  _resolve(sessionId) {
+    if (sessionId) {
+      const s = this.sessions.get(sessionId);
+      if (!s) throw new Error(`no such session: ${sessionId}`);
+      return s;
+    }
+    if (this.order.length === 0) {
+      throw new Error(
+        'no Freeboard-SK runtime is connected — open Freeboard-SK with the fsk-mcp plugin enabled'
+      );
+    }
+    return this.sessions.get(this.order[this.order.length - 1]); // most recent
+  }
+
+  // Relay a host-API call to a session and await its reply.
+  call(method, params, { session } = {}) {
+    const s = this._resolve(session);
+    const id = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        s.pending.delete(id);
+        reject(
+          new Error(
+            `host call timed out after ${this.callTimeoutMs}ms: ${method}`
+          )
+        );
+      }, this.callTimeoutMs);
+      s.pending.set(id, { resolve, reject, timer });
+      try {
+        s.ws.send(JSON.stringify({ type: 'call', id, method, params }));
+      } catch (err) {
+        clearTimeout(timer);
+        s.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  close() {
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    for (const session of this.connections) {
+      if (session.helloTimer) clearTimeout(session.helloTimer);
+      // Reject in-flight calls now — the ws 'close' cleanup is async, so
+      // otherwise they linger until their timeout during shutdown.
+      for (const pending of session.pending.values()) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error('bridge hub closed'));
+      }
+      session.pending.clear();
+      try {
+        session.ws.close(1001, 'server shutting down');
+      } catch {
+        /* ignore */
+      }
+    }
+    this.connections.clear();
+    this.sessions.clear();
+    this.order = [];
+    if (this.wss) this.wss.close();
+  }
+}
+
+module.exports = { BridgeHub };

--- a/dev-tools/fsk-mcp/src/manifest.js
+++ b/dev-tools/fsk-mcp/src/manifest.js
@@ -1,0 +1,43 @@
+// The plotterExtensions manifest this plugin advertises. Kept separate so its
+// shape can be unit-tested without starting the bridge/MCP servers.
+//
+// It declares one headless background runtime and requires only
+// `background.iframe`; every host capability the runtime might drive is
+// `optional`, so the bridge mounts on any conforming host and simply reports a
+// capability error if the agent calls a method the host doesn't implement.
+
+const pkg = require('../package.json');
+
+const PLUGIN_ID = 'fsk-mcp';
+const ASSET_BASE = `/plotterext/${PLUGIN_ID}`;
+
+function buildManifest() {
+  return {
+    name: 'FSK MCP Bridge (dev)',
+    description:
+      'Development bridge: lets an MCP client (AI agent) drive this chart plotter via a headless background runtime.',
+    version: pkg.version,
+    apiVersion: '1',
+    requires: ['background.iframe'],
+    optional: [
+      'map',
+      'routes',
+      'resources',
+      'resources.filter',
+      'signalk.stream',
+      'signalk.put',
+      'units',
+      'ui'
+    ],
+    background: [
+      {
+        id: 'bridge',
+        title: 'FSK MCP Bridge',
+        type: 'iframe',
+        url: `${ASSET_BASE}/runtime.html`
+      }
+    ]
+  };
+}
+
+module.exports = { PLUGIN_ID, ASSET_BASE, buildManifest };

--- a/dev-tools/fsk-mcp/src/mcp-http.js
+++ b/dev-tools/fsk-mcp/src/mcp-http.js
@@ -1,0 +1,214 @@
+// MCP server over Streamable HTTP.
+//
+// The agent connects here as a remote MCP server (POST/GET/DELETE on /mcp).
+// Tool calls are dispatched to the declarative TOOLS table and relayed to the
+// browser runtime through the bridge hub. The MCP SDK is ESM-only, so it is
+// pulled in with a dynamic import() from this CommonJS plugin.
+
+const { randomUUID } = require('node:crypto');
+const { TOOLS } = require('./tools');
+
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    let aborted = false;
+    req.on('data', (chunk) => {
+      size += chunk.length; // byte length — the cap is a byte limit
+      if (size > MAX_BODY_BYTES) {
+        aborted = true;
+        reject(new Error('request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      if (aborted) return;
+      const text = Buffer.concat(chunks).toString('utf8'); // decode once, whole
+      try {
+        resolve(text ? JSON.parse(text) : undefined);
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJsonRpcError(res, status, message, id = null) {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(
+    JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message }, id })
+  );
+}
+
+// Build an MCP handler bound to a bridge hub. Returns { handle(req,res), close() }.
+// When `token` is set, every MCP request must present `Authorization: Bearer <token>`
+// — so the token guards the MCP endpoint as well as the WebSocket bridge, which
+// matters if the server is bound to a non-loopback interface.
+//
+// On a loopback bind we also turn on the SDK's DNS-rebinding protection with a
+// localhost Host allow-list: that is the interface a malicious web page could try
+// to reach via DNS rebinding, and the guard rejects any request whose Host header
+// isn't one of ours. A non-loopback (LAN) bind can't enumerate its valid hosts,
+// so it relies on the token instead.
+async function createMcpHttpHandler({
+  hub,
+  logger,
+  version,
+  token,
+  host,
+  port
+}) {
+  const log = logger || (() => {});
+  const isLoopback =
+    host === '127.0.0.1' || host === 'localhost' || host === '::1';
+  const dnsGuard = isLoopback
+    ? {
+        enableDnsRebindingProtection: true,
+        allowedHosts: [
+          `127.0.0.1:${port}`,
+          `localhost:${port}`,
+          `[::1]:${port}`
+        ]
+      }
+    : {};
+  const authorized = (req) =>
+    !token || req.headers['authorization'] === `Bearer ${token}`;
+  const [{ Server }, { StreamableHTTPServerTransport }, types] =
+    await Promise.all([
+      import('@modelcontextprotocol/sdk/server/index.js'),
+      import('@modelcontextprotocol/sdk/server/streamableHttp.js'),
+      import('@modelcontextprotocol/sdk/types.js')
+    ]);
+  const { ListToolsRequestSchema, CallToolRequestSchema, isInitializeRequest } =
+    types;
+
+  const makeServer = () => {
+    const server = new Server(
+      { name: 'fsk-mcp', version: version || '0.0.0' },
+      {
+        capabilities: { tools: {} },
+        instructions:
+          'Drive a running Freeboard-SK chart plotter for debugging: set the map view, ' +
+          'inspect and edit routes, query resources and push display filters. ' +
+          'Start with fsk_list_sessions; use fsk_call for any host API method without a dedicated tool.'
+      }
+    );
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: TOOLS.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema
+      }))
+    }));
+
+    server.setRequestHandler(CallToolRequestSchema, async (req) => {
+      const tool = TOOLS.find((t) => t.name === req.params.name);
+      if (!tool) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Unknown tool: ${req.params.name}` }]
+        };
+      }
+      try {
+        const result = await tool.run(hub, req.params.arguments || {});
+        return {
+          content: [
+            { type: 'text', text: JSON.stringify(result ?? null, null, 2) }
+          ]
+        };
+      } catch (err) {
+        const reason = err?.reason ? ` (reason: ${err.reason})` : '';
+        return {
+          isError: true,
+          content: [
+            { type: 'text', text: `Error: ${err?.message ?? err}${reason}` }
+          ]
+        };
+      }
+    });
+
+    return server;
+  };
+
+  const transports = new Map(); // sessionId -> transport
+
+  async function handle(req, res) {
+    try {
+      if (!authorized(req)) {
+        res.writeHead(401, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: { code: -32001, message: 'unauthorized' },
+            id: null
+          })
+        );
+        return;
+      }
+      if (req.method === 'POST') {
+        const body = await readJsonBody(req);
+        const sid = req.headers['mcp-session-id'];
+        let transport = sid ? transports.get(sid) : undefined;
+
+        if (!transport) {
+          if (!isInitializeRequest(body)) {
+            return sendJsonRpcError(
+              res,
+              400,
+              'No valid session — send an initialize request first',
+              body?.id ?? null
+            );
+          }
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            enableJsonResponse: true,
+            onsessioninitialized: (id) => transports.set(id, transport),
+            ...dnsGuard
+          });
+          transport.onclose = () => {
+            if (transport.sessionId) transports.delete(transport.sessionId);
+          };
+          await makeServer().connect(transport);
+        }
+        await transport.handleRequest(req, res, body);
+        return;
+      }
+
+      if (req.method === 'GET' || req.method === 'DELETE') {
+        const sid = req.headers['mcp-session-id'];
+        const transport = sid ? transports.get(sid) : undefined;
+        if (!transport)
+          return sendJsonRpcError(res, 400, 'Unknown or missing session');
+        await transport.handleRequest(req, res);
+        return;
+      }
+
+      res.writeHead(405, { allow: 'POST, GET, DELETE' }).end();
+    } catch (err) {
+      log(`mcp: request error: ${err?.message ?? err}`);
+      if (!res.headersSent)
+        sendJsonRpcError(res, 400, err?.message ?? 'bad request');
+    }
+  }
+
+  function close() {
+    for (const transport of transports.values()) {
+      try {
+        transport.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    transports.clear();
+  }
+
+  return { handle, close };
+}
+
+module.exports = { createMcpHttpHandler };

--- a/dev-tools/fsk-mcp/src/tools.js
+++ b/dev-tools/fsk-mcp/src/tools.js
@@ -1,0 +1,201 @@
+// The MCP tool surface exposed to the agent.
+//
+// ────────────────────────────────────────────────────────────────────────────
+//  KEEP IN SYNC WITH THE PLOTTER EXTENSIONS HOST API.
+//  When you add or change a host API method in Freeboard-SK
+//  (docs/api/plotter-extensions-api.md — the "Host API" table), add or update
+//  the matching curated tool below so agents get a clean, discoverable schema
+//  for it. `fsk_call` already reaches any method generically; the curated tools
+//  are for ergonomics and discoverability, and this file is the single place
+//  they live.
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Each tool declares a JSON Schema `inputSchema` and a `run(hub, args)` that
+// relays to a host-API method over the bridge. `session` selects which
+// connected Freeboard tab to drive; omit it to use the most recent.
+
+const SESSION_PROP = {
+  session: {
+    type: 'string',
+    description:
+      'Which connected Freeboard-SK runtime to target (from fsk_list_sessions). Omit to use the most recently connected one.'
+  }
+};
+
+// Merge the shared `session` property into a tool's own properties.
+function withSession(properties = {}, required = []) {
+  return {
+    type: 'object',
+    properties: { ...properties, ...SESSION_PROP },
+    required,
+    additionalProperties: false
+  };
+}
+
+const TOOLS = [
+  {
+    name: 'fsk_list_sessions',
+    description:
+      'List the connected Freeboard-SK runtimes (each open tab is one session). Returns each session id, the host name/version, its advertised capabilities, and when it connected. Use a session id with the other tools to target a specific tab.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false
+    },
+    run: (hub) => hub.listSessions()
+  },
+  {
+    name: 'fsk_call',
+    description:
+      'Generic escape hatch: call ANY Plotter Extensions host API method on the target Freeboard-SK runtime and return its result. Use this for methods without a dedicated tool (route.create, route.save, signalk.put, ui.openPanel, units.get, and any method added to the host API later). See docs/api/plotter-extensions-api.md for the method table.',
+    inputSchema: withSession(
+      {
+        method: {
+          type: 'string',
+          description:
+            'Host API method name, e.g. "map.getView", "route.list", "resources.setFilter".'
+        },
+        params: {
+          type: 'object',
+          description:
+            'Parameters object for the method (shape per the host API spec).'
+        }
+      },
+      ['method']
+    ),
+    run: (hub, a) => hub.call(a.method, a.params ?? {}, { session: a.session })
+  },
+  {
+    name: 'fsk_get_view',
+    description:
+      'Read the current map view (center [lon,lat], zoom, and bounds) from Freeboard-SK. Handy for verifying the effect of a fsk_set_view / fsk_fit_bounds call.',
+    inputSchema: withSession(),
+    run: (hub, a) => hub.call('map.getView', {}, { session: a.session })
+  },
+  {
+    name: 'fsk_set_view',
+    description:
+      'Center the Freeboard-SK map on a coordinate, optionally setting the zoom level. Longitude/latitude are in decimal degrees; zoom is a slippy-map zoom (roughly 1=world … 20=street).',
+    inputSchema: withSession(
+      {
+        longitude: {
+          type: 'number',
+          description: 'Center longitude, decimal degrees (-180..180).'
+        },
+        latitude: {
+          type: 'number',
+          description: 'Center latitude, decimal degrees (-90..90).'
+        },
+        zoom: { type: 'number', description: 'Optional target zoom level.' }
+      },
+      ['longitude', 'latitude']
+    ),
+    run: (hub, a) =>
+      hub.call(
+        'map.center',
+        a.zoom === undefined
+          ? { position: [a.longitude, a.latitude] }
+          : { position: [a.longitude, a.latitude], zoom: a.zoom },
+        { session: a.session }
+      )
+  },
+  {
+    name: 'fsk_fit_bounds',
+    description:
+      'Fit the Freeboard-SK map to a bounding box so the whole box is visible. Coordinates are decimal degrees.',
+    inputSchema: withSession(
+      {
+        minLon: { type: 'number' },
+        minLat: { type: 'number' },
+        maxLon: { type: 'number' },
+        maxLat: { type: 'number' }
+      },
+      ['minLon', 'minLat', 'maxLon', 'maxLat']
+    ),
+    run: (hub, a) =>
+      hub.call(
+        'map.fitBounds',
+        { bounds: [a.minLon, a.minLat, a.maxLon, a.maxLat] },
+        { session: a.session }
+      )
+  },
+  {
+    name: 'fsk_list_resources',
+    description:
+      "Query a Signal K resource collection through the host's authenticated session (relayed resources.list). Optionally pass a query object, e.g. { position: [lon,lat], distance: 18520 }.",
+    inputSchema: withSession(
+      {
+        type: {
+          type: 'string',
+          description: 'Resource type, e.g. "routes", "notes", "waypoints".'
+        },
+        query: {
+          type: 'object',
+          description: 'Optional query parameters for the collection.'
+        }
+      },
+      ['type']
+    ),
+    run: (hub, a) =>
+      hub.call(
+        'resources.list',
+        a.query ? { type: a.type, query: a.query } : { type: a.type },
+        {
+          session: a.session
+        }
+      )
+  },
+  {
+    name: 'fsk_set_filter',
+    description:
+      'Set a display-only filter for a resource type so Freeboard shows only (or hides) matching resources. Never modifies stored resources. `filter` follows the host API shape: { mode: "include"|"exclude", ids?, match?, label? }.',
+    inputSchema: withSession(
+      {
+        type: {
+          type: 'string',
+          description: 'Resource type to filter, e.g. "notes".'
+        },
+        filter: {
+          type: 'object',
+          description: 'Filter object per the host API (mode/ids/match/label).'
+        }
+      },
+      ['type', 'filter']
+    ),
+    run: (hub, a) =>
+      hub.call(
+        'resources.setFilter',
+        { type: a.type, filter: a.filter },
+        { session: a.session }
+      )
+  },
+  {
+    name: 'fsk_clear_filter',
+    description:
+      "Clear this tool's display filter for a resource type in Freeboard-SK.",
+    inputSchema: withSession({ type: { type: 'string' } }, ['type']),
+    run: (hub, a) =>
+      hub.call(
+        'resources.clearFilter',
+        { type: a.type },
+        { session: a.session }
+      )
+  },
+  {
+    name: 'fsk_list_routes',
+    description:
+      'List the routes currently visible on the Freeboard-SK chart (the small "visible set", not the whole stored catalogue). Each entry includes its opaque routeId plus saved/dirty flags.',
+    inputSchema: withSession(),
+    run: (hub, a) => hub.call('route.list', {}, { session: a.session })
+  },
+  {
+    name: 'fsk_get_route',
+    description:
+      'Get the full detail (name, description, points, rev, saved/dirty) of one visible route by its routeId (from fsk_list_routes).',
+    inputSchema: withSession({ routeId: { type: 'string' } }, ['routeId']),
+    run: (hub, a) =>
+      hub.call('route.get', { routeId: a.routeId }, { session: a.session })
+  }
+];
+
+module.exports = { TOOLS };

--- a/dev-tools/fsk-mcp/src/web/runtime.js
+++ b/dev-tools/fsk-mcp/src/web/runtime.js
@@ -1,0 +1,137 @@
+// fsk-mcp background-runtime bridge (browser side).
+//
+// This is a headless Plotter Extension background runtime. It does two things:
+//
+//   1. Connects to the host chartplotter (Freeboard-SK) over the standard
+//      plotterExtensions message bus, giving it the full host API surface
+//      (map.*, route.*, resources.*, signalk.*, state.*, units.get, ui.*).
+//   2. Opens an outbound WebSocket to the fsk-mcp plugin running in the Signal K
+//      server, and relays commands that arrive on it into host API calls,
+//      sending each result back.
+//
+// A browser page cannot listen on a port, but it *can* dial out; the plugin's
+// WebSocket server is what makes the agent -> plugin -> here -> host chain work.
+// Nothing here is FSK-specific: it drives whatever host answered the handshake.
+
+import { connectExtension } from 'signalk-plotterext-bus/extension';
+
+const CONFIG_URL = 'bridge-config.json'; // resolved against this iframe's origin
+const RECONNECT_MIN_MS = 1000;
+const RECONNECT_MAX_MS = 15000;
+
+function log(...args) {
+  // Recoverable/diagnostic only; the host console is where a dev sees this.
+  console.warn('[fsk-mcp runtime]', ...args);
+}
+
+async function loadConfig() {
+  const res = await fetch(CONFIG_URL, { credentials: 'include' });
+  if (!res.ok) throw new Error(`bridge-config.json ${res.status}`);
+  return res.json();
+}
+
+// The plugin serves a plain (non-TLS) WebSocket bridge on the same host the
+// iframe was served from — only the port differs. It is a local dev tool, so it
+// speaks `ws:` only; an https-origin Freeboard can't reach a plain-ws bridge
+// (browser mixed-content) — run it over http/localhost. `config.url` lets an
+// advanced setup point at an explicit endpoint (e.g. a TLS-terminating proxy).
+function bridgeUrl(config) {
+  if (config.url) return config.url;
+  const host = config.host || location.hostname;
+  const path = config.path || '/bridge';
+  return `ws://${host}:${config.port}${path}`;
+}
+
+function reasonOf(err) {
+  // Host API errors carry a stable string in error.data.reason (see spec).
+  return err?.data?.reason ?? err?.reason ?? undefined;
+}
+
+async function main() {
+  const client = await connectExtension();
+  log(
+    `handshake ok: host=${client.handshake.host}@${client.handshake.hostVersion}`,
+    `caps=[${client.capabilities.join(', ')}]`
+  );
+
+  let config;
+  try {
+    config = await loadConfig();
+  } catch (err) {
+    log('cannot read bridge-config.json — bridge disabled:', err.message);
+    return;
+  }
+
+  if (location.protocol === 'https:' && !config.url) {
+    log(
+      'page is https but the fsk-mcp bridge is plain ws — the browser will block',
+      'the connection. Run Freeboard over http/localhost for this dev tool.'
+    );
+  }
+
+  let ws = null;
+  let backoff = RECONNECT_MIN_MS;
+
+  const send = (obj) => {
+    if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(obj));
+  };
+
+  async function handleCall(msg) {
+    try {
+      const result = await client.call(msg.method, msg.params);
+      send({ type: 'result', id: msg.id, result });
+    } catch (err) {
+      send({
+        type: 'error',
+        id: msg.id,
+        error: { reason: reasonOf(err), message: err?.message ?? String(err) }
+      });
+    }
+  }
+
+  function connect() {
+    const url = bridgeUrl(config);
+    ws = new WebSocket(url);
+
+    ws.addEventListener('open', () => {
+      backoff = RECONNECT_MIN_MS;
+      log('bridge connected:', url);
+      send({
+        type: 'hello',
+        token: config.token,
+        host: client.handshake.host,
+        hostVersion: client.handshake.hostVersion,
+        apiVersion: client.apiVersion,
+        capabilities: client.capabilities,
+        context: client.context
+      });
+    });
+
+    ws.addEventListener('message', (ev) => {
+      let msg;
+      try {
+        msg = JSON.parse(ev.data);
+      } catch {
+        return;
+      }
+      // JSON.parse('null'|'5'|...) yields a non-object; guard before .type.
+      if (!msg || typeof msg !== 'object') return;
+      if (msg.type === 'call') handleCall(msg);
+      else if (msg.type === 'ping') send({ type: 'pong', id: msg.id });
+    });
+
+    ws.addEventListener('close', () => {
+      ws = null;
+      const wait = backoff;
+      backoff = Math.min(backoff * 2, RECONNECT_MAX_MS);
+      setTimeout(connect, wait);
+    });
+
+    // 'error' precedes 'close'; let close drive the reconnect so we don't race.
+    ws.addEventListener('error', () => {});
+  }
+
+  connect();
+}
+
+main().catch((err) => log('fatal:', err?.message ?? err));

--- a/dev-tools/fsk-mcp/test/bridge.test.js
+++ b/dev-tools/fsk-mcp/test/bridge.test.js
@@ -1,0 +1,394 @@
+// End-to-end relay: MCP HTTP endpoint -> bridge hub -> a fake browser runtime.
+// Exercises the full agent-facing path minus the real chart plotter host.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const WebSocket = require('ws');
+const { BridgeHub } = require('../src/bridge-hub');
+
+// Each test uses its own port: node's global fetch pools keep-alive sockets, and
+// reusing a port across a stopped+restarted server hands back a dead socket.
+let nextPort = 3096;
+const MCP_HEADERS = {
+  'content-type': 'application/json',
+  accept: 'application/json, text/event-stream'
+};
+
+function makeApp() {
+  let resolveReady;
+  const ready = new Promise((r) => (resolveReady = r));
+  const providers = [];
+  const app = {
+    providers,
+    ready,
+    debug: () => {},
+    error: () => {},
+    setPluginStatus: () => resolveReady(),
+    setPluginError: (m) => resolveReady(new Error(m)),
+    registerResourceProvider: (p) => providers.push(p)
+    // No Express app (use/get): mountAssets() skips serving in this minimal host;
+    // tests drive the bridge over a direct WebSocket, not the served runtime.
+  };
+  return app;
+}
+
+async function startPlugin(port, options = {}) {
+  const app = makeApp();
+  const plugin = require('../plugin/index.js')(app);
+  plugin.start({ port, host: '127.0.0.1', ...options });
+  const err = await app.ready;
+  if (err instanceof Error) throw err;
+  return { app, plugin };
+}
+
+// A fake host runtime: connects, says hello, answers relayed calls from a table.
+function fakeRuntime(port, { capabilities, responses }) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/bridge`);
+  ws.on('message', (data) => {
+    const msg = JSON.parse(data);
+    if (msg.type === 'call') {
+      ws.send(
+        JSON.stringify({
+          type: 'result',
+          id: msg.id,
+          result: responses[msg.method] ?? { ok: true }
+        })
+      );
+    }
+  });
+  ws.on('open', () => {
+    ws.send(
+      JSON.stringify({
+        type: 'hello',
+        host: 'test-host',
+        hostVersion: '1.0.0',
+        apiVersion: '1',
+        capabilities,
+        context: { kind: 'background' }
+      })
+    );
+  });
+  return new Promise((res) => ws.on('open', () => res(ws)));
+}
+
+// One MCP client bound to a port, holding its own session id.
+function makeClient(port) {
+  const base = `http://127.0.0.1:${port}`;
+  let session = null;
+  const mcp = async (method, params) => {
+    const headers = session
+      ? { ...MCP_HEADERS, 'mcp-session-id': session }
+      : MCP_HEADERS;
+    const res = await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: Math.floor(Math.random() * 1e6),
+        method,
+        params
+      })
+    });
+    if (res.headers.get('mcp-session-id'))
+      session = res.headers.get('mcp-session-id');
+    const text = await res.text();
+    return { status: res.status, body: text ? JSON.parse(text) : null };
+  };
+  const handshake = async () => {
+    const init = await mcp('initialize', {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0' }
+    });
+    await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: { ...MCP_HEADERS, 'mcp-session-id': session },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized'
+      })
+    });
+    return init;
+  };
+  const callTool = async (name, args = {}) =>
+    (await mcp('tools/call', { name, arguments: args })).body.result;
+  return {
+    mcp,
+    handshake,
+    callTool,
+    get session() {
+      return session;
+    }
+  };
+}
+
+test('MCP relays tool calls through the bridge to a runtime', async (t) => {
+  const port = nextPort++;
+  const { plugin } = await startPlugin(port);
+  const ws = await fakeRuntime(port, {
+    capabilities: ['map', 'routes', 'background.iframe'],
+    responses: {
+      'map.getView': { center: [-80.1, 25.8], zoom: 12 },
+      'route.list': { routes: [{ routeId: 'r1', saved: true, dirty: false }] }
+    }
+  });
+  t.after(() => {
+    ws.close();
+    plugin.stop();
+  });
+
+  const client = makeClient(port);
+  const init = await client.handshake();
+  assert.strictEqual(init.status, 200);
+  assert.strictEqual(init.body.result.serverInfo.name, 'fsk-mcp');
+  assert.ok(client.session, 'server returned a session id');
+
+  const list = await client.mcp('tools/list', {});
+  const names = list.body.result.tools.map((tool) => tool.name);
+  assert.ok(names.includes('fsk_call'));
+  assert.ok(names.includes('fsk_get_view'));
+
+  // Poll until the runtime's async hello has registered, rather than sleeping.
+  let sessions = [];
+  for (let i = 0; i < 100 && sessions.length === 0; i++) {
+    sessions = JSON.parse(
+      (await client.callTool('fsk_list_sessions')).content[0].text
+    );
+    if (sessions.length === 0) await new Promise((r) => setTimeout(r, 20));
+  }
+  assert.strictEqual(sessions.length, 1);
+  assert.strictEqual(sessions[0].host, 'test-host');
+
+  const view = JSON.parse(
+    (await client.callTool('fsk_get_view')).content[0].text
+  );
+  assert.deepStrictEqual(view.center, [-80.1, 25.8]);
+
+  const routes = JSON.parse(
+    (await client.callTool('fsk_call', { method: 'route.list' })).content[0]
+      .text
+  );
+  assert.strictEqual(routes.routes[0].routeId, 'r1');
+});
+
+test('a call to an unknown session is a clean tool error', async (t) => {
+  const port = nextPort++;
+  const { plugin } = await startPlugin(port);
+  t.after(() => plugin.stop());
+  const client = makeClient(port);
+  await client.handshake();
+  const result = await client.callTool('fsk_get_view', {
+    session: 'does-not-exist'
+  });
+  assert.strictEqual(result.isError, true);
+  assert.match(result.content[0].text, /no such session/i);
+});
+
+test('a configured token guards the MCP endpoint', async (t) => {
+  const port = nextPort++;
+  const { plugin } = await startPlugin(port, { token: 's3cret' });
+  t.after(() => plugin.stop());
+
+  const initBody = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'test', version: '0' }
+    }
+  });
+  const headers = {
+    'content-type': 'application/json',
+    accept: 'application/json, text/event-stream'
+  };
+
+  const denied = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers,
+    body: initBody
+  });
+  assert.strictEqual(denied.status, 401);
+
+  const allowed = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: { ...headers, authorization: 'Bearer s3cret' },
+    body: initBody
+  });
+  assert.strictEqual(allowed.status, 200);
+});
+
+test('a failed bind reports an error and stops advertising the extension', async (t) => {
+  const port = nextPort++;
+  const first = await startPlugin(port);
+  t.after(() => first.plugin.stop());
+
+  // Second plugin on the same port -> EADDRINUSE. Build it directly so we can
+  // inspect its provider after the (expected) failure.
+  const app = makeApp();
+  const plugin = require('../plugin/index.js')(app);
+  t.after(() => plugin.stop());
+  plugin.start({ port, host: '127.0.0.1' });
+  const err = await app.ready;
+  assert.ok(err instanceof Error, 'setPluginError fired');
+
+  // With no bridge behind it, the provider must not advertise fsk-mcp, or
+  // Freeboard would load a runtime that can never connect.
+  assert.deepStrictEqual(await app.providers[0].methods.listResources({}), {});
+});
+
+test('restart on the same port does not race EADDRINUSE', async (t) => {
+  const port = nextPort++;
+  let resolveReady;
+  const arm = () => new Promise((r) => (resolveReady = r));
+  let ready = arm();
+  const app = {
+    debug() {},
+    error() {},
+    setPluginStatus: () => resolveReady(),
+    setPluginError: (m) => resolveReady(new Error(m)),
+    registerResourceProvider() {}
+  };
+  const plugin = require('../plugin/index.js')(app);
+  t.after(() => plugin.stop());
+
+  plugin.start({ port, host: '127.0.0.1' });
+  assert.ok(!((await ready) instanceof Error), 'first start came up');
+
+  plugin.stop(); // begins async close of the listening server
+  ready = arm();
+  plugin.start({ port, host: '127.0.0.1' }); // immediate restart, same port
+  const err = await ready;
+  assert.ok(
+    !(err instanceof Error),
+    `restart must wait for port release: ${err && err.message}`
+  );
+});
+
+test('hub.close() rejects in-flight calls immediately', async (t) => {
+  const server = http.createServer();
+  const hub = new BridgeHub({});
+  hub.attach(server, '/bridge');
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/bridge`);
+  await new Promise((res, rej) => {
+    ws.once('open', res);
+    ws.once('error', rej);
+  });
+  t.after(() => {
+    try {
+      ws.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      server.close();
+    } catch {
+      /* ignore */
+    }
+  });
+  // Runtime says hello but never answers calls.
+  ws.send(
+    JSON.stringify({
+      type: 'hello',
+      host: 'test-host',
+      hostVersion: '1.0.0',
+      apiVersion: '1',
+      capabilities: [],
+      context: { kind: 'background' }
+    })
+  );
+  await new Promise((r) => setTimeout(r, 50)); // let the hello register
+
+  const pending = hub.call('map.getView', {}); // no reply will come
+  const settled = pending.then(
+    () => null,
+    (e) => e
+  );
+  hub.close(); // must reject the pending call now, not at its timeout
+  const err = await settled;
+  assert.ok(err instanceof Error);
+  assert.match(err.message, /closed/i);
+});
+
+test('does not advertise the extension when assets cannot be served', async (t) => {
+  // A host that looks like Express (use/get present) but whose mounting fails.
+  // Then the extension must not be advertised.
+  const app = makeApp();
+  app.use = () => {};
+  app.get = () => {
+    throw new Error('mount failed');
+  };
+  const plugin = require('../plugin/index.js')(app);
+  t.after(() => plugin.stop());
+  plugin.start({ port: nextPort++, host: '127.0.0.1' });
+  const err = await app.ready;
+  assert.ok(err instanceof Error, 'setPluginError fired');
+  assert.strictEqual(app.providers.length, 0, 'provider was never registered');
+});
+
+test('non-object JSON messages do not crash the hub', async (t) => {
+  const port = nextPort++;
+  const { plugin } = await startPlugin(port);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/bridge`);
+  await new Promise((res, rej) => {
+    ws.once('open', res);
+    ws.once('error', rej);
+  });
+  t.after(() => {
+    ws.close();
+    plugin.stop();
+  });
+  // JSON that parses to non-objects — would throw on msg.type without the guard.
+  for (const bad of ['null', '42', 'true', '"hello"']) ws.send(bad);
+  ws.send(
+    JSON.stringify({
+      type: 'hello',
+      host: 'test-host',
+      hostVersion: '1.0.0',
+      apiVersion: '1',
+      capabilities: [],
+      context: { kind: 'background' }
+    })
+  );
+
+  // The hub survived the junk and still registered the subsequent hello.
+  const client = makeClient(port);
+  await client.handshake();
+  let sessions = [];
+  for (let i = 0; i < 100 && sessions.length === 0; i++) {
+    sessions = JSON.parse(
+      (await client.callTool('fsk_list_sessions')).content[0].text
+    );
+    if (sessions.length === 0) await new Promise((r) => setTimeout(r, 20));
+  }
+  assert.strictEqual(sessions.length, 1);
+});
+
+test('a socket that never sends hello is still closed on shutdown', async (t) => {
+  const port = nextPort++;
+  const { plugin } = await startPlugin(port);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/bridge`);
+  await new Promise((res, rej) => {
+    ws.once('open', res);
+    ws.once('error', rej);
+  });
+  const closeCode = new Promise((res) => ws.once('close', (code) => res(code)));
+  plugin.stop(); // hub.close() must reach a pre-hello socket, not just sessions
+  assert.strictEqual(await closeCode, 1001);
+});
+
+test('provider is read-only and empties when stopped', async () => {
+  const { app, plugin } = await startPlugin(nextPort++);
+  const provider = app.providers[0];
+  assert.strictEqual(provider.type, 'plotterExtensions');
+  const list = await provider.methods.listResources({});
+  assert.ok(list['fsk-mcp']);
+  await assert.rejects(() => provider.methods.setResource('x', {}));
+  await assert.rejects(() => provider.methods.deleteResource('x'));
+  plugin.stop();
+  assert.deepStrictEqual(await provider.methods.listResources({}), {});
+});

--- a/dev-tools/fsk-mcp/test/manifest.test.js
+++ b/dev-tools/fsk-mcp/test/manifest.test.js
@@ -1,0 +1,33 @@
+// Manifest shape — pure, no servers started.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { buildManifest } = require('../src/manifest');
+
+test('declares a version-1 background-runtime extension', () => {
+  const m = buildManifest();
+  assert.strictEqual(m.apiVersion, '1');
+  assert.deepStrictEqual(m.requires, ['background.iframe']);
+  assert.strictEqual(m.background.length, 1);
+
+  const runtime = m.background[0];
+  assert.strictEqual(runtime.type, 'iframe');
+  assert.ok(runtime.url.startsWith('/plotterext/fsk-mcp/'));
+  assert.ok(runtime.url.endsWith('.html'));
+});
+
+test('contributes no visible UI (headless bridge only)', () => {
+  const m = buildManifest();
+  assert.strictEqual(m.widgets, undefined);
+  assert.strictEqual(m.panels, undefined);
+  assert.strictEqual(m.buttons, undefined);
+});
+
+test('lists the driveable host capabilities as optional, not required', () => {
+  const m = buildManifest();
+  for (const cap of ['map', 'routes', 'resources', 'resources.filter']) {
+    assert.ok(m.optional.includes(cap), `expected optional capability ${cap}`);
+    assert.ok(!m.requires.includes(cap), `${cap} must not be required`);
+  }
+});

--- a/docs/dev-tools/fsk-mcp.md
+++ b/docs/dev-tools/fsk-mcp.md
@@ -1,0 +1,158 @@
+# Driving Freeboard-SK from an agent (fsk-mcp)
+
+`dev-tools/fsk-mcp` is a **development-only** Signal K plugin that lets an AI
+coding agent control a running Freeboard-SK — set the map view, inspect and edit
+routes, run resource queries, push display filters, read live Signal K values —
+through [MCP](https://modelcontextprotocol.io/). It turns "put the chart at these
+coordinates and this zoom, then tell me what's rendered" into a tool call instead
+of a manual click-through, which is far more reliable in a verify-fix loop.
+
+This is the **one-time setup guide**. Once you've wired it up, you don't need to
+re-read this — the tools are self-describing to the agent.
+
+## How it works
+
+```text
+agent ──MCP/HTTP──► fsk-mcp plugin ──WebSocket──► background runtime ──host bus──► Freeboard-SK
+        (:3013/mcp)   (Signal K server)            (hidden iframe in the FSK tab)
+```
+
+A browser page cannot listen on a port, so the connection is established
+_outward_: Freeboard loads the plugin's headless **background runtime** (a
+standard Plotter Extension — see
+[`freeboard-plotter-ext-support.md`](../freeboard/freeboard-plotter-ext-support.md)),
+which dials the plugin's WebSocket. The plugin also serves an **MCP endpoint**
+the agent connects to, and relays each tool call down the WebSocket to the
+runtime, which invokes the host API and returns the result.
+
+Nothing here is Freeboard-specific — the runtime drives whatever host answered
+the Plotter Extensions handshake — but Freeboard-SK is the reference host and the
+usual target.
+
+## Prerequisites
+
+- A **local Signal K server** you can link dev modules into and a Freeboard-SK
+  dev build in front of it. If you don't have that yet, set it up first:
+  [`../signalk/local-dev-environment.md`](../signalk/local-dev-environment.md).
+- An MCP-capable agent (e.g. Claude Code).
+
+## Setup
+
+### 1. Install (builds the runtime)
+
+```sh
+cd dev-tools/fsk-mcp
+npm install          # runs the build; emits public/runtime.html + bundle
+```
+
+`fsk-mcp` has its own `package.json` and is **not** part of the Freeboard build
+or npm workspace, so this install is separate from the repo-root `npm i` and
+never runs in Freeboard's CI.
+
+### 2. Link the plugin into your local Signal K server
+
+Same mechanism as any dev plugin (see the local-dev guide):
+
+```sh
+# in dev-tools/fsk-mcp
+npm link
+
+# in your signalk-server checkout
+npm link fsk-mcp
+```
+
+Restart the server so it re-scans `node_modules` and discovers the plugin.
+
+### 3. Enable it in the server admin UI
+
+**Plugins start disabled.** Open _Server → Plugin Config → "FSK MCP Bridge
+(dev)"_, enable it, and (optionally) set the port — default **3013**, bind
+address **127.0.0.1**. Save. The plugin status should read something like
+`MCP on http://127.0.0.1:3013/mcp, bridge on ws://127.0.0.1:3013/bridge`.
+
+### 4. Open Freeboard-SK
+
+Open your Freeboard-SK dev build against that server in a browser. Because the
+plugin is enabled, its background runtime loads automatically and connects to the
+bridge — no UI appears (it's headless). Each open Freeboard tab is one "session".
+
+### 5. Wire the MCP endpoint into your agent
+
+For **Claude Code**:
+
+```sh
+claude mcp add --transport http fsk http://127.0.0.1:3013/mcp
+```
+
+(or add an `fsk` entry under `mcpServers` with that URL to your project's
+`.mcp.json`). Any MCP client that speaks Streamable HTTP works the same way.
+
+Confirm the chain end-to-end by asking the agent to call **`fsk_list_sessions`**
+— it should show your open Freeboard tab with the host name, version and
+capabilities. If the list is empty, see _Troubleshooting_.
+
+## Tools
+
+| Tool                                  | Drives                                | Purpose                                                                                                                   |
+| ------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `fsk_list_sessions`                   | —                                     | list connected Freeboard tabs (session id, host, version, capabilities)                                                   |
+| `fsk_call`                            | any host method                       | **generic passthrough** — call any host API method by name (covers methods without a dedicated tool, and any added later) |
+| `fsk_get_view`                        | `map.getView`                         | read center / zoom / bounds                                                                                               |
+| `fsk_set_view`                        | `map.center`                          | center on a coordinate, optionally set zoom                                                                               |
+| `fsk_fit_bounds`                      | `map.fitBounds`                       | fit the map to a bounding box                                                                                             |
+| `fsk_list_resources`                  | `resources.list`                      | query a resource collection (relayed, authenticated)                                                                      |
+| `fsk_set_filter` / `fsk_clear_filter` | `resources.setFilter` / `clearFilter` | display-only resource filters                                                                                             |
+| `fsk_list_routes` / `fsk_get_route`   | `route.list` / `route.get`            | inspect the visible routes                                                                                                |
+
+**Targeting a specific tab.** With more than one Freeboard tab open, pass a
+`session` id (from `fsk_list_sessions`) to any tool; omit it to use the most
+recently connected tab.
+
+**Anything not listed** is reachable via `fsk_call` — e.g.
+`fsk_call({ method: "route.create", params: { points: [...] } })`,
+`fsk_call({ method: "signalk.put", params: { path, value } })`,
+`fsk_call({ method: "units.get" })`. The full method table is in
+[`../api/plotter-extensions-api.md`](../api/plotter-extensions-api.md).
+
+## Security
+
+- **Dev only, never on a production/boat server.** It is a remote-control channel
+  whose only boundary is network reachability. It is excluded from the published
+  `@signalk/freeboard-sk` package and has no App Store presence.
+- **Default bind is `127.0.0.1`**, so only your machine can reach the bridge and
+  MCP endpoint — correct for the usual all-on-one-laptop dev setup. On a loopback
+  bind the MCP endpoint also enables DNS-rebinding protection (it rejects requests
+  whose `Host` header isn't localhost), so a web page you happen to be browsing
+  can't reach it.
+- If you must bind to a LAN interface (`0.0.0.0`) to reach a Freeboard tab on
+  another machine, set a **token** in the plugin config. It then guards **both**
+  the WebSocket bridge and the MCP endpoint (which otherwise takes commands from
+  anyone who can reach the port). Point your agent at it with the header:
+
+  ```sh
+  claude mcp add --transport http fsk http://<host>:3013/mcp \
+    --header "Authorization: Bearer <token>"
+  ```
+
+  It's still a _light_ guard — the runtime receives the token via the public
+  `bridge-config.json`, so treat it as friction against accidental/casual
+  connections, not a real secret. Prefer loopback whenever you can.
+
+## Troubleshooting
+
+- **`fsk_list_sessions` is empty.** Freeboard isn't open, isn't pointed at the
+  server running the plugin, or the plugin isn't enabled (the classic disabled
+  plugin — step 3). Reload the Freeboard tab after enabling.
+- **`fsk_list_sessions` stays empty and Freeboard is served over `https`.** The
+  bridge is a plain (non-TLS) WebSocket, so a browser blocks the connection from
+  an `https` page (mixed content) and no session ever registers. Run Freeboard
+  over `http`/`localhost` for this tool. The runtime logs a warning to the browser
+  console in this case.
+- **Agent can't reach the MCP endpoint.** Check the plugin status line for the
+  actual host/port, and that your agent URL matches it. A `127.0.0.1` bind is not
+  reachable from another machine.
+- **Port already in use.** Change the port in the plugin config (keep it off
+  3000, the Signal K server's own port).
+- **Commands time out.** The Freeboard tab may have been closed (its session went
+  away) or the host doesn't implement that capability — a capability error comes
+  back as a tool error naming the reason.

--- a/docs/freeboard/freeboard-plotter-ext-support.md
+++ b/docs/freeboard/freeboard-plotter-ext-support.md
@@ -108,6 +108,14 @@ persist — distinct from the user-cancel `routes.saveCancelled`),
 | `src/app/modules/plotterext/types.ts` | `HOST_API_VERSION`, `HOST_CAPABILITIES`, manifest types |
 | `src/app/modules/map/fb-map.component.ts` + `app.component.ts` | native route draw/modify/delete bridged into the registry |
 
+## Extending the host API? Update the agent bridge
+
+When you add or change a host API method here, also add or update the matching
+tool in [`../../dev-tools/fsk-mcp/src/tools.js`](../../dev-tools/fsk-mcp/src/tools.js)
+so the `fsk-mcp` dev bridge can drive the new behaviour from an agent (setup:
+[`../dev-tools/fsk-mcp.md`](../dev-tools/fsk-mcp.md)). The generic `fsk_call` tool
+already reaches any method; the curated tools are for discoverability.
+
 ## See also
 
 - [`../api/plotter-extensions-api.md`](../api/plotter-extensions-api.md) — the

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -317,6 +317,12 @@ export class AppComponent {
     effect(() => {
       const req = this.app.mapMoveRequest();
       if (req) {
+        // An explicit reposition outranks follow-vessel mode: turn it off so
+        // the requested view isn't immediately re-centered on the vessel.
+        // update() (not a reactive read) avoids a read/write feedback loop.
+        this.app.uiConfig.update((c) =>
+          c.mapMove ? { ...c, mapMove: false } : c
+        );
         this.centerAndZoom(req.center, req.zoom);
       }
     });


### PR DESCRIPTION
Two related Plotter-Extensions changes.

**1. `dev-tools/fsk-mcp` — an agent bridge (dev-only, not shipped).** A Signal K
plugin that exposes the Plotter Extensions host API as MCP tools, so an AI coding
agent can drive a running Freeboard-SK — map view, routes, resource filters, live
data — instead of clicking through the UI. It lives in the reference host so
anyone who clones the repo inherits it; `AGENTS.md` documents the one-time wiring
and a rule to keep the tools in sync as the host API grows.

*How:* a browser page can't listen on a port, so the connection is outward — the
host loads a headless background runtime that dials the plugin's WebSocket; the
plugin also serves an MCP endpoint the agent connects to and relays each tool
call to the runtime. A curated tool set plus a generic `fsk_call` passthrough
covers the whole API.

*Not shipped:* excluded from the published package (`files` whitelist), not an npm
workspace (invisible to the build/CI), loopback-bound by default.

**2. Extension reposition cancels follow-vessel mode.** An explicit
`map.center` / `map.fitBounds` is an intentional "go here", so it now outranks
follow mode instead of being immediately re-centered on the vessel. Plotter
Extensions are unreleased, so this defines previously-undefined behavior.

*Testing:* `node --test` covers the bridge relay, session addressing, auth,
teardown, and shutdown; follow-cancel verified live against Freeboard v2.28.0
through the bridge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a developer-only agent bridge for driving the app from an MCP-capable tool, including session-based control and support for map, route, and resource actions.
  * Added setup guidance for linking and using the bridge with a local environment.

* **Bug Fixes**
  * Improved map reposition handling to avoid unintended re-centering and update loops.

* **Documentation**
  * Expanded developer docs to explain the bridge workflow, setup, and supported actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->