### PR TITLE
feat(plotterext): add  chart-layer control API support

### DIFF
--- a/dev-tools/fsk-mcp/src/tools.js
+++ b/dev-tools/fsk-mcp/src/tools.js
@@ -195,6 +195,77 @@ const TOOLS = [
     inputSchema: withSession({ routeId: { type: 'string' } }, ['routeId']),
     run: (hub, a) =>
       hub.call('route.get', { routeId: a.routeId }, { session: a.session })
+  },
+  {
+    name: 'fsk_list_charts',
+    description:
+      'List the chart layers Freeboard-SK manages, in display order (topmost first). Each entry has an opaque id, name, visible flag, opacity (0..1) and best-effort type/bounds/zoom range. This is also how you read the current stacking order.',
+    inputSchema: withSession(),
+    run: (hub, a) => hub.call('chart.list', {}, { session: a.session })
+  },
+  {
+    name: 'fsk_set_chart_visibility',
+    description:
+      'Show or hide one or more chart layers by id (from fsk_list_charts). Idempotent — charts already in the requested state are unchanged.',
+    inputSchema: withSession(
+      {
+        ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Chart ids to show/hide.'
+        },
+        visible: {
+          type: 'boolean',
+          description: 'true to show, false to hide.'
+        }
+      },
+      ['ids', 'visible']
+    ),
+    run: (hub, a) =>
+      hub.call(
+        'chart.setVisibility',
+        { ids: a.ids, visible: a.visible },
+        { session: a.session }
+      )
+  },
+  {
+    name: 'fsk_set_chart_opacity',
+    description:
+      'Set the display opacity (0..1) of one or more chart layers by id (from fsk_list_charts).',
+    inputSchema: withSession(
+      {
+        ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Chart ids to retint.'
+        },
+        opacity: { type: 'number', description: 'Opacity, 0..1.' }
+      },
+      ['ids', 'opacity']
+    ),
+    run: (hub, a) =>
+      hub.call(
+        'chart.setOpacity',
+        { ids: a.ids, opacity: a.opacity },
+        { session: a.session }
+      )
+  },
+  {
+    name: 'fsk_set_chart_order',
+    description:
+      'Set the chart display/stacking order from a topmost-first list of chart ids (from fsk_list_charts). Ids you omit keep their relative order below the named ones. Order is host-clamped.',
+    inputSchema: withSession(
+      {
+        order: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Chart ids, topmost first.'
+        }
+      },
+      ['order']
+    ),
+    run: (hub, a) =>
+      hub.call('chart.setOrder', { order: a.order }, { session: a.session })
   }
 ];
 

--- a/docs/freeboard/freeboard-plotter-ext-support.md
+++ b/docs/freeboard/freeboard-plotter-ext-support.md
@@ -15,7 +15,7 @@ Freeboard-SK. The host-agnostic contracts it implements live in:
 
 The wire contract (the JSON-RPC-over-`postMessage` bus) is the
 [`signalk-plotterext-bus`](https://www.npmjs.com/package/signalk-plotterext-bus)
-package; Freeboard depends on it (`^0.7.1`) and imports its host entry point
+package; Freeboard depends on it (`^0.8.0`) and imports its host entry point
 (`signalk-plotterext-bus/host`).
 
 ## How the host works
@@ -37,7 +37,8 @@ package; Freeboard depends on it (`^0.7.1`) and imports its host entry point
 ### Capabilities Freeboard advertises (`HOST_CAPABILITIES`)
 
 `widgets`, `panels.iframe`, `buttons`, `signalk.stream`, `signalk.put`, `units`,
-`map`, `resources`, `resources.filter`, `routes`, `background.iframe`, `ui`.
+`map`, `resources`, `resources.filter`, `routes`, `charts`, `background.iframe`,
+`ui`.
 
 (The authoritative list is `HOST_CAPABILITIES` in
 `src/app/modules/plotterext/types.ts`.)
@@ -107,6 +108,68 @@ persist — distinct from the user-cancel `routes.saveCancelled`),
 | `src/app/modules/plotterext/route-methods.ts` | the `route.*` method handlers + param validation |
 | `src/app/modules/plotterext/types.ts` | `HOST_API_VERSION`, `HOST_CAPABILITIES`, manifest types |
 | `src/app/modules/map/fb-map.component.ts` + `app.component.ts` | native route draw/modify/delete bridged into the registry |
+
+## The `charts` capability
+
+`charts` is a lightweight facade over the chart layers Freeboard **already
+manages** — the same charts the user turns on and off in the chart controls. An
+extension enumerates them and changes visibility, opacity and stacking order. It
+is deliberately **not** a chart provider: no create, add, import or delete.
+
+### The chart model
+
+Freeboard's charts come from the server `charts` resource plus the built-in
+OpenStreetMap / OpenSeaMap defaults. The displayed set is `SKResourceService`'s
+`charts()` signal (bottom-first render order); which charts are on is stored in
+`app.config.selections.charts` (an explicit id list, or `null` = "show all"),
+their stacking in `selections.chartOrder`, and per-chart opacity in
+`selections.chartOpacity`. Each chart is addressed by an **opaque `id`**.
+
+### Methods
+
+`chart.list`, `chart.setVisibility({ids, visible})`,
+`chart.setOpacity({ids, opacity})`, `chart.setOrder({order})`. All mutators are
+**batch** (take a set of ids). `chart.list` returns the full available set
+(visible **and** available-but-off charts, each with a `visible` flag) in display
+order, **topmost first** — so it doubles as the way to read the current order.
+The handlers are a pure factory (`chart-methods.ts`) over accessors the service
+binds to `SKResourceService`.
+
+### Events (`chart.**`)
+
+`chart.visibility` (`{id, visible}`), `chart.opacity` (`{id, opacity}`),
+`chart.order` (`{order}`). Emitted for **every** change regardless of origin — an
+extension command *or* the user's own chart controls — by diffing successive
+`charts()` emissions in an Angular `effect`. A batch `chart.setVisibility` emits
+one `chart.visibility` per *changed* chart. `chart.order` carries the topmost-first
+order of the **displayed** charts (hidden charts have no stacking position);
+re-read `chart.list` for the full snapshot.
+
+### Freeboard specifics
+
+- **`chart.setOrder` is host-clamped.** OpenStreetMap sits at the bottom and the
+  reorder applies to the rendered (visible) charts; the request expresses relative
+  intent and the resulting order is whatever the next `chart.list` reports.
+- **Show-all vs. explicit set.** When no chart has been deselected, Freeboard runs
+  in "show all" mode (`selections.charts === null`); hiding a chart materialises
+  the explicit selection, and showing the last missing one returns to show-all —
+  matching the native chart list's behaviour so extension and user stay in sync.
+- **Opacity persists.** `chart.setOpacity` writes `selections.chartOpacity` so the
+  value survives a refresh and applies when a currently-hidden chart is shown.
+
+### Error reasons
+
+`charts.unknownId` (a supplied id names no managed chart), `charts.badRequest`
+(malformed params — e.g. a non-array `ids`, non-boolean `visible`, or out-of-range
+`opacity`), `charts.notSupported`.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `src/app/modules/plotterext/chart-methods.ts` | the `chart.*` handlers + param validation + `FBChart`→`ChartLayer` mapping |
+| `src/app/modules/plotterext/plotterext.service.ts` | binds the handlers to the service and emits `chart.*` events (`emitChartChanges`) |
+| `src/app/modules/skresources/resources.service.ts` | `chartsForHostApi` / `setChartsVisibility` / `setChartsOpacity` / `setChartsOrder` |
 
 ## Extending the host API? Update the agent bridge
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@signalk/server-api": "^2.24.0",
         "geolib": "^3.3.3",
         "google-protobuf": "^4.0.1",
-        "signalk-plotterext-bus": "^0.7.1",
+        "signalk-plotterext-bus": "^0.8.0",
         "tslib": "^2.0.0",
         "uuid": "^11.1.0"
       },
@@ -10687,9 +10687,9 @@
       }
     },
     "node_modules/signalk-plotterext-bus": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.7.1.tgz",
-      "integrity": "sha512-8x2K79MmLevNHXzAB8ef3BP5kEk5lIzaGpwohm9xtaFowKEQuy0F5ZW+Xik/4tBzwi0DB01f/0rdZGWPS0kn/w==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.8.0.tgz",
+      "integrity": "sha512-xSVAJI2u1ZQD4ky0GW9qfUQzA1ClIWBI//ugIOayyuCZ86509M8nkyLIGh3+FYMAXeG8Q8SLDpkWMpzz50lW/w==",
       "license": "MIT"
     },
     "node_modules/sigstore": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@signalk/server-api": "^2.24.0",
     "geolib": "^3.3.3",
     "google-protobuf": "^4.0.1",
-    "signalk-plotterext-bus": "^0.7.1",
+    "signalk-plotterext-bus": "^0.8.0",
     "tslib": "^2.0.0",
     "uuid": "^11.1.0"
   },

--- a/src/app/modules/plotterext/chart-methods.spec.ts
+++ b/src/app/modules/plotterext/chart-methods.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createChartMethods, toChartLayer } from './chart-methods';
+import { FBChart, FBCharts } from 'src/app/types';
+
+/** Build an FBChart tuple from a partial SKChart-shaped object. */
+function chart(
+  id: string,
+  visible: boolean,
+  props: Record<string, unknown> = {}
+): FBChart {
+  return [id, props as never, visible] as FBChart;
+}
+
+function setup(available: FBCharts = []) {
+  const deps = {
+    listAvailableOrdered: vi.fn(async () => available),
+    setVisibility: vi.fn(),
+    setOpacity: vi.fn(),
+    setOrder: vi.fn()
+  };
+  const methods = createChartMethods(deps);
+  // The bus dispatches handlers as (params, ctx); ctx is unused here.
+  const call = async (name: string, params?: unknown) =>
+    methods[name](params, {} as never);
+  return { deps, methods, call };
+}
+
+describe('toChartLayer', () => {
+  it('maps required fields and defaults opacity to 1', () => {
+    const layer = toChartLayer(chart('c1', true, { name: 'Chart One' }));
+    expect(layer).toEqual({
+      id: 'c1',
+      name: 'Chart One',
+      visible: true,
+      opacity: 1
+    });
+  });
+
+  it('falls back to id when name is missing', () => {
+    expect(toChartLayer(chart('c1', false)).name).toBe('c1');
+  });
+
+  it('includes optional fields only when present', () => {
+    const layer = toChartLayer(
+      chart('c1', true, {
+        name: 'C',
+        type: 'raster',
+        bounds: [-80.5, 25.5, -80, 26],
+        minZoom: 4,
+        maxZoom: 18,
+        defaultOpacity: 0.5
+      })
+    );
+    expect(layer).toEqual({
+      id: 'c1',
+      name: 'C',
+      visible: true,
+      opacity: 0.5,
+      type: 'raster',
+      bounds: [-80.5, 25.5, -80, 26],
+      minZoom: 4,
+      maxZoom: 18
+    });
+  });
+
+  it('omits malformed bounds', () => {
+    const layer = toChartLayer(
+      chart('c1', true, { name: 'C', bounds: [1, 2, 3] })
+    );
+    expect(layer.bounds).toBeUndefined();
+  });
+});
+
+describe('chart.list', () => {
+  it('returns the available charts mapped in order', async () => {
+    const { call } = setup([
+      chart('top', true, { name: 'Top' }),
+      chart('bottom', false, { name: 'Bottom' })
+    ]);
+    const res = (await call('chart.list')) as {
+      charts: { id: string; visible: boolean }[];
+    };
+    expect(res.charts.map((c) => c.id)).toEqual(['top', 'bottom']);
+    expect(res.charts[1].visible).toBe(false);
+  });
+});
+
+describe('chart.setVisibility', () => {
+  const available = [chart('c1', true, { name: 'C1' })];
+
+  it('shows/hides known charts', async () => {
+    const { call, deps } = setup(available);
+    const res = await call('chart.setVisibility', {
+      ids: ['c1'],
+      visible: false
+    });
+    expect(res).toEqual({});
+    expect(deps.setVisibility).toHaveBeenCalledWith(['c1'], false);
+  });
+
+  it('rejects a non-array ids with charts.badRequest', async () => {
+    const { call } = setup(available);
+    await expect(
+      call('chart.setVisibility', { ids: 'c1', visible: true })
+    ).rejects.toHaveProperty('reason', 'charts.badRequest');
+  });
+
+  it('rejects a non-boolean visible with charts.badRequest', async () => {
+    const { call } = setup(available);
+    await expect(
+      call('chart.setVisibility', { ids: ['c1'], visible: 1 })
+    ).rejects.toHaveProperty('reason', 'charts.badRequest');
+  });
+
+  it('rejects an unknown id with charts.unknownId', async () => {
+    const { call } = setup(available);
+    await expect(
+      call('chart.setVisibility', { ids: ['nope'], visible: true })
+    ).rejects.toHaveProperty('reason', 'charts.unknownId');
+  });
+
+  it('treats an empty batch as a no-op', async () => {
+    const { call, deps } = setup(available);
+    expect(
+      await call('chart.setVisibility', { ids: [], visible: true })
+    ).toEqual({});
+    expect(deps.setVisibility).not.toHaveBeenCalled();
+  });
+});
+
+describe('chart.setOpacity', () => {
+  const available = [chart('c1', true, { name: 'C1' })];
+
+  it('sets opacity on known charts', async () => {
+    const { call, deps } = setup(available);
+    await call('chart.setOpacity', { ids: ['c1'], opacity: 0.4 });
+    expect(deps.setOpacity).toHaveBeenCalledWith(['c1'], 0.4);
+  });
+
+  it('rejects opacity out of range with charts.badRequest', async () => {
+    const { call } = setup(available);
+    await expect(
+      call('chart.setOpacity', { ids: ['c1'], opacity: 1.5 })
+    ).rejects.toHaveProperty('reason', 'charts.badRequest');
+  });
+
+  it('rejects a non-number opacity with charts.badRequest', async () => {
+    const { call } = setup(available);
+    await expect(
+      call('chart.setOpacity', { ids: ['c1'], opacity: 'x' })
+    ).rejects.toHaveProperty('reason', 'charts.badRequest');
+  });
+
+  it('rejects an unknown id with charts.unknownId', async () => {
+    const { call } = setup(available);
+    await expect(
+      call('chart.setOpacity', { ids: ['nope'], opacity: 0.5 })
+    ).rejects.toHaveProperty('reason', 'charts.unknownId');
+  });
+});
+
+describe('chart.setOrder', () => {
+  const available = [
+    chart('a', true, { name: 'A' }),
+    chart('b', true, { name: 'B' })
+  ];
+
+  it('applies a topmost-first order', async () => {
+    const { call, deps } = setup(available);
+    await call('chart.setOrder', { order: ['b', 'a'] });
+    expect(deps.setOrder).toHaveBeenCalledWith(['b', 'a']);
+  });
+
+  it('rejects a non-array order with charts.badRequest', async () => {
+    const { call } = setup(available);
+    await expect(call('chart.setOrder', { order: 'b' })).rejects.toHaveProperty(
+      'reason',
+      'charts.badRequest'
+    );
+  });
+
+  it('rejects an unknown id with charts.unknownId', async () => {
+    const { call } = setup(available);
+    await expect(
+      call('chart.setOrder', { order: ['a', 'zz'] })
+    ).rejects.toHaveProperty('reason', 'charts.unknownId');
+  });
+});

--- a/src/app/modules/plotterext/chart-methods.ts
+++ b/src/app/modules/plotterext/chart-methods.ts
@@ -1,0 +1,144 @@
+import {
+  RPC_ERRORS,
+  RpcError,
+  type ChartLayer,
+  type MethodHandler
+} from 'signalk-plotterext-bus/host';
+import { FBChart, FBCharts } from 'src/app/types';
+
+/**
+ * Host method handlers for the `charts` capability — a lightweight facade over
+ * the chart layers Freeboard already manages (the same charts the user turns on
+ * and off in the chart controls). It enumerates them and changes visibility,
+ * opacity and stacking order; it is **not** a chart provider (no create/delete).
+ *
+ * A pure factory over injected accessors so the handlers are unit-testable
+ * without the Angular host service, matching the {@link createRouteMethods}
+ * pattern; the service spreads the result into each extension context's method
+ * table.
+ */
+export interface ChartMethodsDeps {
+  /**
+   * The full available chart set (server charts + built-in defaults) in display
+   * order, **topmost first** — visible charts in their stacking order, hidden
+   * charts after. Backs `chart.list` and is the source of truth for validating
+   * that supplied ids name a managed chart.
+   */
+  listAvailableOrdered: () => Promise<FBCharts>;
+  /** Show (`true`) or hide (`false`) each named chart. Idempotent. */
+  setVisibility: (ids: string[], visible: boolean) => void | Promise<void>;
+  /** Set display opacity (0..1) on each named chart. */
+  setOpacity: (ids: string[], opacity: number) => void | Promise<void>;
+  /** Set the display/stacking order, topmost first (host-clamped). */
+  setOrder: (orderTopmostFirst: string[]) => void | Promise<void>;
+}
+
+/** Map Freeboard's internal chart tuple to the host-agnostic {@link ChartLayer}. */
+export function toChartLayer(fb: FBChart): ChartLayer {
+  const [id, chart, visible] = fb;
+  const layer: ChartLayer = {
+    id,
+    name: chart?.name ?? id,
+    visible: !!visible,
+    opacity:
+      typeof chart?.defaultOpacity === 'number' ? chart.defaultOpacity : 1
+  };
+  if (chart?.type) {
+    layer.type = chart.type;
+  }
+  if (Array.isArray(chart?.bounds) && chart.bounds.length === 4) {
+    layer.bounds = [
+      chart.bounds[0],
+      chart.bounds[1],
+      chart.bounds[2],
+      chart.bounds[3]
+    ];
+  }
+  if (typeof chart?.minZoom === 'number') {
+    layer.minZoom = chart.minZoom;
+  }
+  if (typeof chart?.maxZoom === 'number') {
+    layer.maxZoom = chart.maxZoom;
+  }
+  return layer;
+}
+
+export function createChartMethods(
+  deps: ChartMethodsDeps
+): Record<string, MethodHandler> {
+  const badRequest = (message: string) =>
+    new RpcError(message, {
+      code: RPC_ERRORS.INVALID_PARAMS,
+      reason: 'charts.badRequest'
+    });
+
+  // Reject a malformed id list at the boundary so it can't reach the host
+  // services. An empty array is a legal no-op batch.
+  const requireIds = (v: unknown, field: string): string[] => {
+    if (
+      !Array.isArray(v) ||
+      v.some((x) => typeof x !== 'string' || x.length === 0)
+    ) {
+      throw badRequest(`${field} must be an array of chart ids`);
+    }
+    return v as string[];
+  };
+
+  // Every supplied id must name a chart the host currently manages, otherwise
+  // the caller is working from a stale list — surface it rather than silently
+  // dropping the id.
+  const requireKnown = (ids: string[], available: FBCharts): void => {
+    const known = new Set(available.map((c) => c[0]));
+    const unknown = ids.find((id) => !known.has(id));
+    if (unknown !== undefined) {
+      throw new RpcError(`Unknown chart id: ${unknown}`, {
+        reason: 'charts.unknownId'
+      });
+    }
+  };
+
+  return {
+    'chart.list': async () => {
+      const available = await deps.listAvailableOrdered();
+      return { charts: available.map(toChartLayer) };
+    },
+
+    'chart.setVisibility': async (params) => {
+      const ids = requireIds((params as { ids?: unknown })?.ids, 'ids');
+      const visible = (params as { visible?: unknown })?.visible;
+      if (typeof visible !== 'boolean') {
+        throw badRequest('visible must be a boolean');
+      }
+      if (ids.length > 0) {
+        requireKnown(ids, await deps.listAvailableOrdered());
+        await deps.setVisibility(ids, visible);
+      }
+      return {};
+    },
+
+    'chart.setOpacity': async (params) => {
+      const ids = requireIds((params as { ids?: unknown })?.ids, 'ids');
+      const opacity = (params as { opacity?: unknown })?.opacity;
+      if (typeof opacity !== 'number' || !Number.isFinite(opacity)) {
+        throw badRequest('opacity must be a finite number');
+      }
+      if (opacity < 0 || opacity > 1) {
+        throw badRequest('opacity must be between 0 and 1');
+      }
+      if (ids.length > 0) {
+        requireKnown(ids, await deps.listAvailableOrdered());
+        await deps.setOpacity(ids, opacity);
+      }
+      return {};
+    },
+
+    'chart.setOrder': async (params) => {
+      const order = requireIds((params as { order?: unknown })?.order, 'order');
+      if (order.length > 0) {
+        requireKnown(order, await deps.listAvailableOrdered());
+        await deps.setOrder(order);
+      }
+      return {};
+    }
+  };
+}

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -28,7 +28,7 @@ import * as uuid from 'uuid';
 import { AppFacade } from 'src/app/app.facade';
 import { SKResourceService } from 'src/app/modules/skresources/resources.service';
 import { MapService } from 'src/app/modules/map/ol/lib/map.service';
-import { FBNotes, LineString, Position } from 'src/app/types';
+import { FBCharts, FBNotes, LineString, Position } from 'src/app/types';
 import {
   HostConnection,
   MethodHandler,
@@ -59,6 +59,7 @@ import {
 } from './types';
 import { RouteBufferRegistry } from './route-buffer.registry';
 import { createRouteMethods } from './route-methods';
+import { createChartMethods } from './chart-methods';
 
 const STATE_STORAGE_KEY = 'fb-plotterext-state';
 const SK_PATH_PERIOD = 1000; // default delta period (ms) for relayed paths
@@ -582,6 +583,9 @@ export class PlotterExtensionService {
     // restored from a previous session's selection state on load. Reads
     // skres.routes() so it re-runs whenever the displayed set changes.
     effect(() => this.syncVisibleFromSelections());
+    // Emit `chart.*` events for every change to the displayed charts, whether it
+    // came from a host method or the user's own chart controls (origin-transparent).
+    effect(() => this.emitChartChanges(this.skres.charts()));
   }
 
   /**
@@ -720,6 +724,75 @@ export class PlotterExtensionService {
       onHide: (routeId) => this.hideRoute(routeId),
       onDelete: (routeId) => this.deleteRoute(routeId)
     });
+  }
+
+  /** Host API handlers for the `charts` capability. */
+  private chartMethods(): Record<string, MethodHandler> {
+    return createChartMethods({
+      listAvailableOrdered: () => this.skres.chartsForHostApi(),
+      setVisibility: (ids, visible) =>
+        this.skres.setChartsVisibility(ids, visible),
+      setOpacity: (ids, opacity) => this.skres.setChartsOpacity(ids, opacity),
+      setOrder: (order) => this.skres.setChartsOrder(order)
+    });
+  }
+
+  /** Topmost-first id order + per-chart opacity of the last displayed-chart set,
+   *  for diffing successive `skres.charts()` emissions into `chart.*` events. */
+  private prevChartSnapshot: {
+    order: string[];
+    opacity: Map<string, number>;
+  } | null = null;
+
+  /**
+   * Diff the displayed chart set against the previous snapshot and emit the
+   * fine-grained `chart.*` events. Delivery is subscription-gated by
+   * broadcastMessage. A show/hide emits `chart.visibility`; an opacity change on
+   * a still-displayed chart emits `chart.opacity`; a genuine reorder of the
+   * surviving set emits `chart.order`. The first (seeding) run emits nothing.
+   */
+  private emitChartChanges(charts: FBCharts): void {
+    const order = charts.map((c) => c[0]).reverse(); // topmost-first
+    const opacity = new Map<string, number>(
+      charts.map((c) => [
+        c[0],
+        typeof c[1]?.defaultOpacity === 'number' ? c[1].defaultOpacity : 1
+      ])
+    );
+    const prev = this.prevChartSnapshot;
+    this.prevChartSnapshot = { order, opacity };
+    if (!prev) {
+      return;
+    }
+
+    const prevSet = new Set(prev.order);
+    const currSet = new Set(order);
+    for (const id of order) {
+      if (!prevSet.has(id)) {
+        this.broadcastMessage('chart.visibility', { id, visible: true });
+      }
+    }
+    for (const id of prev.order) {
+      if (!currSet.has(id)) {
+        this.broadcastMessage('chart.visibility', { id, visible: false });
+      }
+    }
+    for (const [id, op] of opacity) {
+      const before = prev.opacity.get(id);
+      if (before !== undefined && before !== op) {
+        this.broadcastMessage('chart.opacity', { id, opacity: op });
+      }
+    }
+    // Fire chart.order only when the relative order of the charts common to both
+    // snapshots actually changed — a pure show/hide is already covered above.
+    const prevCommon = prev.order.filter((id) => currSet.has(id));
+    const currCommon = order.filter((id) => prevSet.has(id));
+    if (
+      prevCommon.length === currCommon.length &&
+      prevCommon.some((id, i) => id !== currCommon[i])
+    ) {
+      this.broadcastMessage('chart.order', { order });
+    }
   }
 
   /**
@@ -1351,6 +1424,7 @@ export class PlotterExtensionService {
         ...this.resourcesMethods(placed.extension),
         ...this.mapMethods(),
         ...this.routeMethods(),
+        ...this.chartMethods(),
         ...this.uiPanelMethods(placed.extension),
         'ui.openConfigPanel': async () => {
           this.openConfigPanel(placed);
@@ -1406,6 +1480,7 @@ export class PlotterExtensionService {
         ...this.resourcesMethods(opts.extension),
         ...this.mapMethods(),
         ...this.routeMethods(),
+        ...this.chartMethods(),
         ...this.uiPanelMethods(opts.extension),
         'ui.closePanel': async () => {
           opts.close();
@@ -1451,6 +1526,7 @@ export class PlotterExtensionService {
         ...this.resourcesMethods(opts.extension),
         ...this.mapMethods(),
         ...this.routeMethods(),
+        ...this.chartMethods(),
         ...this.uiPanelMethods(opts.extension)
       },
       onError: (err) => console.warn('plotterext background error', err)

--- a/src/app/modules/plotterext/types.ts
+++ b/src/app/modules/plotterext/types.ts
@@ -19,6 +19,7 @@ export const HOST_CAPABILITIES = [
   'resources',
   'resources.filter',
   'routes',
+  'charts',
   'background.iframe',
   'ui'
 ];

--- a/src/app/modules/skresources/resources-charts-opacity.spec.ts
+++ b/src/app/modules/skresources/resources-charts-opacity.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { SKResourceService } from './resources.service';
+import { FBCharts } from 'src/app/types';
+
+/**
+ * Regression tests for chart opacity persistence (the `chart.setOpacity` host
+ * method promises the value survives a refresh). Both paths that build chart
+ * objects must read `chartOpacity` config with a *defined* check, not a truthy
+ * one, so a fully-transparent `0` isn't dropped — and the built-in OSM charts,
+ * which bypass `transformChart`, must honor it too.
+ *
+ * `appendOSM` / `transformChart` only read `this.app`, so exercise them on a bare
+ * prototype instance with a mock app — no Angular DI needed.
+ */
+function svcWithOpacity(chartOpacity: Record<string, number>) {
+  const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+  (svc as unknown as { app: unknown }).app = {
+    config: { selections: { charts: null, chartOpacity } }
+  };
+  return svc;
+}
+
+describe('chart opacity persistence (#454)', () => {
+  it('appendOSM applies a stored opacity to the built-in OSM charts', () => {
+    const svc = svcWithOpacity({ openstreetmap: 0.3, openseamap: 0.6 });
+    const list = svc.appendOSM([]) as FBCharts;
+    const byId = Object.fromEntries(
+      list.map((c) => [c[0], c[1].defaultOpacity])
+    );
+    expect(byId['openstreetmap']).toBe(0.3);
+    expect(byId['openseamap']).toBe(0.6);
+  });
+
+  it('appendOSM honors a fully-transparent 0 (not dropped as falsy)', () => {
+    const svc = svcWithOpacity({ openstreetmap: 0 });
+    const osm = (svc.appendOSM([]) as FBCharts).find(
+      (c) => c[0] === 'openstreetmap'
+    );
+    expect(osm?.[1].defaultOpacity).toBe(0);
+  });
+
+  it('appendOSM leaves the default opacity when config has none', () => {
+    const osm = (svcWithOpacity({}).appendOSM([]) as FBCharts).find(
+      (c) => c[0] === 'openstreetmap'
+    );
+    expect(osm?.[1].defaultOpacity).toBe(1);
+  });
+
+  it('transformChart honors a stored opacity of 0 on a server chart', () => {
+    const svc = svcWithOpacity({ 'my-chart': 0 });
+    const result = (
+      svc as unknown as {
+        transformChart: (c: unknown, id: string) => { defaultOpacity: number };
+      }
+    ).transformChart(
+      { name: 'X', url: 'http://x/{z}/{x}/{y}.png' },
+      'my-chart'
+    );
+    expect(result.defaultOpacity).toBe(0);
+  });
+});

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -566,6 +566,17 @@ export class SKResourceService {
             : this.app.config.selections.charts.includes('openseamap')
       ]
     ];
+    // The built-in charts are constructed from scratch (not through
+    // transformChart), so apply any user-set opacity from config here too —
+    // otherwise a chart.setOpacity on openstreetmap/openseamap is lost on refresh.
+    if (this.app) {
+      OSM.forEach((c: FBChart) => {
+        const op = this.app.config.selections.chartOpacity[c[0]];
+        if (typeof op !== 'undefined') {
+          c[1].defaultOpacity = op;
+        }
+      });
+    }
     chtList.push(OSM[1]);
     chtList.unshift(OSM[0]);
     return chtList;
@@ -620,8 +631,9 @@ export class SKResourceService {
         chart.url = this.app.hostDef.url + chart.url;
       }
     }
-    // map local chart opacity
-    if (this.app.config.selections.chartOpacity[id]) {
+    // map local chart opacity (use a defined-check, not truthiness, so a fully
+    // transparent 0 is honored rather than silently dropped on refresh)
+    if (typeof this.app.config.selections.chartOpacity[id] !== 'undefined') {
       chart.defaultOpacity = this.app.config.selections.chartOpacity[id];
     }
     return new SKChart(chart);
@@ -826,6 +838,132 @@ export class SKResourceService {
       }
     });
     this.refreshCharts();
+  }
+
+  // **** CHARTS: Plotter Extensions host API (`charts` capability) ****
+
+  /**
+   * @description Full available chart set (server charts + built-in defaults)
+   * in host-API display order: **topmost first**. Visible charts come first in
+   * their current stacking order (the rendered order reversed); hidden charts
+   * follow. Backs the `chart.list` host method.
+   * @returns Promise resolving to an ordered FBChart array
+   */
+  public async chartsForHostApi(): Promise<FBCharts> {
+    let available: FBCharts;
+    try {
+      available = this.appendOSM(await this.listFromServer<FBChart>('charts'));
+    } catch (err) {
+      this.app.debug('** chartsForHostApi:', err);
+      available = this.appendOSM([]);
+    }
+    // Reconcile the rendered set against the freshly-fetched available charts:
+    // a chart dropped server-side may still linger in the cache, and callers
+    // treat this list as the source of truth for which ids are managed.
+    const availableIds = new Set(available.map((c: FBChart) => c[0]));
+    const visibleKnown = this.chartCacheSignal()
+      .slice()
+      .reverse()
+      .filter((c: FBChart) => availableIds.has(c[0]));
+    const seen = new Set(visibleKnown.map((c: FBChart) => c[0]));
+    const hidden = available.filter((c: FBChart) => !seen.has(c[0]));
+    return visibleKnown.concat(hidden);
+  }
+
+  /**
+   * @description Set the visibility of a set of charts to an explicit value
+   * (idempotent). Mirrors the chart-list UI's selection algorithm: recompute
+   * the visible id set, then either unfilter (all shown) or store the explicit
+   * subset. Callers should pass ids already known to be managed charts.
+   * @param ids Chart identifiers to show/hide
+   * @param visible true to show, false to hide
+   */
+  public async setChartsVisibility(ids: string[], visible: boolean) {
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return;
+    }
+    let available: FBCharts;
+    try {
+      available = this.appendOSM(await this.listFromServer<FBChart>('charts'));
+    } catch (err) {
+      // A transient fetch failure leaves us unable to reason about the current
+      // visible set; degrade like the sibling chart methods and leave the
+      // selection state untouched rather than corrupt it.
+      this.app.debug('** setChartsVisibility:', err);
+      return;
+    }
+    const nowVisible = new Set(
+      available.filter((c: FBChart) => c[2]).map((c: FBChart) => c[0])
+    );
+    let changed = false;
+    ids.forEach((id: string) => {
+      if (nowVisible.has(id) === visible) {
+        return;
+      }
+      changed = true;
+      if (visible) {
+        nowVisible.add(id);
+      } else {
+        nowVisible.delete(id);
+      }
+    });
+    if (!changed) {
+      return;
+    }
+    if (nowVisible.size >= available.length) {
+      this.selectionUnfilter('charts');
+    } else {
+      this.selectionClear('charts');
+      this.selectionAdd('charts', [...nowVisible]);
+    }
+    await this.refreshCharts();
+  }
+
+  /**
+   * @description Set display opacity (0-1) on a set of charts. Persists to
+   * config so the value survives a refresh and applies to a chart once it
+   * becomes visible; also updates the rendered cache for currently-visible ones.
+   * @param ids Chart identifiers
+   * @param value Opacity value (0-1)
+   */
+  public setChartsOpacity(ids: string[], value: number) {
+    if (
+      !Array.isArray(ids) ||
+      !Number.isFinite(value) ||
+      value < 0 ||
+      value > 1
+    ) {
+      return;
+    }
+    ids.forEach((id: string) => {
+      this.app.config.selections.chartOpacity[id] = value;
+      this.chartSetOpacity(id, value);
+    });
+    this.app.saveConfig();
+  }
+
+  /**
+   * @description Set the chart display/stacking order from a **topmost-first**
+   * id list. Ids the caller omits keep their existing relative order below the
+   * named ones. The stored `chartOrder` is bottom-first (see the chart-layers
+   * reorder), so the request is reversed before storing; `chartReorder()` then
+   * applies it to the rendered set (host-clamped to the visible charts).
+   * @param orderTopmostFirst Chart identifiers, topmost first
+   */
+  public setChartsOrder(orderTopmostFirst: string[]) {
+    if (!Array.isArray(orderTopmostFirst)) {
+      return;
+    }
+    const existing = Array.isArray(this.app.config.selections.chartOrder)
+      ? this.app.config.selections.chartOrder.slice()
+      : [];
+    const requestedBottomFirst = orderTopmostFirst.slice().reverse();
+    const named = new Set(requestedBottomFirst);
+    const remainder = existing.filter((id: string) => !named.has(id));
+    this.app.config.selections.chartOrder =
+      remainder.concat(requestedBottomFirst);
+    this.app.saveConfig();
+    this.chartReorder();
   }
 
   /**


### PR DESCRIPTION
Implements the `charts` capability of the Plotter Extensions API in the reference host (spec merged in #452, wire vocabulary in `signalk-plotterext-bus@^0.8.0`).

It gives an extension a lightweight facade over the chart layers Freeboard already manages — enumerate them and batch-toggle visibility, opacity and stacking order. It is deliberately **not** a chart provider: no create, add, import or delete of chart sources, only display management of what already exists.

## What it adds
- **Methods** (all batch): `chart.list` returns the full managed set — visible *and* available-but-hidden charts, in display order (topmost first) — plus `chart.setVisibility` / `chart.setOpacity` / `chart.setOrder`. Handlers live in a pure `chart-methods.ts` factory (mirroring `route-methods.ts`) delegating to `SKResourceService`.
- **Events**: `chart.visibility` / `chart.opacity` / `chart.order`, emitted for *every* change — an extension's command or the user's own chart controls (origin-transparent, like the route events) — by diffing the displayed-chart signal.
- `charts` added to `HOST_CAPABILITIES`; order is host-clamped and opacity persists.
- The `fsk-mcp` dev bridge gains matching `chart.*` tools.

## Testing
- Unit tests for the handlers (validation, error reasons, `FBChart`→`ChartLayer` mapping).
- Verified end-to-end against a live server: list/visibility/opacity/order and the `charts.unknownId` / `charts.badRequest` error paths all behave, and the native chart-layers panel stays in sync with API-driven changes.

Reference-host notes in `docs/freeboard/freeboard-plotter-ext-support.md`.

Closes #453


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chart management for extensions: list charts and control visibility, opacity, and display order.
  * Exposed the new `charts` capability to extension contexts and updated the corresponding documentation.
  * Added MCP tools to manage chart layers (list, show/hide, set opacity, reorder).
* **Bug Fixes**
  * Persisted per-chart opacity correctly, including fully transparent opacity (`0`), and ensured ordering/visibility stays in sync.
* **Tests**
  * Added regression coverage for chart opacity persistence and validation behavior.
* **Documentation**
  * Updated Freeboard-SK plotter extension support with the new charts capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->