### PR TITLE
feat(map): show live bearing, distance and ETA at cursor

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -62,11 +62,21 @@ export function cleanConfig(
         parameters: null,
         favourites: []
       },
-      preferInfoPanel: true
+      preferInfoPanel: true,
+      statusBar: {
+        liveEta: false,
+        referenceSpeed: 6
+      }
     };
   } else {
     if (typeof settings.display.preferInfoPanel === 'undefined') {
       settings.display.preferInfoPanel = true;
+    }
+    if (typeof settings.display.statusBar === 'undefined') {
+      settings.display.statusBar = {
+        liveEta: false,
+        referenceSpeed: 6
+      };
     }
   }
 
@@ -444,7 +454,11 @@ export function defaultConfig(): IAppConfig {
         parameters: null,
         favourites: []
       },
-      preferInfoPanel: true
+      preferInfoPanel: true,
+      statusBar: {
+        liveEta: false,
+        referenceSpeed: 6
+      }
     },
     units: {
       distance: 'kilometer',

--- a/src/app/modules/map/cursor-eta.spec.ts
+++ b/src/app/modules/map/cursor-eta.spec.ts
@@ -1,0 +1,34 @@
+import { expect, describe, it } from 'vitest';
+import { computeCursorEta } from './cursor-eta';
+import { Position } from 'src/app/types';
+
+const FROM: Position = [0, 0];
+const TO: Position = [0, 0.1]; // ~11 km due north
+
+describe('computeCursorEta', () => {
+  it('reports distance and a due-north bearing to the cursor', () => {
+    const info = computeCursorEta(FROM, TO, 5, 3);
+    expect(info.distance).toBeGreaterThan(0);
+    expect(info.bearing).toBeCloseTo(0, 0);
+  });
+
+  it('uses SOG for the ETA when under way', () => {
+    const info = computeCursorEta(FROM, TO, 5, 3);
+    expect(info.timeToGo).toBeCloseTo(info.distance / 5, 5);
+  });
+
+  it('falls back to the reference speed when SOG is ~0', () => {
+    const info = computeCursorEta(FROM, TO, 0, 3);
+    expect(info.timeToGo).toBeCloseTo(info.distance / 3, 5);
+  });
+
+  it('treats a negligible SOG as stopped and uses the reference speed', () => {
+    const info = computeCursorEta(FROM, TO, 0.01, 3);
+    expect(info.timeToGo).toBeCloseTo(info.distance / 3, 5);
+  });
+
+  it('returns a null ETA when stopped with no reference speed', () => {
+    const info = computeCursorEta(FROM, TO, 0, 0);
+    expect(info.timeToGo).toBeNull();
+  });
+});

--- a/src/app/modules/map/cursor-eta.ts
+++ b/src/app/modules/map/cursor-eta.ts
@@ -1,0 +1,40 @@
+import { getGreatCircleBearing } from 'geolib';
+import { GeoUtils } from 'src/app/lib/geoutils';
+import { Position } from 'src/app/types';
+
+/** Bearing / distance / ETA from the vessel to the cursor for the status-bar readout. */
+export interface CursorEtaInfo {
+  bearing: number; // degrees (0..360)
+  distance: number; // metres
+  timeToGo: number | null; // seconds; null when no usable speed
+}
+
+// Below this speed (m/s, ~0.1 kn) the vessel is treated as stopped and the
+// configured reference speed is used for the ETA instead of live SOG.
+const STOPPED_SOG_THRESHOLD = 0.05;
+
+/**
+ * Compute the cursor bearing, distance and ETA relative to the vessel position.
+ * Uses live SOG when under way; falls back to the reference speed (e.g. at
+ * anchor or hove to) when SOG is ~0. `timeToGo` is null when neither speed is
+ * usable.
+ * @param from vessel position `[lon, lat]`
+ * @param to cursor position `[lon, lat]`
+ * @param sog vessel speed over ground (m/s)
+ * @param referenceSpeed fallback speed (m/s) used when the vessel is stopped
+ */
+export function computeCursorEta(
+  from: Position,
+  to: Position,
+  sog: number | null | undefined,
+  referenceSpeed: number | null | undefined
+): CursorEtaInfo {
+  const distance = GeoUtils.distanceTo(from, to) ?? 0;
+  const bearing = getGreatCircleBearing(from, to) ?? 0;
+  const speed =
+    typeof sog === 'number' && sog > STOPPED_SOG_THRESHOLD
+      ? sog
+      : (referenceSpeed ?? 0);
+  const timeToGo = speed > 0 ? distance / speed : null;
+  return { bearing, distance, timeToGo };
+}

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -128,6 +128,31 @@
           ></span>
           &nbsp;
           <span [innerText]="'Zm: ' + mapZoomLevel().toFixed(1)"></span>
+          @if (cursorInfo(); as ci) {
+            &nbsp;
+            <span
+              [innerText]="
+                'Brg: ' +
+                app.formatValueForDisplay(ci.bearing, 'deg', {
+                  precision: 0
+                })
+              "
+            ></span>
+            &nbsp;
+            <span
+              [innerText]="
+                'Dist: ' + app.formatValueForDisplay(ci.distance, 'm')
+              "
+            ></span>
+            @if (ci.timeToGo !== null) {
+              &nbsp;
+              <span
+                [innerText]="
+                  'ETA: ' + app.formatValueForDisplay(ci.timeToGo, 's')
+                "
+              ></span>
+            }
+          }
         </span>
       </div>
     </ol-content>

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -46,8 +46,9 @@ import { Style, Stroke, Fill } from 'ol/style';
 import { Collection, Feature } from 'ol';
 import { Feature as GeoJsonFeature } from 'geojson';
 
-import { Convert } from 'src/app/lib/convert';
+import { Convert, TARGET_UNIT } from 'src/app/lib/convert';
 import { GeoUtils, Angle } from 'src/app/lib/geoutils';
+import { computeCursorEta, CursorEtaInfo } from './cursor-eta';
 import {
   FBRoute,
   FBRoutes,
@@ -279,6 +280,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
     coords: [0, 0],
     xy: null
   };
+  // Bearing/distance/ETA from the vessel to the cursor, shown in the status bar
+  // when the "Live ETA at cursor" option is enabled (null = hidden).
+  protected cursorInfo = signal<CursorEtaInfo | null>(null);
   contextMenuPosition = { x: '0px', y: '0px' };
   // Empty widget-anchor cell at the last right-click (or null) — gates and
   // drives the "Add widget here" context-menu item (desktop).
@@ -635,6 +639,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
     this.mouse.pixel = e.pixel;
     this.mouse.xy = e.coordinate;
     this.mouse.coords = GeoUtils.normaliseCoords(e.lonlat as Position);
+    this.updateCursorInfo(e.lonlat as Position);
     if (this.mapInteract.isMeasuring()) {
       if (
         this.mapInteract.measureGeometryType === 'LineString' &&
@@ -679,6 +684,30 @@ export class FBMapComponent implements OnInit, OnDestroy {
     if (!this.app.config.map.lockMoveMap && this.app.uiConfig().mapMove) {
       this.exitMovingMap.emit(true);
     }
+  }
+
+  // Update the status-bar cursor bearing/distance/ETA readout. Off unless the
+  // "Live ETA at cursor" option is enabled and the vessel position is known.
+  private updateCursorInfo(cursor: Position) {
+    const vessel = this.app.data.vessels.self;
+    if (
+      !this.app.config.display.statusBar?.liveEta ||
+      !vessel?.positionReceived ||
+      !vessel.position
+    ) {
+      this.cursorInfo.set(null);
+      return;
+    }
+    // referenceSpeed is stored in the user's display speed unit; convert to m/s.
+    const factor =
+      Convert.transform(1, 'm/s', this.app.config.units.speed as TARGET_UNIT) ??
+      1;
+    const refSpeed = this.app.config.display.statusBar.referenceSpeed;
+    const referenceSpeedMs =
+      factor > 0 && typeof refSpeed === 'number' ? refSpeed / factor : 0;
+    this.cursorInfo.set(
+      computeCursorEta(vessel.position, cursor, vessel.sog, referenceSpeedMs)
+    );
   }
 
   protected onMapPointerDown(e: FBPointerEvent) {

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -219,6 +219,46 @@
               </mat-card-content>
             </mat-card>
           </div>
+          <div class="setting-group">
+            <div class="setting-group-title">STATUS BAR OPTIONS</div>
+            <mat-card class="setting-card">
+              <mat-card-content>
+                <div class="setting-card-row" style="padding-bottom: 10px">
+                  <div class="setting-card-row-item">
+                    <mat-checkbox
+                      [(ngModel)]="facade.settings.display.statusBar.liveEta"
+                      (change)="persistModel()"
+                      label="after"
+                      matTooltip="Show the bearing, distance and ETA from the vessel to the cursor in the status bar (mouse only)."
+                    >
+                      Live ETA at cursor
+                    </mat-checkbox>
+                  </div>
+                  <div class="setting-card-row-item">
+                    <mat-form-field style="width: 100%" floatLabel="always">
+                      <mat-label
+                        >Reference Boat Speed ({{ speedUnitSymbol }})</mat-label
+                      >
+                      <input
+                        matInput
+                        type="number"
+                        #refspeed="ngModel"
+                        min="0"
+                        [disabled]="!facade.settings.display.statusBar.liveEta"
+                        [(ngModel)]="facade.settings.display.statusBar.referenceSpeed"
+                        (change)="parseNumber(refspeed)"
+                        matTooltip="Boat speed used to estimate ETA when SOG is unavailable (e.g. at anchor or hove to)."
+                      />
+                      @if ( refspeed.invalid && (refspeed.dirty ||
+                      refspeed.touched) ) {
+                      <mat-error>Please enter a number &gt;= 0</mat-error>
+                      }
+                    </mat-form-field>
+                  </div>
+                </div>
+              </mat-card-content>
+            </mat-card>
+          </div>
         </div>
       </div>
     </mat-tab>

--- a/src/app/modules/settings/components/settings-dialog.ts
+++ b/src/app/modules/settings/components/settings-dialog.ts
@@ -265,6 +265,11 @@ export class SettingsDialog implements OnInit {
    */
   private fallbackToDefault() {
     const dconfig = defaultConfig();
+    if (
+      typeof this.facade.settings.display.statusBar.referenceSpeed !== 'number'
+    ) {
+      return dconfig.display.statusBar.referenceSpeed;
+    }
     if (typeof this.facade.settings.map.s57Options.shallowDepth !== 'number') {
       return dconfig.map.s57Options.shallowDepth;
     }
@@ -291,6 +296,10 @@ export class SettingsDialog implements OnInit {
   persistModel(value?: string) {
     this.facade.applySettings();
     this.facade.emitChangeEvent(value);
+  }
+
+  protected get speedUnitSymbol(): string {
+    return Convert.getSymbol(this.facade.settings.units.speed);
   }
 
   /**

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -87,6 +87,10 @@ export interface IAppConfig {
       favourites: string[];
     };
     preferInfoPanel: boolean;
+    statusBar: {
+      liveEta: boolean; // show cursor bearing/distance/ETA in the status bar (mouse only)
+      referenceSpeed: number; // fallback boat speed (in display speed units) for ETA when SOG is ~0
+    };
   };
   units: {
     distance: DistanceUnitDef;


### PR DESCRIPTION
Adds an opt-in "Live ETA at cursor" readout to the map status bar: as the
mouse moves over the chart it shows the bearing, distance and ETA from the
vessel to the cursor, alongside the existing cursor lat/lon.

**Why:** requested in #328 (OpenCPN parity) — a quick "how far, what heading,
when would I get there" without setting a destination. It's a
planning/desktop aid, so it's off by default and mouse-driven; touch helm
users are unaffected.

**How:**
- New **Display → Status Bar Options** settings group: a "Live ETA at cursor"
  checkbox (default off) and a reference boat speed field.
- ETA uses live SOG when under way, falling back to the configured reference
  speed when SOG is ~0 (at anchor / hove to), so the readout stays useful when
  stopped.
- Bearing/distance/ETA all render through `formatValueForDisplay`, so they
  honour the user's unit and duration preferences.
- The calculation is a small pure function (`computeCursorEta`) with unit tests
  covering the SOG path, the reference-speed fallback, and the no-speed case.

No new Signal K paths or server calls — the vessel already provides position
and SOG on the client.

Closes #328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live cursor readouts on the map showing bearing, distance, and ETA from the vessel to the cursor.
  * Added status bar options to enable/disable Live ETA at the cursor and configure a reference boat speed for calculations.
  * Extended default configuration so the new status bar options are available out of the box.
* **Bug Fixes**
  * ETA now reliably falls back to the configured reference speed when vessel speed is unavailable or too low, and shows no ETA when neither speed source can be used.
* **Tests**
  * Added unit tests covering cursor ETA calculations, including stopped and near-zero speed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->