### PR TITLE
fix(about): derive version from package.json instead of a hardcoded literal

### DIFF
--- a/src/app/app.facade.spec.ts
+++ b/src/app/app.facade.spec.ts
@@ -4,6 +4,16 @@ import { of } from 'rxjs';
 import '@vitest/web-worker';
 import { AppFacade } from './app.facade';
 import { SignalKClient } from 'signalk-client-angular';
+import { version as PACKAGE_VERSION } from '../../package.json';
+
+describe('AppFacade app version (#458)', () => {
+  it('reports the version from package.json, not a hardcoded literal', () => {
+    TestBed.configureTestingModule({});
+    const app = TestBed.inject(AppFacade);
+    // The About box renders app.version; it must track `npm version` bumps.
+    expect(app.version).toBe(PACKAGE_VERSION);
+  });
+});
 
 describe('AppFacade.formatValueForDisplay', () => {
   let app: AppFacade;

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -24,6 +24,9 @@ import { Convert, SI_BASE_UNIT, TARGET_UNIT } from './lib/convert';
 import { SignalKClient } from 'signalk-client-angular';
 import { SKWorkerService } from './modules';
 
+// Package version — single source of truth is package.json, bumped by `npm version`
+import { version as PACKAGE_VERSION } from '../../package.json';
+
 import {
   Position,
   ErrorList,
@@ -71,7 +74,7 @@ const FSK: AppInfoDef = {
   id: 'freeboard',
   name: 'Freeboard-SK',
   description: `Signal K Chart Plotter.`,
-  version: '2.24.0',
+  version: PACKAGE_VERSION,
   url: 'https://github.com/signalk/freeboard-sk',
   logo: './assets/img/app_logo.png'
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,


### PR DESCRIPTION
## Problem

The **About** box reported a hardcoded version string (`2.24.0`) that never tracked the published package version. `npm version` bumps `package.json` and tags the release but never touched this literal, so the two drifted silently — by the `3.0.0-beta.0` release the About box was two-plus versions stale.

## Fix

Derive the version from `package.json` at build time so it can never drift again:

- `app.facade.ts` — import `version` from `package.json` and use it in the `AppInfoDef` constant that feeds the About dialog (`app.version`).
- `tsconfig.json` — add `resolveJsonModule` so the JSON import type-checks for the webapp build.

The import is a **named** import (`{ version }`), which esbuild tree-shakes: only the version string lands in the bundle, not the whole `package.json` (verified `devDependencies` does not leak into `main`).

`npm version` remains the single source of truth — cutting a release now updates the About box on the next build with no manual step. This intentionally removes a version literal; per the issue, that hand-maintained value *is* the defect.

## Test

Adds a vitest regression test asserting `app.version` equals the `package.json` version (fails at the old hardcoded `2.24.0`, passes after).

Closes #458


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app’s displayed version now automatically matches the version published in the package metadata.

* **Tests**
  * Added coverage to verify the app version is reported from the packaged version value rather than a fixed number.

* **Chores**
  * Updated build settings to support loading package metadata directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->