### PR TITLE
docs(lessons): capture the named-JSON-import trap and surface the lessons log to all contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,9 @@ See CONTRIBUTING.md / AGENTS.md for the full guidelines.
 
 <!-- How you verified it. New behaviour should have tests (npm run test:ci).
      Include before/after screenshots for visible UI changes. -->
+
+## Checklist
+
+- [ ] One logical change; version numbers untouched.
+- [ ] Skimmed [`DEV-LESSONS-LEARNED.md`](../docs/freeboard/DEV-LESSONS-LEARNED.md) for traps relevant to this change.
+- [ ] Tests added/updated for new behaviour and `npm run test:ci` passes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,13 @@ To build for release: `npm run build:prod` (webapp → `public/`, helper plugin 
 
 Before you open a PR (full detail in [`AGENTS.md`](AGENTS.md)):
 
+> **As you work each phase — coding, testing, building — skim the matching section
+> of [`docs/freeboard/DEV-LESSONS-LEARNED.md`](docs/freeboard/DEV-LESSONS-LEARNED.md)
+> first.** It records non-obvious, repo-specific traps that cost earlier
+> contributors real time (a hung `ng build`, a single-spec run that won't resolve
+> path aliases, a JSON import that bloats the bundle). Reading the relevant section
+> up front is the cheapest way to avoid re-discovering them.
+
 1. [Fork](https://help.github.com/articles/fork-a-repo/) the repo and branch from
    the latest `master`: `git checkout -b my-fix-branch master`.
 2. **One logical change per PR.** Split unrelated work into separate PRs — if the

--- a/docs/freeboard/DEV-LESSONS-LEARNED.md
+++ b/docs/freeboard/DEV-LESSONS-LEARNED.md
@@ -32,6 +32,15 @@ feedback loop — the write re-triggers the effect, which writes again.
 or snapshot method) when the same effect also mutates that state, so the read
 doesn't register a reactive dependency.
 
+### Importing one field from a large JSON — use a *named* import
+
+A default/namespace import (`import pkg from '../../package.json'`) ships the **whole
+file** — `devDependencies`, `scripts`, everything — into the client bundle, and the
+build stays green so it's invisible. Import the field by name instead
+(`import { version } from '../../package.json'`) so esbuild drops the rest; add
+`resolveJsonModule: true` to the base `tsconfig.json` for the type-check. Whole-file
+import is fine only when you genuinely use all of it (e.g. `helper/openApi.json`).
+
 ---
 
 ## When testing


### PR DESCRIPTION
## What problem does this solve?

The `DEV-LESSONS-LEARNED.md` log only helps if people actually read it at the right moment — and nothing at the point of work pushed them to. Working a recent fix surfaced both a new lesson worth recording *and* the meta-problem that the log was too easy to skip (it was, in fact, skipped, costing a redundant verification run).

## How does it work?

Two parts of one change — record the lesson, and make the mechanism reach everyone:

- **DEV-LESSONS-LEARNED.md** — new *When coding* entry: import a single field from `package.json` with a **named** import so esbuild tree-shakes it; a default/namespace import silently ships the entire manifest (`devDependencies`, `scripts`) into the client bundle.
- **CONTRIBUTING.md** — a pointer at the top of the PR steps telling contributors to skim the phase-matched section of the lessons log first. This is the surface GitHub auto-links for every human contributor.
- **.github/pull_request_template.md** — promotes the "read the guidelines" nudge out of an HTML comment into a *visible* checklist item, so every PR author sees it regardless of tooling.

No code changes; docs and contributor process only.

## How was this tested?

N/A — documentation. Verified the relative markdown links resolve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for contributors to review repo-specific coding, testing, and build notes before making changes.
  * Expanded the internal lessons guide with a bundling tip to help avoid accidentally increasing client bundle size.

* **Chores**
  * Updated the pull request template with a checklist covering change scope, relevant guidance review, and test verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->