### PR TITLE
ci(deps): refine dependabot npm groups (ignore angular majors, isolate prettier)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
           - major
           - minor
           - patch
+      # Own group: a prettier bump can reformat source and fail format:check.
+      # Isolating it keeps the reformat commit scoped to prettier's PR instead
+      # of turning the whole minor-and-patch group red. Listed before
+      # minor-and-patch so prettier is assigned here (first match wins).
+      prettier:
+        patterns:
+          - 'prettier'
       minor-and-patch:
         update-types:
           - minor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,11 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
+      # Angular majors move all @angular/* packages in lockstep; Dependabot
+      # can't express that as one group PR, so it splits into broken
+      # single-package PRs. Do Angular major upgrades manually via `ng update`.
+      - dependency-name: '@angular/*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Two Dependabot config refinements, both prompted by the Angular-22 and prettier bumps that just landed as broken/red PRs.

**1. Ignore \`@angular/*\` majors.** Angular majors move every \`@angular/*\` package in lockstep, so Dependabot can't express a framework-wide major as one group PR — it splits the \`angular\` group into individual single-package PRs that fail \`npm install\` (each peer-requires \`@angular/core\` at the new major while the rest stay behind). This just happened with #464/#465/#467. Angular majors will be done manually via \`ng update\`; minor/patch Angular bumps still flow through the existing \`angular\` group.

**2. Give prettier its own group.** A prettier bump can reformat source and fail the \`format:check\` gate, turning the whole \`minor-and-patch\` group red — as in #463 (prettier 3.8.3 → 3.9.4). Isolating prettier scopes the required reformat commit to prettier's own PR instead of blocking unrelated updates.

@coderabbitai ignore