### PR TITLE
fix(units): show sub-0.5 NM distances in the length unit instead of flooring to 0

### DIFF
--- a/src/app/app.facade.spec.ts
+++ b/src/app/app.facade.spec.ts
@@ -212,3 +212,32 @@ describe('AppFacade per-path display units (#304)', () => {
     ).toBeUndefined();
   });
 });
+
+describe('AppFacade nautical-mile short-distance formatting (#474)', () => {
+  let app: AppFacade;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    app = TestBed.inject(AppFacade);
+    app.config.units.distance = 'naut-mile';
+  });
+
+  // A distance below 0.5 NM (500 m ≈ 0.27 NM) must drop to the length unit and
+  // show the real value — the regression floored it to "0m" by displaying the
+  // sub-1 nautical-mile number under a metre symbol.
+  it('shows sub-0.5 NM distances granularly in the length unit, not a floored 0', () => {
+    app.config.units.length = 'm';
+    expect(app.formatValueForDisplay(500, 'm')).toBe('500m');
+  });
+
+  it('honours a feet length preference for sub-0.5 NM distances', () => {
+    app.config.units.length = 'foot';
+    expect(app.formatValueForDisplay(500, 'm')).toBe('1640ft');
+  });
+
+  // At/above 0.5 NM (2000 m ≈ 1.08 NM) the value stays in nautical miles.
+  it('shows distances at or above 0.5 NM in nautical miles', () => {
+    app.config.units.length = 'm';
+    expect(app.formatValueForDisplay(2000, 'm')).toBe('1.1nmi');
+  });
+});

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -1224,15 +1224,11 @@ export class AppFacade extends InfoService {
             precision
           );
         } else if (options?.category === 'length') {
-          symbol = Convert.getSymbol(this.config.units.length);
-          nv = this.formatNumericDisplay(
-            Convert.transform(
-              value,
-              sourceUnit,
-              this.config.units.length as TARGET_UNIT
-            ),
+          ({ nv, symbol } = this.formatAsLengthUnit(
+            value,
+            sourceUnit,
             precision
-          );
+          ));
         } else {
           // distance
           if (this.config.units.distance === 'kilometer' && value < 1000) {
@@ -1245,8 +1241,7 @@ export class AppFacade extends InfoService {
               this.config.units.distance
             );
             if (nm < 0.5) {
-              symbol = Convert.getSymbol(this.config.units.length);
-              nv = this.formatNumericDisplay(nm, 0);
+              ({ nv, symbol } = this.formatAsLengthUnit(value, sourceUnit, 0));
             } else {
               symbol = Convert.getSymbol(this.config.units.distance);
               nv = this.formatNumericDisplay(nm, precision);
@@ -1308,6 +1303,28 @@ export class AppFacade extends InfoService {
       : Number.isFinite(precision)
         ? value.toFixed(precision)
         : `${value}`;
+  }
+
+  /**
+   * Formats a metre value in the user's configured length unit (m/ft/…),
+   * returning the numeric text and its symbol.
+   */
+  private formatAsLengthUnit(
+    value: number,
+    sourceUnit: SI_BASE_UNIT,
+    precision: number
+  ): { nv: string; symbol: string } {
+    return {
+      nv: this.formatNumericDisplay(
+        Convert.transform(
+          value,
+          sourceUnit,
+          this.config.units.length as TARGET_UNIT
+        ),
+        precision
+      ),
+      symbol: Convert.getSymbol(this.config.units.length)
+    };
   }
 
   // convert speed value and set the value of this.app.formattedSpeedUnits


### PR DESCRIPTION
Under a nautical-mile distance preference, any distance below 0.5 NM floored to
a useless `0m`/`0ft` (Measurement tool, route drawing, vessel-relative
bearing/distance), then jumped straight to `0.5nmi` once it crossed the boundary.
Metric units were unaffected. Regression surfaced after #194.

**Cause:** the sub-0.5 NM branch of `formatValueForDisplay()` set the symbol to the
length unit but passed the *nautical-mile* value into the formatter, so e.g. 500 m
became `(0.27).toFixed(0)` → `0`.

**Fix:** convert the original metre value into the configured length unit before
formatting — the same thing the kilometre branch and the `length` category already
do. 500 m now shows `500m` (or `1640ft` with a feet preference); distances ≥ 0.5 NM
still display in nautical miles.

Added regression tests covering sub-0.5 NM (metre and feet length prefs) and the
≥ 0.5 NM case.

Closes #474


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved short-distance display when nautical miles are selected, so very small distances now show the correct converted value instead of rounding down incorrectly.
  * Kept units consistent for sub-0.5 nautical-mile values, including showing feet when that length preference is selected.
  * Distances at or above the nautical-mile threshold continue to display in nautical miles as expected.
* **Tests**
  * Added coverage for short nautical-mile formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->