### PR TITLE
ci(deps): ignore all @angular/* and typescript-major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,6 @@ updates:
     schedule:
       interval: weekly
     groups:
-      angular:
-        patterns:
-          - '@angular/*'
-          - '@angular-devkit/*'
-        update-types:
-          - major
-          - minor
-          - patch
       # Own group: a prettier bump can reformat source and fail format:check.
       # Isolating it keeps the reformat commit scoped to prettier's PR instead
       # of turning the whole minor-and-patch group red. Listed before
@@ -27,10 +19,22 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
-      # Angular majors move all @angular/* packages in lockstep; Dependabot
-      # can't express that as one group PR, so it splits into broken
-      # single-package PRs. Do Angular major upgrades manually via `ng update`.
+      # The @angular/* family must move in exact-minor lockstep. Dependabot can't
+      # guarantee that for ANY semver bump — even grouped, it bumps the subset
+      # with an available release and leaves the peer-coupled siblings
+      # (animations, cdk, material, build, router) behind, producing an
+      # unsatisfiable peer graph that fails `npm ci` on every CI job. So ignore
+      # all @angular/* updates here and do Angular upgrades via `ng update`.
       - dependency-name: '@angular/*'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
+      # TypeScript majors lead Angular's supported peer range (@angular/build
+      # pins typescript '>=5.9 <6.0'), so a TS-major bump can't install against
+      # Angular 21. Bump TS major via `ng update` when the Angular major that
+      # supports it lands; in-range TS minor/patch still flow through the groups.
+      - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
Dependabot can't move the peer-locked `@angular/*` family in exact-minor lockstep. Even with the `angular` group, it bumps only the packages that have an available release and leaves the coupled siblings (`animations`, `cdk`, `material`, `build`, `router`) behind — producing an unsatisfiable peer graph that fails `npm ci` on **every** CI job (e.g. the recurring #469 / #476 minor-and-patch PRs).

This extends the existing "Angular majors go via `ng update`" decision to **all** `@angular/*` semver bumps, and drops the `angular` group that never produced an installable PR.

It also ignores `typescript` **majors**, which lead Angular's supported peer range — `@angular/build` pins `typescript ">=5.9 <6.0"`, so TS 6.x can't install against Angular 21 (#472).

In-range TypeScript minor/patch and all non-Angular dependencies still flow through the existing groups. Angular and TS-major upgrades are done deliberately via `ng update`.


@coderabbitai ignore
