### PR TITLE
ci(deps): ignore Angular-peer-coupled ng-packagr and zone.js bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,20 @@ updates:
       # supports it lands; in-range TS minor/patch still flow through the groups.
       - dependency-name: 'typescript'
         update-types: ['version-update:semver-major']
+      # ng-packagr is peer-pinned by @angular/build (`ng-packagr@^21`), so a
+      # major bump can't install until the Angular major that requires it lands.
+      # In-range minor/patch still flow through the groups; bump the major via
+      # `ng update`.
+      - dependency-name: 'ng-packagr'
+        update-types: ['version-update:semver-major']
+      # zone.js is peer-pinned by @angular/core (`~0.15.0 || ~0.16.0`). Because
+      # zone.js is 0.x, a semver-minor bump (0.16 -> 0.17) is breaking and falls
+      # outside that range, failing `npm ci`; patch releases stay in range. Bump
+      # zone.js in step with the Angular major via `ng update`.
+      - dependency-name: 'zone.js'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
ng-packagr and zone.js are Angular-peer-coupled but don't match the existing `@angular/*` ignore, so Dependabot still opens broken major/minor PRs for them (#480 bumps ng-packagr 21→22 and fails `npm ci`: `@angular/build@21` peer-requires `ng-packagr@^21`).

- **ng-packagr** — peer-pinned by `@angular/build` (`^21`); ignore the major only (in-range minor/patch still install).
- **zone.js** — peer-pinned by `@angular/core` (`~0.15.0 || ~0.16.0`); since it's 0.x, a semver-minor (0.16→0.17) is breaking, so ignore minor + major (patch stays in range).

Move both in step with the Angular major via `ng update`. Same class as the `@angular/*` and `typescript`-major rules already in this file.

@coderabbitai ignore