### PR TITLE
feat(ais): add "Buddies only" option to the vessel filter

### DIFF
--- a/src/app/modules/map/ol/lib/resources/ais-base.component.spec.ts
+++ b/src/app/modules/map/ol/lib/resources/ais-base.component.spec.ts
@@ -95,4 +95,22 @@ describe('okToRenderTarget — Buddies only filter (#478)', () => {
     // buddy is a buddy but not in the id selection
     expect(c.okToRenderTarget('b')).toBe(false);
   });
+
+  it('ANDs with the ship-type filter', () => {
+    const buddyCargo = vessel({ buddy: true, type: { id: 70, name: 'Cargo' } });
+    const strangerCargo = vessel({
+      buddy: false,
+      type: { id: 70, name: 'Cargo' }
+    });
+    const c = component({
+      targets: new Map([
+        ['bc', buddyCargo],
+        ['sc', strangerCargo]
+      ]),
+      filterByShipType: true,
+      filterShipTypes: [70, -998]
+    });
+    expect(c.okToRenderTarget('bc')).toBe(true);
+    expect(c.okToRenderTarget('sc')).toBe(false);
+  });
 });

--- a/src/app/modules/map/ol/lib/resources/ais-base.component.spec.ts
+++ b/src/app/modules/map/ol/lib/resources/ais-base.component.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { AISBaseLayerComponent, SKTarget } from './ais-base.component';
+
+/**
+ * Behaviour tests for the vessel display filters resolved by
+ * `okToRenderTarget()` (#478). The "Buddies only" filter is a `-998` sentinel in
+ * `filterShipTypes` (mirroring the `-999` "IMO only" sentinel) and must AND with
+ * the other filters, so a target renders only when it satisfies every active one.
+ *
+ * `okToRenderTarget` only reads plain instance fields, so exercise it on a bare
+ * prototype instance — no Angular DI needed (same approach as the chart-opacity
+ * spec).
+ */
+function component(fields: {
+  targets: Map<string, SKTarget>;
+  filterShipTypes?: number[];
+  filterByShipType?: boolean;
+  filterIds?: string[];
+}) {
+  const c = Object.create(
+    AISBaseLayerComponent.prototype
+  ) as AISBaseLayerComponent;
+  Object.assign(c, fields);
+  return c as unknown as { okToRenderTarget: (id: string) => boolean };
+}
+
+function vessel(props: Partial<SKTarget>): SKTarget {
+  return { registrations: {}, ...props } as SKTarget;
+}
+
+describe('okToRenderTarget — Buddies only filter (#478)', () => {
+  const buddy = vessel({ buddy: true });
+  const stranger = vessel({ buddy: false });
+
+  it('renders every vessel when the buddies-only sentinel is absent', () => {
+    const c = component({
+      targets: new Map([
+        ['b', buddy],
+        ['s', stranger]
+      ]),
+      filterShipTypes: []
+    });
+    expect(c.okToRenderTarget('b')).toBe(true);
+    expect(c.okToRenderTarget('s')).toBe(true);
+  });
+
+  it('renders only buddies when the -998 sentinel is set', () => {
+    const c = component({
+      targets: new Map([
+        ['b', buddy],
+        ['s', stranger]
+      ]),
+      filterShipTypes: [-998]
+    });
+    expect(c.okToRenderTarget('b')).toBe(true);
+    expect(c.okToRenderTarget('s')).toBe(false);
+  });
+
+  it('hides a non-vessel target (no buddy flag) when buddies-only is set', () => {
+    const aton = vessel({}); // buddy undefined
+    const c = component({
+      targets: new Map([['a', aton]]),
+      filterShipTypes: [-998]
+    });
+    expect(c.okToRenderTarget('a')).toBe(false);
+  });
+
+  it('ANDs with IMO only — a buddy without an IMO is hidden', () => {
+    const buddyWithImo = vessel({
+      buddy: true,
+      registrations: { imo: 'IMO1234567' }
+    });
+    const buddyNoImo = vessel({ buddy: true });
+    const c = component({
+      targets: new Map([
+        ['bi', buddyWithImo],
+        ['bn', buddyNoImo]
+      ]),
+      filterShipTypes: [-998, -999]
+    });
+    expect(c.okToRenderTarget('bi')).toBe(true);
+    expect(c.okToRenderTarget('bn')).toBe(false);
+  });
+
+  it('ANDs with a filterIds selection', () => {
+    const c = component({
+      targets: new Map([
+        ['b', buddy],
+        ['s', stranger]
+      ]),
+      filterShipTypes: [-998],
+      filterIds: ['s'] // stranger selected, but not a buddy
+    });
+    expect(c.okToRenderTarget('s')).toBe(false);
+    // buddy is a buddy but not in the id selection
+    expect(c.okToRenderTarget('b')).toBe(false);
+  });
+});

--- a/src/app/modules/map/ol/lib/resources/ais-base.component.ts
+++ b/src/app/modules/map/ol/lib/resources/ais-base.component.ts
@@ -119,17 +119,31 @@ export class AISBaseLayerComponent
       }
     };
 
+    // Buddies only
+    const checkBuddy = (id: string) => {
+      const buddiesOnly =
+        Array.isArray(this.filterShipTypes) &&
+        this.filterShipTypes.includes(-998);
+      if (buddiesOnly) {
+        return (this.targets.get(id) as SKVessel).buddy === true;
+      } else {
+        return true;
+      }
+    };
+
     if (this.filterByShipType && Array.isArray(this.filterShipTypes)) {
       const st = Math.floor(this.targets.get(id).type.id / 10) * 10;
-      return this.filterShipTypes.includes(st) && checkImo(id);
+      return (
+        this.filterShipTypes.includes(st) && checkImo(id) && checkBuddy(id)
+      );
     }
     if (!this.filterIds) {
-      return checkImo(id);
+      return checkImo(id) && checkBuddy(id);
     }
     if (Array.isArray(this.filterIds)) {
-      return this.filterIds.includes(id) && checkImo(id);
+      return this.filterIds.includes(id) && checkImo(id) && checkBuddy(id);
     } else {
-      return checkImo(id);
+      return checkImo(id) && checkBuddy(id);
     }
   }
 

--- a/src/app/modules/map/ol/lib/resources/ais-base.component.ts
+++ b/src/app/modules/map/ol/lib/resources/ais-base.component.ts
@@ -131,19 +131,20 @@ export class AISBaseLayerComponent
       }
     };
 
+    const passesSentinelFilters = (id: string) =>
+      checkImo(id) && checkBuddy(id);
+
     if (this.filterByShipType && Array.isArray(this.filterShipTypes)) {
       const st = Math.floor(this.targets.get(id).type.id / 10) * 10;
-      return (
-        this.filterShipTypes.includes(st) && checkImo(id) && checkBuddy(id)
-      );
+      return this.filterShipTypes.includes(st) && passesSentinelFilters(id);
     }
     if (!this.filterIds) {
-      return checkImo(id) && checkBuddy(id);
+      return passesSentinelFilters(id);
     }
     if (Array.isArray(this.filterIds)) {
-      return this.filterIds.includes(id) && checkImo(id) && checkBuddy(id);
+      return this.filterIds.includes(id) && passesSentinelFilters(id);
     } else {
-      return checkImo(id) && checkBuddy(id);
+      return passesSentinelFilters(id);
     }
   }
 

--- a/src/app/modules/skresources/components/ais/aislist.html
+++ b/src/app/modules/skresources/components/ais/aislist.html
@@ -75,6 +75,14 @@
       >
         IMO Only
       </mat-slide-toggle>
+      @if (app.featureFlags().buddyList) { &nbsp;
+      <mat-slide-toggle
+        [checked]="onlyBuddies"
+        (change)="shipTypeSelect($event.checked, -998)"
+      >
+        Buddies Only
+      </mat-slide-toggle>
+      }
     </mat-card-actions>
   </mat-card>
 

--- a/src/app/modules/skresources/components/ais/aislist.ts
+++ b/src/app/modules/skresources/components/ais/aislist.ts
@@ -51,6 +51,7 @@ export class AISListComponent extends ResourceListBase {
 
   aisAvailable = [];
   onlyIMO = false;
+  onlyBuddies = false;
   filterList = [];
   override filterText = '';
   override someSel = false;
@@ -174,6 +175,7 @@ export class AISListComponent extends ResourceListBase {
       i.selected = this.app.config.selections.aisTargetTypes.includes(i.id);
     });
     this.onlyIMO = this.app.config.selections.aisTargetTypes.includes(-999);
+    this.onlyBuddies = this.app.config.selections.aisTargetTypes.includes(-998);
   }
 
   /**
@@ -204,6 +206,7 @@ export class AISListComponent extends ResourceListBase {
       }
     }
     this.onlyIMO = t.includes(-999);
+    this.onlyBuddies = t.includes(-998);
     this.app.config.selections.aisTargetTypes = t.splice(0);
     this.app.saveConfig();
   }


### PR DESCRIPTION
Adds a **Buddies Only** toggle to the vessel (AIS) filter list, alongside the
existing **IMO Only** toggle. When enabled, only targets flagged as a buddy are
rendered on the chart.

The toggle only appears when the buddy-list plugin (`signalk-buddylist-plugin`
>1.2.0) is present, gated behind the existing `buddyList` feature flag.

It follows the same shape as IMO-only: a sentinel (`-998`) in
`selections.aisTargetTypes`, resolved by a `checkBuddy()` helper in
`okToRenderTarget()` that composes with the other filters via AND — so it can be
combined with IMO-only, ship-type, and the id selection. The `buddy` boolean is
already carried on each target, so no new data is needed.

Closes #478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Buddies Only” filter in the AIS ship type controls when available.
  * The filter selection now stays in sync with saved AIS target type choices.

* **Bug Fixes**
  * Refined target rendering so “Buddies Only” works alongside existing ship-type, IMO, and target list filters.
  * Non-vessel targets are handled more consistently when buddy-only filtering is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->