### PR TITLE
feat(notes): size Note Details dialog to fit its content

### DIFF
--- a/src/app/modules/skresources/components/notes/note-dialog.html
+++ b/src/app/modules/skresources/components/notes/note-dialog.html
@@ -11,6 +11,15 @@
   :host ::ng-deep .ck.ck-editor__main > .ck-editor__editable {
     color: black;
   }
+  /* Note Details: scale wide embedded media (e.g. a tide-station graph) to fit
+     the dialog rather than clipping it. Vertical overflow is handled by the
+     single mat-dialog-content scroll region (max-height: 65vh), so the
+     description must NOT add its own scroller. */
+  :host ::ng-deep .note-description img,
+  :host ::ng-deep .note-description svg {
+    max-width: 100%;
+    height: auto;
+  }
   @media only screen and (min-width: 600px) {
     .ap-confirm-icon {
       min-width: 25%;
@@ -88,13 +97,12 @@
               Description:
             </div>
             @if(data.note.mimeType.includes('markdown')) {
-            <div>
+            <div class="note-description">
               <remark [markdown]="data.note.description" />
             </div>
             } @else {
             <div
               class="note-description"
-              style="overflow-y: auto; height: 150px"
               target="notelink"
               [innerHTML]="data.note.description | addTarget: '_notes'"
             ></div>

--- a/src/app/modules/skresources/note-details-sizing.spec.ts
+++ b/src/app/modules/skresources/note-details-sizing.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { SKResourceService } from './resources.service';
+import { NoteDialog } from './components/notes/note-dialog';
+
+/**
+ * Regression test for #462 — the read-only "Note Details" dialog must open with
+ * content-fitting size options so a wide embedded graphic (e.g. a tide-station
+ * graph) is shown as large as possible up to a cap, instead of being clipped.
+ *
+ * The layout itself (fit-content growth, image scaling) is CSS and can't be
+ * asserted under jsdom, which does no layout — so this guards the sizing *config*
+ * that drives it, the part most likely to be silently dropped in a refactor.
+ *
+ * `showNoteDetails` only reads `this.app.sIsFetching`, `this.fromServer` and
+ * `this.dialog`, so exercise it on a bare prototype instance — no Angular DI
+ * (same approach as resources-charts-opacity.spec.ts).
+ */
+type CapturedDialogConfig = {
+  width?: string;
+  minWidth?: string;
+  maxWidth?: string;
+  data?: { editable?: boolean };
+};
+
+type Captured = { component?: unknown; config?: CapturedDialogConfig };
+
+function svcCapturingDialogOpen(captured: Captured) {
+  const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+  Object.assign(svc as unknown as Record<string, unknown>, {
+    app: { sIsFetching: { set: () => undefined } },
+    fromServer: async () => ({ name: 'X', mimeType: '', properties: {} }),
+    dialog: {
+      open: (component: unknown, config: CapturedDialogConfig) => {
+        captured.component = component;
+        captured.config = config;
+        return { afterClosed: () => ({ subscribe: () => undefined }) };
+      }
+    }
+  });
+  return svc;
+}
+
+describe('Note Details dialog sizing (#462)', () => {
+  it('opens the read-only NoteDialog with content-fitting size options', async () => {
+    const captured: Captured = {};
+    await svcCapturingDialogOpen(captured).showNoteDetails('note-1');
+
+    expect(captured.component).toBe(NoteDialog);
+    expect(captured.config).toMatchObject({
+      width: 'fit-content',
+      minWidth: '350px',
+      maxWidth: '90vw'
+    });
+    // read-only view is what the graphic-clipping report is about
+    expect(captured.config?.data?.editable).toBe(false);
+  });
+});

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -2309,6 +2309,9 @@ export class SKResourceService {
     this.dialog
       .open(NoteDialog, {
         disableClose: true,
+        width: 'fit-content',
+        minWidth: '350px',
+        maxWidth: '90vw',
         data: { note: note, editable: false }
       })
       .afterClosed()


### PR DESCRIPTION
The read-only **Note Details** dialog opened at a fixed size with its
description hard-capped at 150px tall, so a wide or tall embedded graphic —
e.g. the water-level graph on a tide-station note — was clipped and had to be
scrolled in both directions to read (see #462).

Let the dialog size to its content, up to a cap:

- open it with `width: fit-content` / `maxWidth: 90vw` (with a small `minWidth`
  floor) so it grows to the content instead of a fixed frame;
- drop the description's fixed `height: 150px`, letting the existing
  `mat-dialog-content` scroll region (`max-height: 65vh`) be the single vertical
  overflow container — so a rich note fills the available height with one
  scrollbar, not a nested pair;
- scale embedded `img`/`svg` to `max-width: 100%` so a wide graphic fits rather
  than overflowing.

Short text notes are unchanged (they stay compact); only rich/large notes grow.

A regression test guards the read-only dialog's sizing config — the layout
itself (fit-content growth, image scaling) is CSS and isn't assertable under
jsdom, so the test pins the config that drives it.

### Before

<img width="1218" alt="Note Details before — tide-station graph clipped both ways" src="https://github.com/user-attachments/assets/24e5fac1-9400-4bd4-ac7b-253eac046a58" />

### After

_(after screenshot)_

Closes #462


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note detail dialog sizing so it opens at a more appropriate width on different screens.
  * Updated note content rendering so embedded images and SVGs stay within the dialog bounds and keep their aspect ratio.
  * Adjusted note description layout to rely on the dialog’s main scroll area for overflow, improving readability in longer notes.
* **Tests**
  * Added regression coverage for the read-only note details dialog sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->