### PR TITLE
fix(ais): restore clipped vessel-row controls and refine the filter toggle row

### DIFF
--- a/src/app/modules/skresources/components/ais/aislist.html
+++ b/src/app/modules/skresources/components/ais/aislist.html
@@ -60,33 +60,37 @@
         </div>
       </div>
     </mat-card-content>
-    <mat-card-actions>
-      Filter:&nbsp;
-      <mat-slide-toggle
-        [checked]="app.config.selections.aisFilterByShipType"
-        (change)="toggleFilterType($event.checked)"
-      >
-        Ship Type
-      </mat-slide-toggle>
-      &nbsp;
-      <mat-slide-toggle
-        [checked]="onlyIMO"
-        (change)="shipTypeSelect($event.checked, -999)"
-      >
-        IMO Only
-      </mat-slide-toggle>
-      @if (app.featureFlags().buddyList) { &nbsp;
-      <mat-slide-toggle
-        [checked]="onlyBuddies"
-        (change)="shipTypeSelect($event.checked, -998)"
-      >
-        Buddies Only
-      </mat-slide-toggle>
-      }
+    <mat-card-actions
+      class="vessel-filter"
+      [class.stacked]="app.featureFlags().buddyList"
+    >
+      <span class="filter-label">Filter:</span>
+      <div class="filter-toggles">
+        <mat-slide-toggle
+          [checked]="app.config.selections.aisFilterByShipType"
+          (change)="toggleFilterType($event.checked)"
+        >
+          Ship Type
+        </mat-slide-toggle>
+        <mat-slide-toggle
+          [checked]="onlyIMO"
+          (change)="shipTypeSelect($event.checked, -999)"
+        >
+          IMO Only
+        </mat-slide-toggle>
+        @if (app.featureFlags().buddyList) {
+        <mat-slide-toggle
+          [checked]="onlyBuddies"
+          (change)="shipTypeSelect($event.checked, -998)"
+        >
+          Buddies Only
+        </mat-slide-toggle>
+        }
+      </div>
     </mat-card-actions>
   </mat-card>
 
-  <div class="resources vessels">
+  <div class="resources vessels" [class.buddies]="app.featureFlags().buddyList">
     @if(this.app.sIsFetching()) {
     <mat-progress-bar mode="query"></mat-progress-bar>
     } @if (app.config.selections.aisFilterByShipType) {
@@ -153,7 +157,7 @@
           </div>
         </mat-card-content>
         <mat-card-actions>
-          <div style="display: flex">
+          <div style="display: flex; flex-wrap: wrap">
             <div style="flex: 1 1 auto">
               @if(r[0] !== focusId()) {
               <button

--- a/src/app/modules/skresources/components/resourcelist.css
+++ b/src/app/modules/skresources/components/resourcelist.css
@@ -31,6 +31,37 @@
     top: 160px;
 }
 
+/* Vessel filter: inline "Filter: [Ship Type] [IMO Only]" by default. When the
+   buddy-list plugin adds a third toggle, the row is stacked (label above the
+   toggles) so all three fit; the list then starts lower to clear the taller
+   header. */
+.resourcelist .vessel-filter .filter-label {
+    padding-right: 8px;
+}
+
+.resourcelist .vessel-filter .filter-toggles {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.resourcelist .vessel-filter.stacked {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.resourcelist .vessel-filter.stacked .filter-toggles {
+    width: 100%;
+}
+
+.resourcelist .vessel-filter.stacked .filter-toggles mat-slide-toggle {
+    flex: 1 1 0;
+}
+
+.resourcelist .resources.vessels.buddies {
+    top: 185px;
+}
+
 .resourcelist .vscroller {
     position: absolute;
     top: 0px;


### PR DESCRIPTION
Two vessel-list layout regressions:

- **Per-row controls clipped.** Since the TRACK button was added (#448), the item
  action row (FOCUS / CENTER / TRACK / ⓘ) no longer fits on one line, and because
  `mat-card` is a flex column that forced the whole card wider than the panel —
  pushing the right-aligned "Show in Map" checkbox and the ⓘ info button
  off-screen. The action row now wraps, so the card stays within the panel and
  both controls are visible again.
- **Filter toggle row.** The new "Buddies Only" toggle crowded the single
  "Filter:" line. The row is now stacked (label above three equal, two-line-label
  toggles) **only** when the buddy-list plugin is present; without it, the original
  inline "Filter: [Ship Type] [IMO Only]" layout is unchanged. Keyed off the
  existing `buddyList` flag via a CSS modifier class — no markup duplication.

Layout only; no behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the vessel filter area with a cleaner, more structured layout.
  * Added a stacked filter style for buddy-list mode so the controls fit better in tighter spaces.
  * Improved vessel action buttons so they can wrap onto multiple lines instead of overflowing.
  * Adjusted spacing and positioning to better support the updated filter header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->