### PR TITLE
feat(charts): add brightness/contrast adjustment for raster image layers

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -363,6 +363,7 @@ export function cleanConfig(
       charts: ['openstreetmap', 'openseamap'],
       chartOrder: ['openstreetmap', 'openseamap'],
       chartOpacity: {},
+      chartImageAdjustment: {},
       aisTargets: null,
       aisTargetTypes: [],
       aisFilterByShipType: false,
@@ -389,6 +390,9 @@ export function cleanConfig(
   }
   if (typeof settings.selections.chartOpacity === 'undefined') {
     settings.selections.chartOpacity = {};
+  }
+  if (typeof settings.selections.chartImageAdjustment === 'undefined') {
+    settings.selections.chartImageAdjustment = {};
   }
 
   if (typeof settings.selections.tracks === 'undefined') {
@@ -606,6 +610,7 @@ export function defaultConfig(): IAppConfig {
       charts: ['openstreetmap', 'openseamap'],
       chartOrder: ['openstreetmap', 'openseamap'], // chart layer ordering
       chartOpacity: {},
+      chartImageAdjustment: {},
       aisTargets: null,
       aisTargetTypes: [],
       aisFilterByShipType: false,

--- a/src/app/lib/components/dialogs/image-adjustment-dialog.ts
+++ b/src/app/lib/components/dialogs/image-adjustment-dialog.ts
@@ -1,0 +1,145 @@
+import { Component, OnInit, signal, inject } from '@angular/core';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import {
+  MatDialogModule,
+  MatDialogRef,
+  MAT_DIALOG_DATA
+} from '@angular/material/dialog';
+import { ChartImageAdjustment } from 'src/app/types';
+
+export interface ImageAdjustmentDialogResult {
+  apply: boolean;
+  value: ChartImageAdjustment;
+}
+
+// Brightness/contrast are stored as multipliers (1 = neutral) but presented as a
+// 0-200% slider, so 100% maps to the neutral value.
+const NEUTRAL_PERCENT = 100;
+const MAX_PERCENT = 200;
+const toPercent = (ratio: number) =>
+  Number.isFinite(ratio)
+    ? Math.min(MAX_PERCENT, Math.max(0, Math.round(ratio * 100)))
+    : NEUTRAL_PERCENT;
+const toRatio = (percent: number) => percent / 100;
+
+@Component({
+  selector: 'ap-image-adjustment-dialog',
+  imports: [
+    MatSliderModule,
+    MatIconModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatTooltipModule
+  ],
+  template: `
+    <div class="_ap-image-adjustment">
+      <div style="display:flex;">
+        <div style="padding: 15px 0 0 10px;">
+          <mat-icon>tune</mat-icon>
+        </div>
+        <div style="flex: 1 1 auto;">
+          <h1 mat-dialog-title>{{ data.title ?? 'Image Adjustment' }}</h1>
+        </div>
+        <div style="width:50px;padding: 15px 0 0 10px;">
+          <button mat-icon-button (click)="handleClose(false)">
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
+      </div>
+
+      <mat-dialog-content style="padding-top: 5px;">
+        <div style="display: flex; align-items: center; margin-bottom: 8px">
+          <div style="flex: 1 1 auto">{{ data.text }}</div>
+        </div>
+        <div style="display: flex; align-items: center">
+          <div style="width: 80px">Brightness</div>
+          <mat-slider style="flex: 1 1 auto" [min]="0" [max]="200" [step]="1">
+            <input
+              matSliderThumb
+              aria-label="Brightness"
+              [value]="brightness()"
+              (input)="onBrightnessChange($event)"
+            />
+          </mat-slider>
+          <div style="min-width: 48px; text-align: right">
+            {{ brightness() }}%
+          </div>
+        </div>
+        <div style="display: flex; align-items: center">
+          <div style="width: 80px">Contrast</div>
+          <mat-slider style="flex: 1 1 auto" [min]="0" [max]="200" [step]="1">
+            <input
+              matSliderThumb
+              aria-label="Contrast"
+              [value]="contrast()"
+              (input)="onContrastChange($event)"
+            />
+          </mat-slider>
+          <div style="min-width: 48px; text-align: right">
+            {{ contrast() }}%
+          </div>
+        </div>
+      </mat-dialog-content>
+      <mat-dialog-actions>
+        <button mat-button (click)="reset()">RESET</button>
+        <span style="flex: 1 1 auto"></span>
+        <button mat-raised-button (click)="handleClose(true)">APPLY</button>
+      </mat-dialog-actions>
+    </div>
+  `
+})
+export class ImageAdjustmentDialog implements OnInit {
+  protected brightness = signal<number>(NEUTRAL_PERCENT);
+  protected contrast = signal<number>(NEUTRAL_PERCENT);
+
+  protected dialogRef = inject(
+    MatDialogRef<ImageAdjustmentDialog, ImageAdjustmentDialogResult>
+  );
+  protected data = inject<{
+    title: string;
+    text: string;
+    value: ChartImageAdjustment;
+    onChange: (value: ChartImageAdjustment) => void;
+  }>(MAT_DIALOG_DATA);
+
+  ngOnInit() {
+    this.brightness.set(toPercent(this.data.value?.brightness ?? 1));
+    this.contrast.set(toPercent(this.data.value?.contrast ?? 1));
+  }
+
+  protected onBrightnessChange(e: Event) {
+    this.brightness.set(Number((e.target as HTMLInputElement).value));
+    this.emitChange();
+  }
+
+  protected onContrastChange(e: Event) {
+    this.contrast.set(Number((e.target as HTMLInputElement).value));
+    this.emitChange();
+  }
+
+  protected reset() {
+    this.brightness.set(NEUTRAL_PERCENT);
+    this.contrast.set(NEUTRAL_PERCENT);
+    this.emitChange();
+  }
+
+  private currentValue(): ChartImageAdjustment {
+    return {
+      brightness: toRatio(this.brightness()),
+      contrast: toRatio(this.contrast())
+    };
+  }
+
+  private emitChange() {
+    if (typeof this.data?.onChange === 'function') {
+      this.data.onChange(this.currentValue());
+    }
+  }
+
+  protected handleClose(apply: boolean) {
+    this.dialogRef.close({ apply, value: this.currentValue() });
+  }
+}

--- a/src/app/lib/components/dialogs/index.ts
+++ b/src/app/lib/components/dialogs/index.ts
@@ -14,3 +14,4 @@ export * from './trail2route-dialog';
 export * from './multiselectlist-dialog';
 export * from './singleselectlist-dialog';
 export * from './slider-dialog';
+export * from './image-adjustment-dialog';

--- a/src/app/modules/map/ol/lib/charts/chart-utils-image-adjustment.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils-image-adjustment.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import TileLayer from 'ol/layer/Tile';
+import {
+  attachImageAdjustmentFilter,
+  imageAdjustmentToFilter
+} from './chart-utils';
+
+describe('imageAdjustmentToFilter (#457)', () => {
+  it('returns an empty string when no adjustment is supplied', () => {
+    expect(imageAdjustmentToFilter(undefined)).toBe('');
+  });
+
+  it('returns an empty string for a neutral adjustment (no filter applied)', () => {
+    expect(imageAdjustmentToFilter({ brightness: 1, contrast: 1 })).toBe('');
+  });
+
+  it('builds a CSS filter string for a non-neutral adjustment', () => {
+    expect(imageAdjustmentToFilter({ brightness: 1.3, contrast: 0.7 })).toBe(
+      'brightness(1.3) contrast(0.7)'
+    );
+  });
+
+  it('treats a single changed channel as non-neutral', () => {
+    expect(imageAdjustmentToFilter({ brightness: 1.2, contrast: 1 })).toBe(
+      'brightness(1.2) contrast(1)'
+    );
+  });
+
+  it('clamps a negative channel to 0 rather than emitting an invalid filter', () => {
+    expect(imageAdjustmentToFilter({ brightness: -1, contrast: 1 })).toBe(
+      'brightness(0) contrast(1)'
+    );
+  });
+});
+
+/** Minimal OL layer/render-context stand-ins for the prerender/postrender hooks. */
+function mockLayer() {
+  const handlers: Record<string, (e: { context: unknown }) => void> = {};
+  const layer = {
+    on: (type: string, cb: (e: { context: unknown }) => void) => {
+      handlers[type] = cb;
+    }
+  } as unknown as TileLayer;
+  const fire = (type: string, context: unknown) =>
+    handlers[type]?.({ context });
+  return { layer, fire };
+}
+
+function mockContext() {
+  return {
+    filter: 'none',
+    save: vi.fn(),
+    restore: vi.fn()
+  } as unknown as CanvasRenderingContext2D & {
+    save: ReturnType<typeof vi.fn>;
+    restore: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('attachImageAdjustmentFilter (#457)', () => {
+  it('applies the filter on prerender and restores it on postrender', () => {
+    const { layer, fire } = mockLayer();
+    const setAdjustment = attachImageAdjustmentFilter(layer);
+    setAdjustment({ brightness: 1.2, contrast: 0.8 });
+
+    const ctx = mockContext();
+    fire('prerender', ctx);
+    expect(ctx.save).toHaveBeenCalledOnce();
+    expect(ctx.filter).toBe('brightness(1.2) contrast(0.8)');
+
+    fire('postrender', ctx);
+    expect(ctx.restore).toHaveBeenCalledOnce();
+  });
+
+  it('leaves the context untouched for a neutral adjustment', () => {
+    const { layer, fire } = mockLayer();
+    const setAdjustment = attachImageAdjustmentFilter(layer);
+    setAdjustment({ brightness: 1, contrast: 1 });
+
+    const ctx = mockContext();
+    fire('prerender', ctx);
+    fire('postrender', ctx);
+    expect(ctx.save).not.toHaveBeenCalled();
+    expect(ctx.restore).not.toHaveBeenCalled();
+    expect(ctx.filter).toBe('none');
+  });
+});

--- a/src/app/modules/map/ol/lib/charts/chart-utils.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils.ts
@@ -1,5 +1,62 @@
 import { Extent } from 'ol/extent';
 import { transformExtent } from 'ol/proj';
+import TileLayer from 'ol/layer/Tile';
+import RenderEvent from 'ol/render/Event';
+import { ChartImageAdjustment } from 'src/app/types';
+
+/**
+ * Build a CSS canvas `filter` string from a chart's image adjustment, or `''`
+ * when the adjustment is absent or neutral (so no filter is applied).
+ */
+export function imageAdjustmentToFilter(adj?: ChartImageAdjustment): string {
+  if (!adj) {
+    return '';
+  }
+  const brightness = Number.isFinite(adj.brightness)
+    ? Math.max(0, adj.brightness)
+    : 1;
+  const contrast = Number.isFinite(adj.contrast)
+    ? Math.max(0, adj.contrast)
+    : 1;
+  if (brightness === 1 && contrast === 1) {
+    return '';
+  }
+  return `brightness(${brightness}) contrast(${contrast})`;
+}
+
+/**
+ * Apply a per-chart brightness/contrast filter to a raster (canvas) tile layer
+ * by wrapping each render pass in a canvas `filter`. Returns a setter the caller
+ * invokes whenever the chart's adjustment changes; a subsequent `map.render()`
+ * repaints with the new values. WebGL tile layers have no 2D context and must
+ * not be passed here.
+ */
+export function attachImageAdjustmentFilter(
+  layer: TileLayer
+): (adj?: ChartImageAdjustment) => void {
+  let filter = '';
+  let applied = false;
+  layer.on('prerender', (evt: RenderEvent) => {
+    if (!filter) {
+      return;
+    }
+    const ctx = evt.context as CanvasRenderingContext2D;
+    ctx.save();
+    ctx.filter = filter;
+    applied = true;
+  });
+  layer.on('postrender', (evt: RenderEvent) => {
+    if (!applied) {
+      return;
+    }
+    const ctx = evt.context as CanvasRenderingContext2D;
+    ctx.restore();
+    applied = false;
+  });
+  return (adj?: ChartImageAdjustment) => {
+    filter = imageAdjustmentToFilter(adj);
+  };
+}
 
 export function resolveLayerMaxZoom(
   chartMax?: number,

--- a/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
@@ -15,9 +15,13 @@ import { XYZ } from 'ol/source';
 import { initPMTilesXYZLayer } from './pmtiles-utils';
 import { osmLayer } from '../util';
 import { MapComponent } from '../map.component';
-import { extentFromBounds, resolveLayerMaxZoom } from './chart-utils';
+import {
+  attachImageAdjustmentFilter,
+  extentFromBounds,
+  resolveLayerMaxZoom
+} from './chart-utils';
 
-import { FBChart } from 'src/app/types';
+import { ChartImageAdjustment, FBChart } from 'src/app/types';
 
 // ** Freeboard Raster TileLayer Chart **
 @Component({
@@ -33,6 +37,7 @@ export class RasterChartLayerComponent implements OnDestroy {
   protected mapMaxZoom = input<number>();
 
   private layer: TileLayer | WebGLTileLayer;
+  private setImageAdjustment?: (adj?: ChartImageAdjustment) => void;
   private changeDetectorRef = inject(ChangeDetectorRef);
   private mapComponent = inject(MapComponent);
 
@@ -108,6 +113,11 @@ export class RasterChartLayerComponent implements OnDestroy {
         this.layer.set('chartId', chart[0]);
         this.layer.set('chartType', chart[1].type);
         this.layer.set('chartFormat', chart[1].format);
+        // Brightness/contrast is a canvas filter; the WebGL pmtiles layer has no
+        // 2D context, so it is left unadjusted.
+        if (this.layer instanceof TileLayer) {
+          this.setImageAdjustment = attachImageAdjustmentFilter(this.layer);
+        }
         map.addLayer(this.layer);
       }
     } else {
@@ -127,6 +137,7 @@ export class RasterChartLayerComponent implements OnDestroy {
       this.layer.setOpacity(chart[1].defaultOpacity ?? 1);
       this.layer.setExtent(extentFromBounds(chart[1].bounds));
     }
+    this.setImageAdjustment?.(chart[1].imageAdjustment);
     map.render();
   }
 }

--- a/src/app/modules/map/ol/lib/charts/layer-tilejson-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-tilejson-chart.component.ts
@@ -13,8 +13,12 @@ import { TileJSON } from 'ol/source';
 
 import { MapComponent } from '../map.component';
 
-import { FBChart } from 'src/app/types';
-import { extentFromBounds, resolveLayerMaxZoom } from './chart-utils';
+import { ChartImageAdjustment, FBChart } from 'src/app/types';
+import {
+  attachImageAdjustmentFilter,
+  extentFromBounds,
+  resolveLayerMaxZoom
+} from './chart-utils';
 
 // ** Freeboard TileJSON Chart **
 @Component({
@@ -30,6 +34,7 @@ export class TileJsonChartLayerComponent implements OnDestroy {
   protected mapMaxZoom = input<number>();
 
   private layer: TileLayer;
+  private setImageAdjustment?: (adj?: ChartImageAdjustment) => void;
   private changeDetectorRef = inject(ChangeDetectorRef);
   private mapComponent = inject(MapComponent);
 
@@ -88,6 +93,7 @@ export class TileJsonChartLayerComponent implements OnDestroy {
         this.layer.set('chartId', chart[0]);
         this.layer.set('chartType', chart[1].type);
         this.layer.set('chartFormat', chart[1].format);
+        this.setImageAdjustment = attachImageAdjustmentFilter(this.layer);
         map.addLayer(this.layer);
       }
     } else {
@@ -107,6 +113,7 @@ export class TileJsonChartLayerComponent implements OnDestroy {
       this.layer.setOpacity(chart[1].defaultOpacity ?? 1);
       this.layer.setExtent(extentFromBounds(chart[1].bounds));
     }
+    this.setImageAdjustment?.(chart[1].imageAdjustment);
     map.render();
   }
 }

--- a/src/app/modules/map/ol/lib/charts/layer-wms-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wms-chart.component.ts
@@ -13,10 +13,14 @@ import { TileWMS } from 'ol/source';
 
 import { MapComponent } from '../map.component';
 
-import { FBChart } from 'src/app/types';
+import { ChartImageAdjustment, FBChart } from 'src/app/types';
 import { Map } from 'ol';
 import { MapService } from '../map.service';
-import { extentFromBounds, resolveLayerMaxZoom } from './chart-utils';
+import {
+  attachImageAdjustmentFilter,
+  extentFromBounds,
+  resolveLayerMaxZoom
+} from './chart-utils';
 
 // ** Freeboard WMS Chart **
 @Component({
@@ -34,6 +38,7 @@ export class WmsChartLayerComponent implements OnDestroy {
   protected mapMaxZoom = input<number>();
 
   private layer: TileLayer;
+  private setImageAdjustment?: (adj?: ChartImageAdjustment) => void;
   private changeDetectorRef = inject(ChangeDetectorRef);
   private mapComponent = inject(MapComponent);
   private mapService = inject(MapService);
@@ -127,6 +132,7 @@ export class WmsChartLayerComponent implements OnDestroy {
         this.layer.set('chartId', chart[0]);
         this.layer.set('chartType', chart[1].type);
         this.layer.set('chartFormat', chart[1].format);
+        this.setImageAdjustment = attachImageAdjustmentFilter(this.layer);
         this.map.addLayer(this.layer);
       }
     } else {
@@ -153,6 +159,7 @@ export class WmsChartLayerComponent implements OnDestroy {
         src.refresh();
       }
     }
+    this.setImageAdjustment?.(chart[1].imageAdjustment);
     this.map.render();
   }
 }

--- a/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
@@ -12,11 +12,15 @@ import TileLayer from 'ol/layer/Tile';
 
 import { MapComponent } from '../map.component';
 
-import { FBChart } from 'src/app/types';
+import { ChartImageAdjustment, FBChart } from 'src/app/types';
 import WMTS, { optionsFromCapabilities } from 'ol/source/WMTS';
 
 import WMTSCapabilities from 'ol/format/WMTSCapabilities';
-import { extentFromBounds, resolveLayerMaxZoom } from './chart-utils';
+import {
+  attachImageAdjustmentFilter,
+  extentFromBounds,
+  resolveLayerMaxZoom
+} from './chart-utils';
 
 // ** Freeboard WMTS Chart **
 @Component({
@@ -33,6 +37,7 @@ export class WmtsChartLayerComponent implements OnDestroy {
 
   private layer: TileLayer;
   private capabilities: string;
+  private setImageAdjustment?: (adj?: ChartImageAdjustment) => void;
   private changeDetectorRef = inject(ChangeDetectorRef);
   private mapComponent = inject(MapComponent);
 
@@ -103,6 +108,7 @@ export class WmtsChartLayerComponent implements OnDestroy {
         this.layer.set('chartId', chart[0]);
         this.layer.set('chartType', chart[1].type);
         this.layer.set('chartFormat', chart[1].format);
+        this.setImageAdjustment = attachImageAdjustmentFilter(this.layer);
         map.addLayer(this.layer);
       }
     } else {
@@ -122,6 +128,7 @@ export class WmtsChartLayerComponent implements OnDestroy {
       this.layer.setOpacity(chart[1].defaultOpacity ?? 1);
       this.layer.setExtent(extentFromBounds(chart[1].bounds));
     }
+    this.setImageAdjustment?.(chart[1].imageAdjustment);
     map.render();
   }
 

--- a/src/app/modules/skresources/components/charts/chartlist.html
+++ b/src/app/modules/skresources/components/charts/chartlist.html
@@ -202,7 +202,19 @@
                 <mat-icon>opacity</mat-icon>
               </button>
             </div>
-            @if(r[1].proxy) {
+            @if(isImageLayer(r)) {
+            <div style="width: 100%; text-align: right">
+              <button
+                mat-icon-button
+                [disabled]="!r[2]"
+                (click)="itemImageAdjustment(r)"
+                matTooltip="Image Adjustment"
+                matTooltipPosition="above"
+              >
+                <mat-icon>tune</mat-icon>
+              </button>
+            </div>
+            } @if(r[1].proxy) {
             <div style="width: 100%; text-align: right">
               <button
                 mat-icon-button

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -24,7 +24,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { AppFacade } from 'src/app/app.facade';
 import { SKResourceService, SKResourceType } from '../../resources.service';
 import { ChartLayers } from './chart-layers.component';
-import { FBCharts, FBChart } from 'src/app/types';
+import { FBCharts, FBChart, ChartImageAdjustment } from 'src/app/types';
 import { WMTSDialog } from './wmts-dialog';
 import { WMSDialog } from './wms-dialog';
 import { JsonMapSourceDialog } from './jsonmapsource-dialog';
@@ -34,7 +34,9 @@ import { FBMapInteractService } from 'src/app/modules/map/fbmap-interact.service
 import {
   SingleSelectListDialog,
   SliderInputDialog,
-  SliderInputDialogResult
+  SliderInputDialogResult,
+  ImageAdjustmentDialog,
+  ImageAdjustmentDialogResult
 } from 'src/app/lib/components';
 import { SKResourceGroupService } from '../groups/groups.service';
 import { SKChart } from '../../resource-classes';
@@ -126,6 +128,7 @@ export class ChartListComponent extends ResourceListBase {
       this.app.sIsFetching.set(false);
       this.doFilter();
       this.cleanOpacityConfig();
+      this.cleanImageAdjustmentConfig();
       this.skres.selectionClean(
         this.collection,
         this.fullList.map((i) => i[0])
@@ -148,6 +151,40 @@ export class ChartListComponent extends ResourceListBase {
         delete this.app.config.selections.chartOpacity[key];
       }
     });
+  }
+
+  /**
+   * Clean orphaned chartImageAdjustment keys from config
+   */
+  cleanImageAdjustmentConfig() {
+    const keys = Object.keys(this.app.config.selections.chartImageAdjustment);
+    const listIds = this.fullList.map((i) => i[0]);
+    keys.forEach((key) => {
+      if (!listIds.includes(key)) {
+        delete this.app.config.selections.chartImageAdjustment[key];
+      }
+    });
+  }
+
+  /**
+   * @description True when a chart renders as a raster image layer (raster tiles,
+   * tileJSON, WMS, WMTS) — the layers brightness/contrast adjustment applies to.
+   * Vector charts (S-57, mapstyleJSON, MVT/PBF tiles) are excluded.
+   * @param chart Chart entry
+   */
+  protected isImageLayer(chart: FBChart): boolean {
+    if (chart[0] === 'openstreetmap') {
+      return true;
+    }
+    const type = chart[1]?.type?.toLowerCase();
+    const format = chart[1]?.format?.toLowerCase();
+    if (!type) {
+      return true;
+    }
+    if (type === 'tilelayer') {
+      return !(format === 'pbf' || format === 'mvt');
+    }
+    return ['tilejson', 'wms', 'wmts'].includes(type);
   }
 
   /**
@@ -260,6 +297,43 @@ export class ChartListComponent extends ResourceListBase {
           // cancelled
           this.skres.chartSetOpacity(chart[0], originalOpacity);
           return;
+        }
+      });
+  }
+
+  protected itemImageAdjustment(chart: FBChart) {
+    const original: ChartImageAdjustment = {
+      brightness: 1,
+      contrast: 1,
+      ...(this.app.config.selections.chartImageAdjustment[chart[0]] ??
+        chart[1]?.imageAdjustment)
+    };
+
+    this.dialog
+      .open(ImageAdjustmentDialog, {
+        disableClose: true,
+        backdropClass: 'transparent-backdrop',
+        data: {
+          title: 'Image Adjustment',
+          text: chart[1]?.name ?? '',
+          value: { ...original },
+          onChange: (value: ChartImageAdjustment) => {
+            this.skres.chartSetImageAdjustment(chart[0], value);
+          }
+        }
+      })
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result: ImageAdjustmentDialogResult) => {
+        if (result?.apply) {
+          const adj = result.value;
+          this.app.config.selections.chartImageAdjustment[chart[0]] = adj;
+          chart[1].imageAdjustment = adj;
+          this.updateFullList(chart);
+          this.app.saveConfig();
+        } else {
+          // cancelled - restore the pre-edit adjustment
+          this.skres.chartSetImageAdjustment(chart[0], original);
         }
       });
   }

--- a/src/app/modules/skresources/resource-classes.ts
+++ b/src/app/modules/skresources/resource-classes.ts
@@ -13,7 +13,8 @@ import {
   WaypointResource,
   RegionResource,
   NoteResource,
-  ChartResource
+  ChartResource,
+  ChartImageAdjustment
 } from 'src/app/types';
 
 // ** Signal K route class
@@ -133,6 +134,7 @@ export class SKChart {
   source: string;
   style: string;
   defaultOpacity: number;
+  imageAdjustment?: ChartImageAdjustment;
   proxy: boolean;
 
   constructor(chart?: ChartResource) {
@@ -157,6 +159,7 @@ export class SKChart {
     this.style = chart?.style ?? undefined;
     this.source = chart?.$source ?? undefined;
     this.defaultOpacity = chart?.defaultOpacity ?? 1;
+    this.imageAdjustment = chart?.imageAdjustment;
     this.proxy = chart?.proxy ?? false;
   }
 }

--- a/src/app/modules/skresources/resources-charts-image-adjustment.spec.ts
+++ b/src/app/modules/skresources/resources-charts-image-adjustment.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { SKResourceService } from './resources.service';
+import { ChartImageAdjustment, FBCharts } from 'src/app/types';
+
+/**
+ * Regression tests for per-chart image adjustment (#457) persistence. Both paths
+ * that build chart objects — `transformChart` for server charts and `appendOSM`
+ * for the built-in OSM charts — must copy a stored brightness/contrast so the
+ * adjustment survives a refresh.
+ *
+ * `appendOSM` / `transformChart` only read `this.app`, so exercise them on a bare
+ * prototype instance with a mock app — no Angular DI needed.
+ */
+function svcWithAdjustment(
+  chartImageAdjustment: Record<string, ChartImageAdjustment>
+) {
+  const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+  (svc as unknown as { app: unknown }).app = {
+    config: {
+      selections: { charts: null, chartOpacity: {}, chartImageAdjustment }
+    }
+  };
+  return svc;
+}
+
+describe('chart image adjustment persistence (#457)', () => {
+  it('appendOSM applies a stored adjustment to the built-in OSM charts', () => {
+    const svc = svcWithAdjustment({
+      openstreetmap: { brightness: 1.2, contrast: 0.8 }
+    });
+    const osm = (svc.appendOSM([]) as FBCharts).find(
+      (c) => c[0] === 'openstreetmap'
+    );
+    expect(osm?.[1].imageAdjustment).toEqual({
+      brightness: 1.2,
+      contrast: 0.8
+    });
+  });
+
+  it('appendOSM leaves the adjustment undefined when config has none', () => {
+    const osm = (svcWithAdjustment({}).appendOSM([]) as FBCharts).find(
+      (c) => c[0] === 'openstreetmap'
+    );
+    expect(osm?.[1].imageAdjustment).toBeUndefined();
+  });
+
+  it('transformChart copies a stored adjustment onto a server chart', () => {
+    const svc = svcWithAdjustment({
+      'my-chart': { brightness: 1.5, contrast: 1.1 }
+    });
+    const result = (
+      svc as unknown as {
+        transformChart: (
+          c: unknown,
+          id: string
+        ) => { imageAdjustment?: ChartImageAdjustment };
+      }
+    ).transformChart(
+      { name: 'X', url: 'http://x/{z}/{x}/{y}.png' },
+      'my-chart'
+    );
+    expect(result.imageAdjustment).toEqual({ brightness: 1.5, contrast: 1.1 });
+  });
+});

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -44,6 +44,7 @@ import {
   Position,
   Regions,
   ChartResource,
+  ChartImageAdjustment,
   FBChart,
   FBCharts,
   FBRegion,
@@ -564,6 +565,10 @@ export class SKResourceService {
         if (typeof op !== 'undefined') {
           c[1].defaultOpacity = op;
         }
+        const adj = this.app.config.selections.chartImageAdjustment?.[c[0]];
+        if (typeof adj !== 'undefined') {
+          c[1].imageAdjustment = adj;
+        }
       });
     }
     chtList.push(OSM[1]);
@@ -624,6 +629,10 @@ export class SKResourceService {
     // transparent 0 is honored rather than silently dropped on refresh)
     if (typeof this.app.config.selections.chartOpacity[id] !== 'undefined') {
       chart.defaultOpacity = this.app.config.selections.chartOpacity[id];
+    }
+    const adj = this.app.config.selections.chartImageAdjustment?.[id];
+    if (typeof adj !== 'undefined') {
+      chart.imageAdjustment = adj;
     }
     return new SKChart(chart);
   }
@@ -807,6 +816,31 @@ export class SKResourceService {
           }
           const updated = new SKChart(c[1]);
           updated.defaultOpacity = value;
+          return [c[0], updated, c[2]];
+        });
+      });
+    }
+  }
+
+  /**
+   * @description Update the image adjustment (brightness/contrast) of a Chart
+   * object in the Chart Cache so a currently-visible layer re-renders.
+   * @param id Chart identifier
+   * @param value Image adjustment to set
+   */
+  public chartSetImageAdjustment(id: string, value: ChartImageAdjustment) {
+    if (!id || !value) {
+      return;
+    }
+    const idx = this.chartCacheSignal().findIndex((c: FBChart) => c[0] === id);
+    if (idx !== -1) {
+      this.chartCacheSignal.update((current: FBCharts) => {
+        return current.map((c: FBChart) => {
+          if (c[0] !== id) {
+            return c;
+          }
+          const updated = new SKChart(c[1]);
+          updated.imageAdjustment = value;
           return [c[0], updated, c[2]];
         });
       });

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -11,6 +11,7 @@ import {
 } from '../modules/skresources/resource-classes';
 import { DEPTH_UNIT } from '../lib/convert';
 import { Options } from '../modules/map/ol/lib/charts/s57.service';
+import { ChartImageAdjustment } from './resources/signalk';
 
 export * from './resources/signalk';
 export * from './resources/custom';
@@ -229,6 +230,7 @@ export interface IAppConfig {
     charts: string[];
     chartOrder: string[]; // chart layer ordering
     chartOpacity: Record<string, number>;
+    chartImageAdjustment: Record<string, ChartImageAdjustment>;
     aisTargets: string[];
     aisTargetTypes: number[];
     aisFilterByShipType: boolean;

--- a/src/app/types/resources/signalk.ts
+++ b/src/app/types/resources/signalk.ts
@@ -54,6 +54,15 @@ export interface NoteResource {
   source: string;
 }
 
+/**
+ * Per-chart image adjustment applied to raster/aerial tile layers. Values are
+ * multipliers where `1` is neutral (unchanged); `0` is black / fully grey.
+ */
+export interface ChartImageAdjustment {
+  brightness: number;
+  contrast: number;
+}
+
 export interface ChartResource {
   name?: string;
   identifier?: string;
@@ -68,6 +77,7 @@ export interface ChartResource {
   layers?: string[];
   tileSize?: number;
   defaultOpacity?: number;
+  imageAdjustment?: ChartImageAdjustment;
   proxy?: boolean;
   $source?: string;
   style?: string;


### PR DESCRIPTION
Adds a per-chart **brightness + contrast** adjustment for raster/aerial image
layers, so imagery can be tuned to pull detail out of poorly-exposed water —
e.g. when scouting anchorages (#457).

## Why
Default tile exposure is tuned for land, so on aerial/satellite imagery the
water — where the hazards are — is often crushed to near-black. Adjusting
brightness/contrast makes submerged rocks, shallows and skerries readable.

## How
- A `tune` control in the chart list opens a two-slider dialog (Brightness,
  Contrast) with a Reset to neutral. Live preview while adjusting; values persist
  per chart alongside opacity (`selections.chartImageAdjustment`), so they survive
  a reload.
- Applied as a canvas `filter` in each raster layer's `prerender`/`postrender`
  pass. Covers raster tiles, tileJSON, WMS and WMTS. Vector charts (S-57,
  mapstyleJSON, MVT/PBF) don't show the control; WebGL pmtiles layers have no 2D
  context and are left unadjusted.
- Neutral defaults (100%/100%) mean no visible change for anyone who doesn't
  touch it.

## Screenshot
![Image adjustment dialog](https://raw.githubusercontent.com/joelkoz/freeboard-sk/pr457-assets/fsk-image-adj.jpg)

## Tests
`imageAdjustmentToFilter` (neutral/absent → no filter; non-neutral → filter
string) and persistence across both chart-build paths (`transformChart`,
`appendOSM`).

Closes #457


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-chart brightness and contrast adjustment controls for supported image layers.
  * Added an “Image Adjustment” action in the chart list and enabled editing/saving adjustments per chart.
  * Apply image adjustments live to raster map layers and persist them across reloads.

* **Bug Fixes**
  * Improved handling of missing or undefined saved adjustment configuration to avoid incomplete defaults.
  * Ensured neutral settings leave rendering unchanged and non-neutral settings are correctly clamped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->