### PR TITLE
feat(weather): add tidal currents overlay with time-stepping controls

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -832,7 +832,8 @@ export class AppComponent {
       weatherApi: false,
       radarApi: false,
       notificationApi: false,
-      buddyList: false
+      buddyList: false,
+      tidalApi: false
     };
     this.signalk.get('/signalk/v2/features?enabled=1').subscribe(
       (res: {
@@ -866,6 +867,11 @@ export class AppComponent {
           if (p.id === 'signalk-pmtiles-plugin') {
             this.app.debug('*** found PMTiles plugin');
             hasPlugin.pmTiles = true;
+          }
+          // tidal currents
+          if (p.id === 'signalk-tidal-currents') {
+            this.app.debug('*** found signalk-tidal-currents plugin');
+            ff.tidalApi = true;
           }
         });
         this.app.featureFlags.update((current) => {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -371,7 +371,8 @@ export function cleanConfig(
       resourceSets: {},
       infolayers: null,
       weatherWindEnabled: false,
-      oceanCurrentsEnabled: false
+      oceanCurrentsEnabled: false,
+      tidalCurrentsEnabled: false
     };
   }
 
@@ -412,6 +413,9 @@ export function cleanConfig(
   }
   if (typeof settings.selections.oceanCurrentsEnabled === 'undefined') {
     settings.selections.oceanCurrentsEnabled = false;
+  }
+  if (typeof settings.selections.tidalCurrentsEnabled === 'undefined') {
+    settings.selections.tidalCurrentsEnabled = false;
   }
 
   // ensure legacy notes selections section is removed
@@ -618,7 +622,8 @@ export function defaultConfig(): IAppConfig {
       resourceSets: {}, // additional resources
       infolayers: null,
       weatherWindEnabled: false,
-      oceanCurrentsEnabled: false
+      oceanCurrentsEnabled: false,
+      tidalCurrentsEnabled: false
     }
   };
 }

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -226,6 +226,7 @@ export class AppFacade extends InfoService {
     resourceTracks: boolean;
     infoLayers: boolean;
     buddyList: boolean;
+    tidalApi: boolean;
   }>({
     anchorApi: true, // default true until API is available
     autopilotApi: false,
@@ -235,7 +236,8 @@ export class AppFacade extends InfoService {
     resourceGroups: false, // ability to store resource groups
     resourceTracks: false, // ability to store track resources
     infoLayers: false, // ability to store map information overlays
-    buddyList: false
+    buddyList: false,
+    tidalApi: false
   });
 
   selfLines = signal<{ cog: LineStyleDef; heading: LineStyleDef }>({

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -852,6 +852,12 @@
   >
   </fb-weather-currents>
 
+  <fb-tidal-currents
+    [show]="app.config.selections.tidalCurrentsEnabled"
+    [opacity]="0.7"
+  >
+  </fb-tidal-currents>
+
   <!-- chart boundaries-->
   @if (app.data.chartBounds.show) {
     <fb-chart-bounds

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -575,6 +575,33 @@
         >
         </s57-popover>
       }
+      @if (this.overlay().type === 'tidal') {
+        <ap-popover
+          [canClose]="app.config.map.popoverMulti"
+          [compact]="true"
+          (closed)="popoverClosed()"
+        >
+          <div style="display: flex; align-items: center; gap: 8px">
+            <mat-icon style="font-size: 22px; height: 22px; width: 22px"
+              >water</mat-icon
+            >
+            <div style="display: flex; flex-direction: column; gap: 2px">
+              <div style="display: flex; align-items: center; gap: 6px">
+                <mat-icon style="font-size: 16px; height: 16px; width: 16px"
+                  >air</mat-icon
+                >
+                <span>{{ overlay().tidal?.speedLabel }}</span>
+              </div>
+              <div style="display: flex; align-items: center; gap: 6px">
+                <mat-icon style="font-size: 16px; height: 16px; width: 16px"
+                  >explore</mat-icon
+                >
+                <span>{{ overlay().tidal?.directionLabel }}</span>
+              </div>
+            </div>
+          </div>
+        </ap-popover>
+      }
       @if (
         overlay().type === 'destination' ||
         overlay().type === 'waypoint' ||

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -125,6 +125,7 @@ import { MapService } from './ol/lib/map.service';
 import { AppIconDef } from '../icons';
 import { LayerWindWeatherComponent } from './ol/lib/resources/layer-wind-weather.component';
 import { LayerCurrentsWeatherComponent } from './ol/lib/resources/layer-currents-weather.component';
+import { TidalCurrentsLayerComponent } from './ol/lib/resources/tidal-currents-layer.component';
 
 interface IResource {
   id: string;
@@ -172,7 +173,8 @@ enum INTERACTION_MODE {
     VesselPopoverComponent,
     S57PopoverComponent,
     LayerWindWeatherComponent,
-    LayerCurrentsWeatherComponent
+    LayerCurrentsWeatherComponent,
+    TidalCurrentsLayerComponent
   ],
   templateUrl: './fb-map.component.html',
   styleUrls: ['./fb-map.component.css']
@@ -1292,6 +1294,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
             addToFeatureList = true;
             aircraft = this.app.data.aircraft.get(id);
             text = aircraft ? aircraft.name || aircraft.mmsi : '';
+            break;
+          case 'tidal':
+            addToFeatureList = true;
+            icon = {
+              name: 'water',
+              svgIcon: undefined
+            };
+            text = feature.get('name');
             break;
         }
       } else if (!id && feature.getProperties) {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -1302,6 +1302,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
               svgIcon: undefined
             };
             text = feature.get('name');
+            this.tidalFeatures[id] = {
+              speedKn: Number(feature.get('driftKts')) || 0,
+              direction: Number(feature.get('setDeg')) || 0
+            };
             break;
         }
       } else if (!id && feature.getProperties) {
@@ -1350,6 +1354,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   private s57Features: Record<string, Record<string, string | number>> = {};
+  private tidalFeatures: Record<string, { speedKn: number; direction: number }> = {};
 
   // ******** POPOVER ACTIONS ************
 
@@ -1496,6 +1501,25 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.position = poData.aircraft.position;
         poData.show = true;
         break;
+      case 'tidal': {
+        const tf = this.tidalFeatures[id];
+        poData.id = id;
+        poData.type = 'tidal';
+        poData.position = coord;
+        poData.show = true;
+        poData.readOnly = true;
+        if (tf) {
+          poData.tidal = {
+            speedLabel: this.app.formatValueForDisplay(
+              tf.speedKn / 1.94384,
+              'm/s',
+              { precision: 1 }
+            ),
+            directionLabel: `${this.app.formatValueForDisplay(tf.direction, 'deg', { precision: 0 })}T`
+          };
+        }
+        break;
+      }
       case 'region':
         item = [this.skres.fromCache('regions', t[1])];
         if (!item) {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -126,6 +126,10 @@ import { AppIconDef } from '../icons';
 import { LayerWindWeatherComponent } from './ol/lib/resources/layer-wind-weather.component';
 import { LayerCurrentsWeatherComponent } from './ol/lib/resources/layer-currents-weather.component';
 import { TidalCurrentsLayerComponent } from './ol/lib/resources/tidal-currents-layer.component';
+import {
+  TidalCurrentsService,
+  GridSample
+} from './ol/lib/tidal-currents.service';
 
 interface IResource {
   id: string;
@@ -321,6 +325,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   private bottomSheet = inject(MatBottomSheet);
   private infoPanel = inject(InfoPanelFacade);
   protected routeBuffers = inject(RouteBufferRegistry);
+  private tidalCurrents = inject(TidalCurrentsService);
   private ngZone = inject(NgZone);
 
   constructor() {
@@ -1354,7 +1359,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   private s57Features: Record<string, Record<string, string | number>> = {};
-  private tidalFeatures: Record<string, { speedKn: number; direction: number }> = {};
+  private tidalFeatures: Record<
+    string,
+    Pick<GridSample, 'speedKn' | 'direction'>
+  > = {};
 
   // ******** POPOVER ACTIONS ************
 
@@ -1510,11 +1518,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.readOnly = true;
         if (tf) {
           poData.tidal = {
-            speedLabel: this.app.formatValueForDisplay(
-              tf.speedKn / 1.94384,
-              'm/s',
-              { precision: 1 }
-            ),
+            speedLabel: this.tidalCurrents.formatSpeed(tf.speedKn),
             directionLabel: `${this.app.formatValueForDisplay(tf.direction, 'deg', { precision: 0 })}T`
           };
         }

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -40,6 +40,7 @@ export interface IPopover {
   aircraft?: SKAircraft;
   alarm?: AlertData;
   s57Feature?: Record<string, string | number>;
+  tidal?: { speedLabel: string; directionLabel: string };
   readOnly: boolean;
 }
 

--- a/src/app/modules/map/ol/index.ts
+++ b/src/app/modules/map/ol/index.ts
@@ -57,6 +57,7 @@ import { RadarComponent } from './lib/radar/layer-radar.component';
 export * from './lib/util';
 export { MapService } from './lib/map.service';
 export { S57Service } from './lib/charts/s57.service';
+export { TidalCurrentsService } from './lib/tidal-currents.service';
 
 export { ContentComponent } from './lib/content.component';
 export { ControlsDirective } from './lib/controls.directive';
@@ -110,6 +111,7 @@ export { MapStyleJsonChartLayerComponent } from './lib/charts/layer-mapstylejson
 export { S57ChartLayerComponent } from './lib/charts/layer-s57-chart.component';
 export { ChartBoundsLayerComponent } from './lib/charts/layer-chart-bounds.component';
 export { RadarComponent } from './lib/radar/layer-radar.component';
+export { TidalCurrentsLayerComponent } from './lib/resources/tidal-currents-layer.component';
 
 const declarations = [
   ContentComponent,

--- a/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
+++ b/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
@@ -182,9 +182,9 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
         setDeg: point.direction
       });
       feature.setId('tidal.' + index);
-      const driftMs = point.speedKn / 1.94384;
-      const speedLabel = this.app.formatValueForDisplay(driftMs, 'm/s', { precision: 1 });
-      feature.set('name', `Current: ${speedLabel} @ ${point.direction.toFixed(0)}°T`);
+      const speedLabel = this.formatSpeed(point.speedKn);
+      const dirLabel = this.app.formatValueForDisplay(point.direction, 'deg', { precision: 0 });
+      feature.set('name', `Current: ${speedLabel} @ ${dirLabel}T`);
       return feature;
     });
     this.source.addFeatures(features);
@@ -211,8 +211,7 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
     const pixelSize = Math.max(16, Math.min(40, 12 + driftKts * 9));
     const scale = pixelSize / 24;
 
-    const driftMs = driftKts / 1.94384;
-    const speedLabel = this.app.formatValueForDisplay(driftMs, 'm/s', { precision: 1 });
+    const speedLabel = this.formatSpeed(driftKts);
 
     return new Style({
       image: new Icon({
@@ -231,5 +230,10 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
         stroke: new Stroke({ color: 'rgba(20, 60, 95, 0.9)', width: 3 })
       })
     });
+  }
+
+  private formatSpeed(knots: number): string {
+    const driftMs = knots / 1.94384;
+    return this.app.formatValueForDisplay(driftMs, 'm/s', { precision: 1 });
   }
 }

--- a/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
+++ b/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
@@ -65,6 +65,11 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
         this.refresh$.next();
       }
     });
+    this.currents.dragEnd$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        if (this.show && this.layer) this.refresh$.next();
+      });
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -108,11 +113,6 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
         switchMap(() => this.fetchCurrents())
       )
       .subscribe();
-    this.currents.dragEnd$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        if (this.show && this.layer) this.fetchCurrents().subscribe();
-      });
     this.mapComponent.getMap().on('moveend', this.onMoveEnd);
     this.refresh$.next();
     this.mapComponent.getMap().render();
@@ -184,6 +184,9 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
   }
 
   private renderCurrents(points: TidalCurrentGridResponse['points']) {
+    if (!this.source) {
+      return;
+    }
     this.source.clear();
     const features = points.map((point, index) => {
       const feature = new Feature({

--- a/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
+++ b/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
@@ -28,7 +28,10 @@ import {
 import { FeatureLike } from 'ol/Feature';
 import { fromLonLat, transformExtent } from 'ol/proj';
 
-import { TidalCurrentsService, TidalCurrentGridResponse } from '../tidal-currents.service';
+import {
+  TidalCurrentsService,
+  TidalCurrentGridResponse
+} from '../tidal-currents.service';
 import { MapComponent } from '../map.component';
 import { AppFacade } from 'src/app/app.facade';
 
@@ -149,13 +152,15 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
       return of<TidalCurrentGridResponse | null>(null);
     }
 
-    return this.currents.getGridCurrents(bbox, this.currents.selectedTime()).pipe(
-      tap((response) => this.renderCurrents(response.points)),
-      catchError(() => {
-        console.warn('Failed to fetch tidal currents');
-        return of<TidalCurrentGridResponse | null>(null);
-      })
-    );
+    return this.currents
+      .getGridCurrents(bbox, this.currents.selectedTime())
+      .pipe(
+        tap((response) => this.renderCurrents(response.points)),
+        catchError(() => {
+          console.warn('Failed to fetch tidal currents');
+          return of<TidalCurrentGridResponse | null>(null);
+        })
+      );
   }
 
   private getBbox(): [number, number, number, number] | null {
@@ -170,7 +175,12 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
       'EPSG:3857',
       'EPSG:4326'
     );
-    return [extent[0], extent[1], extent[2], extent[3]] as [number, number, number, number];
+    return [extent[0], extent[1], extent[2], extent[3]] as [
+      number,
+      number,
+      number,
+      number
+    ];
   }
 
   private renderCurrents(points: TidalCurrentGridResponse['points']) {
@@ -182,8 +192,10 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
         setDeg: point.direction
       });
       feature.setId('tidal.' + index);
-      const speedLabel = this.formatSpeed(point.speedKn);
-      const dirLabel = this.app.formatValueForDisplay(point.direction, 'deg', { precision: 0 });
+      const speedLabel = this.currents.formatSpeed(point.speedKn);
+      const dirLabel = this.app.formatValueForDisplay(point.direction, 'deg', {
+        precision: 0
+      });
       feature.set('name', `Current: ${speedLabel} @ ${dirLabel}T`);
       return feature;
     });
@@ -211,7 +223,7 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
     const pixelSize = Math.max(16, Math.min(40, 12 + driftKts * 9));
     const scale = pixelSize / 24;
 
-    const speedLabel = this.formatSpeed(driftKts);
+    const speedLabel = this.currents.formatSpeed(driftKts);
 
     return new Style({
       image: new Icon({
@@ -230,10 +242,5 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
         stroke: new Stroke({ color: 'rgba(20, 60, 95, 0.9)', width: 3 })
       })
     });
-  }
-
-  private formatSpeed(knots: number): string {
-    const driftMs = knots / 1.94384;
-    return this.app.formatValueForDisplay(driftMs, 'm/s', { precision: 1 });
   }
 }

--- a/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
+++ b/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
@@ -1,0 +1,235 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  effect,
+  inject,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import VectorLayer from 'ol/layer/Vector';
+import VectorSource from 'ol/source/Vector';
+import { Fill, Icon, Stroke, Style, Text } from 'ol/style';
+import {
+  Subject,
+  Subscription,
+  auditTime,
+  catchError,
+  of,
+  switchMap,
+  tap
+} from 'rxjs';
+import { FeatureLike } from 'ol/Feature';
+import { fromLonLat, transformExtent } from 'ol/proj';
+
+import { TidalCurrentsService, TidalCurrentGridResponse } from '../tidal-currents.service';
+import { MapComponent } from '../map.component';
+import { AppFacade } from 'src/app/app.facade';
+
+@Component({
+  selector: 'ol-map > fb-tidal-currents',
+  template: '<ng-content></ng-content>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true
+})
+export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
+  @Input() show = false;
+  @Input() opacity = 0.7;
+
+  private layer: VectorLayer<VectorSource>;
+  private source: VectorSource;
+  private refresh$ = new Subject<void>();
+  private refreshSub: Subscription;
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly zIndex = 50;
+
+  constructor(
+    private mapComponent: MapComponent,
+    private currents: TidalCurrentsService,
+    private app: AppFacade,
+    changeDetectorRef: ChangeDetectorRef
+  ) {
+    changeDetectorRef.detach();
+    effect(() => {
+      this.currents.scrubTime();
+      if (this.show && this.layer) {
+        this.refresh$.next();
+      }
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (typeof changes.opacity !== 'undefined' && this.layer) {
+      this.layer.setOpacity(this.normalizedOpacity);
+    }
+
+    if (this.show) {
+      this.addLayer();
+    } else {
+      this.removeLayer();
+    }
+  }
+
+  ngOnDestroy() {
+    this.refreshSub?.unsubscribe();
+    this.removeLayer();
+  }
+
+  private addLayer() {
+    if (this.layer) {
+      this.layer.setOpacity(this.normalizedOpacity);
+      this.refresh$.next();
+      return;
+    }
+
+    this.source = new VectorSource();
+    this.layer = new VectorLayer({
+      source: this.source,
+      opacity: this.normalizedOpacity,
+      zIndex: this.zIndex,
+      visible: this.show,
+      style: (feature) => this.currentsStyleFunction(feature)
+    });
+    this.layer.set('id', 'tidal-currents');
+    this.mapComponent.getMap().addLayer(this.layer);
+
+    this.refreshSub = this.refresh$
+      .pipe(
+        auditTime(300),
+        switchMap(() => this.fetchCurrents())
+      )
+      .subscribe();
+    this.currents.dragEnd$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        if (this.show && this.layer) this.fetchCurrents().subscribe();
+      });
+    this.mapComponent.getMap().on('moveend', this.onMoveEnd);
+    this.refresh$.next();
+    this.mapComponent.getMap().render();
+  }
+
+  private removeLayer() {
+    const map = this.mapComponent.getMap();
+    if (!map || !this.layer) {
+      return;
+    }
+
+    map.un('moveend', this.onMoveEnd);
+    this.refreshSub?.unsubscribe();
+    this.refreshSub = undefined;
+    map.removeLayer(this.layer);
+    this.source?.clear();
+    this.source = undefined;
+    this.layer = undefined;
+    map.render();
+  }
+
+  private onMoveEnd = () => {
+    this.refresh$.next();
+  };
+
+  private get normalizedOpacity() {
+    return Math.max(0, Math.min(1, this.opacity ?? 1));
+  }
+
+  private fetchCurrents() {
+    if (!this.show || !this.source) {
+      return of<TidalCurrentGridResponse | null>(null);
+    }
+
+    const bbox = this.getBbox();
+    if (!bbox) {
+      return of<TidalCurrentGridResponse | null>(null);
+    }
+
+    return this.currents.getGridCurrents(bbox, this.currents.selectedTime()).pipe(
+      tap((response) => this.renderCurrents(response.points)),
+      catchError(() => {
+        console.warn('Failed to fetch tidal currents');
+        return of<TidalCurrentGridResponse | null>(null);
+      })
+    );
+  }
+
+  private getBbox(): [number, number, number, number] | null {
+    const map = this.mapComponent.getMap();
+    const size = map.getSize();
+    if (!size) {
+      return null;
+    }
+
+    const extent = transformExtent(
+      map.getView().calculateExtent(size),
+      'EPSG:3857',
+      'EPSG:4326'
+    );
+    return [extent[0], extent[1], extent[2], extent[3]] as [number, number, number, number];
+  }
+
+  private renderCurrents(points: TidalCurrentGridResponse['points']) {
+    this.source.clear();
+    const features = points.map((point, index) => {
+      const feature = new Feature({
+        geometry: new Point(fromLonLat([point.longitude, point.latitude])),
+        driftKts: point.speedKn,
+        setDeg: point.direction
+      });
+      feature.setId('tidal.' + index);
+      const driftMs = point.speedKn / 1.94384;
+      const speedLabel = this.app.formatValueForDisplay(driftMs, 'm/s', { precision: 1 });
+      feature.set('name', `Current: ${speedLabel} @ ${point.direction.toFixed(0)}°T`);
+      return feature;
+    });
+    this.source.addFeatures(features);
+  }
+
+  private currentsStyleFunction(feature: FeatureLike) {
+    const driftKts = Number(feature.get('driftKts')) || 0;
+    const setDeg = Number(feature.get('setDeg')) || 0;
+    const setRad = (setDeg * Math.PI) / 180;
+
+    let color = '#28a745';
+    if (driftKts >= 2.0) {
+      color = '#dc3545';
+    } else if (driftKts >= 1.0) {
+      color = '#ffc107';
+    }
+
+    const svg = `
+      <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 2L19 10H14V22H10V10H5L12 2Z" fill="${color}" stroke="#000" stroke-width="1"/>
+      </svg>`;
+
+    const src = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+    const pixelSize = Math.max(16, Math.min(40, 12 + driftKts * 9));
+    const scale = pixelSize / 24;
+
+    const driftMs = driftKts / 1.94384;
+    const speedLabel = this.app.formatValueForDisplay(driftMs, 'm/s', { precision: 1 });
+
+    return new Style({
+      image: new Icon({
+        src: src,
+        rotation: setRad,
+        scale: scale,
+        anchor: [0.5, 0.5],
+        anchorXUnits: 'fraction',
+        anchorYUnits: 'fraction'
+      }),
+      text: new Text({
+        text: speedLabel,
+        offsetY: 14,
+        font: '11px Roboto, Arial, sans-serif',
+        fill: new Fill({ color: 'rgba(255, 255, 255, 0.95)' }),
+        stroke: new Stroke({ color: 'rgba(20, 60, 95, 0.9)', width: 3 })
+      })
+    });
+  }
+}

--- a/src/app/modules/map/ol/lib/tidal-currents.service.ts
+++ b/src/app/modules/map/ol/lib/tidal-currents.service.ts
@@ -1,0 +1,187 @@
+import { computed, Injectable, signal, WritableSignal } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import { SignalKClient } from 'signalk-client-angular';
+import { AppFacade } from 'src/app/app.facade';
+
+export interface GridSample {
+  latitude: number;
+  longitude: number;
+  speedKn: number;
+  direction: number;
+  u: number;
+  v: number;
+}
+
+export interface TidalCurrentGridResponse {
+  time: string;
+  units: {
+    speedKn: string;
+    u: string;
+    v: string;
+  };
+  points: GridSample[];
+}
+
+export interface HourTick {
+  ms: number;
+  pct: number;
+  isDayStart: boolean;
+}
+
+export interface HourLabel {
+  ms: number;
+  pct: number;
+  label: string;
+  isDayStart: boolean;
+}
+
+const PLAY_STEP_MS = 600;
+const STEP_MINUTES = 15;
+
+@Injectable({ providedIn: 'root' })
+export class TidalCurrentsService {
+  /** Absolute ms timestamp of the bar center. Null = "now" (no time param). */
+  readonly scrubTime: WritableSignal<number | null> = signal(null);
+  readonly isPlaying = signal(false);
+  readonly dragEnd$ = new Subject<void>();
+  private playTimer: ReturnType<typeof setInterval> | null = null;
+
+  /** Thin vertical lines at each whole-hour boundary. */
+  readonly hourTicks = computed(() => {
+    const st = this.scrubTime() ?? Date.now();
+    const wStart = st - 12 * 3600_000;
+    const wEnd = st + 12 * 3600_000;
+    const hourMs = 3600_000;
+    const totalMs = wEnd - wStart;
+    const ticks: HourTick[] = [];
+    const firstHour = Math.floor(wStart / hourMs) * hourMs;
+    let t = firstHour;
+    while (t <= wEnd) {
+      const pct = ((t - wStart) / totalMs) * 100;
+      if (pct >= -3 && pct <= 103) {
+        ticks.push({ ms: t, pct, isDayStart: new Date(t).getHours() === 0 });
+      }
+      t += hourMs;
+    }
+    return ticks;
+  });
+
+  /** Labels centered within each hour segment. */
+  readonly hourLabels = computed(() => {
+    const st = this.scrubTime() ?? Date.now();
+    const wStart = st - 12 * 3600_000;
+    const wEnd = st + 12 * 3600_000;
+    const hourMs = 3600_000;
+    const totalMs = wEnd - wStart;
+    const labels: HourLabel[] = [];
+    const firstHour = Math.floor(wStart / hourMs) * hourMs;
+    let t = firstHour;
+    while (t < wEnd) {
+      const segEnd = Math.min(t + hourMs, wEnd);
+      const midMs = (t + segEnd) / 2;
+      const midPct = ((midMs - wStart) / totalMs) * 100;
+      const h = new Date(midMs).getHours();
+      labels.push({
+        ms: midMs,
+        pct: midPct,
+        label: h % 2 === 0 ? String(h).padStart(2, '0') : '',
+        isDayStart: h === 0,
+      });
+      t += hourMs;
+    }
+    return labels;
+  });
+
+  /** CSS gradient string with stops shifted to align with actual hour boundaries. */
+  readonly barBgGradient = computed(() => {
+    const st = this.scrubTime() ?? Date.now();
+    const wStart = st - 12 * 3600_000;
+    const totalMs = 24 * 3600_000;
+    const firstHour = Math.floor(wStart / 3600_000) * 3600_000;
+    const off = ((firstHour - wStart) / totalMs) * 100;
+    const hw = 100 / 24;
+    const shade = this.app.uiConfig().invertColor
+      ? 'rgba(255,255,255,0.07)'
+      : 'rgba(0,0,0,0.06)';
+    return `repeating-linear-gradient(to right, transparent ${off}%, transparent ${off + hw}%, ${shade} ${off + hw}%, ${shade} ${off + 2 * hw}%)`;
+  });
+
+  constructor(private sk: SignalKClient, private app: AppFacade) {}
+
+  getGridCurrents(
+    bbox: [number, number, number, number],
+    time?: Date
+  ): Observable<TidalCurrentGridResponse> {
+    const [w, s, e, n] = bbox;
+    let url = `/currents/grid?bbox=${w},${s},${e},${n}&maxPoints=200`;
+    if (time) {
+      url += `&time=${time.toISOString()}`;
+    }
+    return this.sk.api.get(2, url);
+  }
+
+  /** Absolute selected Date (or null for "now"). */
+  selectedTime(): Date | null {
+    const t = this.scrubTime();
+    return t !== null ? new Date(t) : null;
+  }
+
+  /** Center the bar on the time at the given fractional position (0 = left edge, 1 = right edge). */
+  setFromBarPosition(percent: number) {
+    const current = this.scrubTime() ?? Date.now();
+    const hourOffset = (percent - 0.5) * 24;
+    this.scrubTime.set(current + hourOffset * 3600_000);
+  }
+
+  stepForward() {
+    const current = this.scrubTime() ?? Date.now();
+    this.scrubTime.set(current + STEP_MINUTES * 60_000);
+  }
+
+  stepBack() {
+    const current = this.scrubTime() ?? Date.now();
+    this.scrubTime.set(current - STEP_MINUTES * 60_000);
+  }
+
+  stepForwardBig() {
+    const current = this.scrubTime() ?? Date.now();
+    this.scrubTime.set(current + 3600_000);
+  }
+
+  stepBackBig() {
+    const current = this.scrubTime() ?? Date.now();
+    this.scrubTime.set(current - 3600_000);
+  }
+
+  resetToNow() {
+    this.pause();
+    this.scrubTime.set(null);
+  }
+
+  togglePlay() {
+    if (this.isPlaying()) {
+      this.pause();
+    } else {
+      this.play();
+    }
+  }
+
+  play() {
+    if (this.playTimer) return;
+    this.isPlaying.set(true);
+    if (this.scrubTime() === null) {
+      this.scrubTime.set(Date.now());
+    }
+    this.playTimer = setInterval(() => {
+      this.stepForward();
+    }, PLAY_STEP_MS);
+  }
+
+  pause() {
+    if (this.playTimer) {
+      clearInterval(this.playTimer);
+      this.playTimer = null;
+    }
+    this.isPlaying.set(false);
+  }
+}

--- a/src/app/modules/map/ol/lib/tidal-currents.service.ts
+++ b/src/app/modules/map/ol/lib/tidal-currents.service.ts
@@ -46,9 +46,12 @@ export class TidalCurrentsService {
   readonly dragEnd$ = new Subject<void>();
   private playTimer: ReturnType<typeof setInterval> | null = null;
 
+  /** Ticks once a minute so "now"-based computed values keep advancing while scrubTime is null. */
+  private readonly clockTick = signal(Date.now());
+
   /** Thin vertical lines at each whole-hour boundary. */
   readonly hourTicks = computed(() => {
-    const st = this.scrubTime() ?? Date.now();
+    const st = this.scrubTime() ?? this.clockTick();
     const wStart = st - 12 * 3600_000;
     const wEnd = st + 12 * 3600_000;
     const hourMs = 3600_000;
@@ -68,7 +71,7 @@ export class TidalCurrentsService {
 
   /** Labels centered within each hour segment. */
   readonly hourLabels = computed(() => {
-    const st = this.scrubTime() ?? Date.now();
+    const st = this.scrubTime() ?? this.clockTick();
     const wStart = st - 12 * 3600_000;
     const wEnd = st + 12 * 3600_000;
     const hourMs = 3600_000;
@@ -94,7 +97,7 @@ export class TidalCurrentsService {
 
   /** CSS gradient string with stops shifted to align with actual hour boundaries. */
   readonly barBgGradient = computed(() => {
-    const st = this.scrubTime() ?? Date.now();
+    const st = this.scrubTime() ?? this.clockTick();
     const wStart = st - 12 * 3600_000;
     const totalMs = 24 * 3600_000;
     const firstHour = Math.floor(wStart / 3600_000) * 3600_000;
@@ -106,7 +109,9 @@ export class TidalCurrentsService {
     return `repeating-linear-gradient(to right, transparent ${off}%, transparent ${off + hw}%, ${shade} ${off + hw}%, ${shade} ${off + 2 * hw}%)`;
   });
 
-  constructor(private sk: SignalKClient, private app: AppFacade) {}
+  constructor(private sk: SignalKClient, private app: AppFacade) {
+    setInterval(() => this.clockTick.set(Date.now()), 60_000);
+  }
 
   getGridCurrents(
     bbox: [number, number, number, number],
@@ -145,12 +150,12 @@ export class TidalCurrentsService {
 
   stepForwardBig() {
     const current = this.scrubTime() ?? Date.now();
-    this.scrubTime.set(current + 3600_000);
+    this.scrubTime.set(current + 6 * 3600_000);
   }
 
   stepBackBig() {
     const current = this.scrubTime() ?? Date.now();
-    this.scrubTime.set(current - 3600_000);
+    this.scrubTime.set(current - 6 * 3600_000);
   }
 
   resetToNow() {

--- a/src/app/modules/map/ol/lib/tidal-currents.service.ts
+++ b/src/app/modules/map/ol/lib/tidal-currents.service.ts
@@ -88,7 +88,7 @@ export class TidalCurrentsService {
         ms: midMs,
         pct: midPct,
         label: h % 2 === 0 ? String(h).padStart(2, '0') : '',
-        isDayStart: h === 0,
+        isDayStart: h === 0
       });
       t += hourMs;
     }
@@ -109,8 +109,17 @@ export class TidalCurrentsService {
     return `repeating-linear-gradient(to right, transparent ${off}%, transparent ${off + hw}%, ${shade} ${off + hw}%, ${shade} ${off + 2 * hw}%)`;
   });
 
-  constructor(private sk: SignalKClient, private app: AppFacade) {
+  constructor(
+    private sk: SignalKClient,
+    private app: AppFacade
+  ) {
     setInterval(() => this.clockTick.set(Date.now()), 60_000);
+  }
+
+  /** Formats a current speed (in knots) for display in the user's preferred units. */
+  formatSpeed(knots: number): string {
+    const driftMs = knots / 1.94384;
+    return this.app.formatValueForDisplay(driftMs, 'm/s', { precision: 1 });
   }
 
   getGridCurrents(
@@ -118,9 +127,9 @@ export class TidalCurrentsService {
     time?: Date
   ): Observable<TidalCurrentGridResponse> {
     const [w, s, e, n] = bbox;
-    let url = `/currents/grid?bbox=${w},${s},${e},${n}&maxPoints=200`;
+    let url = `/currents/grid?bbox=${encodeURIComponent(`${w},${s},${e},${n}`)}&maxPoints=200`;
     if (time) {
-      url += `&time=${time.toISOString()}`;
+      url += `&time=${encodeURIComponent(time.toISOString())}`;
     }
     return this.sk.api.get(2, url);
   }

--- a/src/app/modules/map/ol/lib/tidal-currents.service.ts
+++ b/src/app/modules/map/ol/lib/tidal-currents.service.ts
@@ -2,7 +2,20 @@ import { computed, Injectable, signal, WritableSignal } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { SignalKClient } from 'signalk-client-angular';
 import { AppFacade } from 'src/app/app.facade';
+import { Convert } from 'src/app/lib/convert';
 
+// Targets the `signalk-tidal-currents` plugin v0.2.0 `/currents/grid` response, e.g.:
+// { time: "2026-07-10T09:00:00.000Z",
+//   units: { speedKn: "knots (magnitude)", u: "m/s east", v: "m/s north" },
+//   points: [{ latitude: 51.2, longitude: 3.9, speedKn: 1.4, direction: 214.0,
+//              u: -0.57, v: -0.4 }, ...] }
+// `speedKn` is always knots and `direction` always degrees true ("direction
+// TOWARD", the oceanographic convention) — fixed by the plugin, not
+// user/request configurable. `u`/`v` are the east/north velocity components
+// (unused today; the `units` object itself is never read, only the point
+// fields). That plugin is still pre-1.0, so a later 0.x release is free to
+// change this under semver — if the overlay stops rendering after a plugin
+// update, diff its actual response against this shape first.
 export interface GridSample {
   latitude: number;
   longitude: number;
@@ -36,7 +49,7 @@ export interface HourLabel {
 }
 
 const PLAY_STEP_MS = 600;
-const STEP_MINUTES = 15;
+const STEP_MINUTES = 60;
 
 @Injectable({ providedIn: 'root' })
 export class TidalCurrentsService {
@@ -118,7 +131,7 @@ export class TidalCurrentsService {
 
   /** Formats a current speed (in knots) for display in the user's preferred units. */
   formatSpeed(knots: number): string {
-    const driftMs = knots / 1.94384;
+    const driftMs = knots / Convert.transform(1, 'm/s', 'kn');
     return this.app.formatValueForDisplay(driftMs, 'm/s', { precision: 1 });
   }
 

--- a/src/app/modules/map/popovers/popover.component.scss
+++ b/src/app/modules/map/popovers/popover.component.scss
@@ -120,3 +120,20 @@
     flex:1 1 45%;
 }
 
+.popover.compact {
+    min-width: 0;
+    max-width: 170px;
+    width: fit-content;
+}
+
+.popover.compact > .popover-title {
+    padding: 0;
+    line-height: 0;
+    min-height: 0;
+    min-width: unset;
+}
+
+.popover.compact > .popover-content {
+    padding: 6px 10px;
+}
+

--- a/src/app/modules/map/popovers/popover.component.ts
+++ b/src/app/modules/map/popovers/popover.component.ts
@@ -35,7 +35,7 @@ measure: boolean= measure mode;
   template: `
     <div
       class="popover top in mat-app-background"
-      [ngClass]="{ measure: measure }"
+      [ngClass]="{ measure: measure, compact: compact }"
     >
       <div class="popover-title">
         <div
@@ -98,6 +98,7 @@ export class PopoverComponent {
   @Input() icon: { class: string; name?: string; svgIcon?: string };
   @Input() canClose = true;
   @Input() measure = false;
+  @Input() compact = false;
   @Input() navTo = false;
   @Output() closed: EventEmitter<void> = new EventEmitter();
   @Output() navigateTo: EventEmitter<void> = new EventEmitter();

--- a/src/app/modules/map/popovers/popover.component.ts
+++ b/src/app/modules/map/popovers/popover.component.ts
@@ -37,52 +37,59 @@ measure: boolean= measure mode;
       class="popover top in mat-app-background"
       [ngClass]="{ measure: measure, compact: compact }"
     >
-      <div class="popover-title">
-        <div
-          [ngClass]="{ measure: measure }"
-          style="flex: 1 1 auto;overflow: hidden;
-                                display: -webkit-box;
-                                -webkit-box-orient: vertical;
-                                -webkit-line-clamp: 1;
-                                line-clamp: 1;
-                                text-overflow:ellipsis;"
-        >
-          @if (mmsi) {
-            <mat-icon>
-              <country-flag
-                [mmsi]="mmsi"
-                [host]="app.hostDef.url"
-              ></country-flag>
-            </mat-icon>
-          }
+      @if (title || icon || mmsi || canClose || navTo) {
+        <div class="popover-title">
+          <div
+            [ngClass]="{ measure: measure }"
+            style="flex: 1 1 auto;overflow: hidden;
+                                  display: -webkit-box;
+                                  -webkit-box-orient: vertical;
+                                  -webkit-line-clamp: 1;
+                                  line-clamp: 1;
+                                  text-overflow:ellipsis;"
+          >
+            @if (mmsi) {
+              <mat-icon>
+                <country-flag
+                  [mmsi]="mmsi"
+                  [host]="app.hostDef.url"
+                ></country-flag>
+              </mat-icon>
+            }
 
-          @if (icon?.svgIcon) {
-            <mat-icon [class]="icon?.class" [svgIcon]="icon.svgIcon"></mat-icon>
-          } @else {
-            <mat-icon [class]="icon?.class">{{ icon?.name }}</mat-icon>
-          }
+            @if (icon?.svgIcon) {
+              <mat-icon
+                [class]="icon?.class"
+                [svgIcon]="icon.svgIcon"
+              ></mat-icon>
+            } @else if (icon?.name) {
+              <mat-icon [class]="icon?.class">{{ icon?.name }}</mat-icon>
+            }
 
-          &nbsp;{{ title }}
+            @if (title) {
+              &nbsp;{{ title }}
+            }
+          </div>
+          @if (canClose) {
+            <div style="">
+              <button mat-icon-button (click)="handleClose()">
+                <mat-icon>close</mat-icon>
+              </button>
+            </div>
+          }
+          @if (!canClose && navTo) {
+            <div style="">
+              <button
+                mat-icon-button
+                matTooltip="Navigate to here"
+                (click)="handleNavTo()"
+              >
+                <mat-icon>near_me</mat-icon>
+              </button>
+            </div>
+          }
         </div>
-        @if (canClose) {
-          <div style="">
-            <button mat-icon-button (click)="handleClose()">
-              <mat-icon>close</mat-icon>
-            </button>
-          </div>
-        }
-        @if (!canClose && navTo) {
-          <div style="">
-            <button
-              mat-icon-button
-              matTooltip="Navigate to here"
-              (click)="handleNavTo()"
-            >
-              <mat-icon>near_me</mat-icon>
-            </button>
-          </div>
-        }
-      </div>
+      }
       <div class="popover-content">
         <ng-content></ng-content>
       </div>

--- a/src/app/modules/skresources/components/weather/weatherlist.html
+++ b/src/app/modules/skresources/components/weather/weatherlist.html
@@ -1,5 +1,5 @@
 <div class="resourcelist">
-  <mat-card style="border-radius: unset">
+  <mat-card style="border-radius: unset; height: 100%; box-sizing: border-box;">
     <mat-card-title>
       <div class="title-block">
         <div style="width: 50px">
@@ -49,6 +49,141 @@
           Enable ocean currents layer
         </mat-checkbox>
       </div>
+      @if (app.featureFlags().tidalApi) {
+      <div style="border-bottom: 1px solid #ccc; margin: 8px 0"></div>
+      <div
+        style="font-size: 11px; font-weight: 500; padding: 4px 0; color: #888"
+      >
+        TIDAL CURRENTS (SIGNALK PLUGIN)
+      </div>
+      <div style="display: flex; align-items: center; padding: 2px 0">
+        <mat-checkbox
+          [checked]="app.config.selections.tidalCurrentsEnabled"
+          (change)="toggleTidalCurrents($event.checked)"
+          matTooltip="Toggle tidal currents overlay"
+          matTooltipPosition="right"
+        >
+          Enable tidal currents layer
+        </mat-checkbox>
+      </div>
+      @if (app.config.selections.tidalCurrentsEnabled) {
+      <div style="margin-top: 6px; border-top: 1px solid #333; padding-top: 6px">
+        <!-- clickable/draggable 24h time bar -->
+        <div
+          #timeBar
+          style="position: relative; height: 28px; margin-bottom: 10px; user-select: none; touch-action: none"
+          (pointerdown)="onBarPointerDown($event, timeBar)"
+        >
+          <div
+            style="position: relative; height: 24px; border-radius: 4px; overflow: hidden; cursor: pointer; backdrop-filter: blur(6px)"
+            [style.background]="app.uiConfig().invertColor ? 'rgba(11,26,43,0.85)' : 'rgba(240,244,248,0.9)'"
+            [style.border]="app.uiConfig().invertColor ? '1px solid rgba(79,148,212,0.35)' : '1px solid rgba(79,148,212,0.5)'"
+          >
+            <!-- alternating background aligned to hour boundaries -->
+            <div
+              style="position: absolute; inset: 0; pointer-events: none"
+              [style.background]="currents.barBgGradient()"
+            ></div>
+            <!-- hour tick lines -->
+            @for (tick of currents.hourTicks(); track tick.ms) {
+            <div
+              [style.left.%]="tick.pct"
+              [style.borderLeft]="tick.isDayStart ? '2px dashed #7fd4ff' : (app.uiConfig().invertColor ? '1px solid rgba(255,255,255,0.1)' : '1px solid rgba(0,0,0,0.12)')"
+              style="position: absolute; top: 0; bottom: 0; pointer-events: none"
+            ></div>
+            }
+            <!-- centered hour labels -->
+            @for (lb of currents.hourLabels(); track lb.ms) {
+            <div
+              [style.left.%]="lb.pct"
+              style="position: absolute; top: 0; bottom: 0; transform: translateX(-50%); pointer-events: none; display: flex; align-items: center; justify-content: center"
+            >
+              @if (lb.label) {
+              <span style="font-size: 9px; white-space: nowrap; margin-top: 18px" [style.color]="app.uiConfig().invertColor ? '#7fa8cf' : '#4a6a8a'">{{ lb.label }}</span>
+              }
+            </div>
+            }
+          </div>
+          <!-- now-tick (dashed, visible when center != now) -->
+          @if (nowTickPct() != null) {
+          <div
+            [style.left.%]="nowTickPct()"
+            style="position: absolute; top: 0; bottom: 0; pointer-events: none; z-index: 1"
+            [style.borderLeft]="'1px dashed ' + (app.uiConfig().invertColor ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.4)')"
+          ></div>
+          }
+          <!-- center marker -->
+          <div
+            style="position: absolute; top: 0; bottom: 0; left: 50%; width: 3px; background: #f2b84b; box-shadow: 0 0 6px rgba(242,184,75,0.8); transform: translateX(-1.5px); pointer-events: none; z-index: 2"
+          ></div>
+          <!-- pill (time label above marker) -->
+          <div
+            style="position: absolute; top: -4px; left: 50%; transform: translate(-50%, -100%); background: #f2b84b; color: #1a2c3d; font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 9px; white-space: nowrap; pointer-events: none; z-index: 3; box-shadow: 0 2px 6px rgba(0,0,0,0.4)"
+          >
+            {{ fmtScrubTime() }}
+          </div>
+        </div>
+        <!-- step buttons -->
+        <div style="display: flex; align-items: center; gap: 3px">
+          <button
+            mat-icon-button
+            (click)="currents.stepBackBig()"
+            matTooltip="-6h"
+            matTooltipPosition="top"
+            style="width: 26px; height: 26px; line-height: 26px"
+          >
+            <mat-icon style="font-size: 14px">skip_previous</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            (click)="currents.stepBack()"
+            matTooltip="-1h"
+            matTooltipPosition="top"
+            style="width: 26px; height: 26px; line-height: 26px"
+          >
+            <mat-icon style="font-size: 14px">chevron_left</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            (click)="currents.togglePlay()"
+            [matTooltip]="currents.isPlaying() ? 'Pause' : 'Play'"
+            matTooltipPosition="top"
+            style="width: 30px; height: 30px; line-height: 30px"
+          >
+            <mat-icon style="font-size: 18px">{{ currents.isPlaying() ? 'pause' : 'play_arrow' }}</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            (click)="currents.stepForward()"
+            matTooltip="+1h"
+            matTooltipPosition="top"
+            style="width: 26px; height: 26px; line-height: 26px"
+          >
+            <mat-icon style="font-size: 14px">chevron_right</mat-icon>
+          </button>
+          <button
+            mat-icon-button
+            (click)="currents.stepForwardBig()"
+            matTooltip="+6h"
+            matTooltipPosition="top"
+            style="width: 26px; height: 26px; line-height: 26px"
+          >
+            <mat-icon style="font-size: 14px">skip_next</mat-icon>
+          </button>
+          <span style="flex: 1"></span>
+          <button
+            mat-button
+            (click)="currents.resetToNow()"
+            matTooltip="Reset to Now"
+            matTooltipPosition="top"
+            style="min-width: unset; padding: 0 8px; font-size: 11px; line-height: 26px; height: 26px"
+          >
+            Now
+          </button>
+        </div>
+      </div>
+      }
+      }
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/app/modules/skresources/components/weather/weatherlist.html
+++ b/src/app/modules/skresources/components/weather/weatherlist.html
@@ -1,5 +1,5 @@
 <div class="resourcelist">
-  <mat-card style="border-radius: unset; height: 100%; box-sizing: border-box;">
+  <mat-card style="border-radius: unset; height: 100%; box-sizing: border-box">
     <mat-card-title>
       <div class="title-block">
         <div style="width: 50px">
@@ -67,15 +67,30 @@
         </mat-checkbox>
       </div>
       @if (app.config.selections.tidalCurrentsEnabled) {
-      <div style="margin-top: 6px; border-top: 1px solid #333; padding-top: 6px">
+      <div
+        style="margin-top: 6px; border-top: 1px solid #333; padding-top: 6px"
+      >
         <!-- clickable/draggable 24h time bar -->
         <div
           #timeBar
-          style="position: relative; height: 28px; margin-bottom: 10px; user-select: none; touch-action: none"
+          style="
+            position: relative;
+            height: 28px;
+            margin-bottom: 10px;
+            user-select: none;
+            touch-action: none;
+          "
           (pointerdown)="onBarPointerDown($event, timeBar)"
         >
           <div
-            style="position: relative; height: 24px; border-radius: 4px; overflow: hidden; cursor: pointer; backdrop-filter: blur(6px)"
+            style="
+              position: relative;
+              height: 24px;
+              border-radius: 4px;
+              overflow: hidden;
+              cursor: pointer;
+              backdrop-filter: blur(6px);
+            "
             [style.background]="app.uiConfig().invertColor ? 'rgba(11,26,43,0.85)' : 'rgba(240,244,248,0.9)'"
             [style.border]="app.uiConfig().invertColor ? '1px solid rgba(79,148,212,0.35)' : '1px solid rgba(79,148,212,0.5)'"
           >
@@ -89,17 +104,35 @@
             <div
               [style.left.%]="tick.pct"
               [style.borderLeft]="tick.isDayStart ? '2px dashed #7fd4ff' : (app.uiConfig().invertColor ? '1px solid rgba(255,255,255,0.1)' : '1px solid rgba(0,0,0,0.12)')"
-              style="position: absolute; top: 0; bottom: 0; pointer-events: none"
+              style="
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                pointer-events: none;
+              "
             ></div>
             }
             <!-- centered hour labels -->
             @for (lb of currents.hourLabels(); track lb.ms) {
             <div
               [style.left.%]="lb.pct"
-              style="position: absolute; top: 0; bottom: 0; transform: translateX(-50%); pointer-events: none; display: flex; align-items: center; justify-content: center"
+              style="
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                transform: translateX(-50%);
+                pointer-events: none;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+              "
             >
               @if (lb.label) {
-              <span style="font-size: 9px; white-space: nowrap; margin-top: 18px" [style.color]="app.uiConfig().invertColor ? '#7fa8cf' : '#4a6a8a'">{{ lb.label }}</span>
+              <span
+                style="font-size: 9px; white-space: nowrap; margin-top: 18px"
+                [style.color]="app.uiConfig().invertColor ? '#7fa8cf' : '#4a6a8a'"
+                >{{ lb.label }}</span
+              >
               }
             </div>
             }
@@ -108,17 +141,49 @@
           @if (nowTickPct() != null) {
           <div
             [style.left.%]="nowTickPct()"
-            style="position: absolute; top: 0; bottom: 0; pointer-events: none; z-index: 1"
+            style="
+              position: absolute;
+              top: 0;
+              bottom: 0;
+              pointer-events: none;
+              z-index: 1;
+            "
             [style.borderLeft]="'1px dashed ' + (app.uiConfig().invertColor ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.4)')"
           ></div>
           }
           <!-- center marker -->
           <div
-            style="position: absolute; top: 0; bottom: 0; left: 50%; width: 3px; background: #f2b84b; box-shadow: 0 0 6px rgba(242,184,75,0.8); transform: translateX(-1.5px); pointer-events: none; z-index: 2"
+            style="
+              position: absolute;
+              top: 0;
+              bottom: 0;
+              left: 50%;
+              width: 3px;
+              background: #f2b84b;
+              box-shadow: 0 0 6px rgba(242, 184, 75, 0.8);
+              transform: translateX(-1.5px);
+              pointer-events: none;
+              z-index: 2;
+            "
           ></div>
           <!-- pill (time label above marker) -->
           <div
-            style="position: absolute; top: -4px; left: 50%; transform: translate(-50%, -100%); background: #f2b84b; color: #1a2c3d; font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 9px; white-space: nowrap; pointer-events: none; z-index: 3; box-shadow: 0 2px 6px rgba(0,0,0,0.4)"
+            style="
+              position: absolute;
+              top: -4px;
+              left: 50%;
+              transform: translate(-50%, -100%);
+              background: #f2b84b;
+              color: #1a2c3d;
+              font-size: 10px;
+              font-weight: 700;
+              padding: 2px 7px;
+              border-radius: 9px;
+              white-space: nowrap;
+              pointer-events: none;
+              z-index: 3;
+              box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+            "
           >
             {{ fmtScrubTime() }}
           </div>
@@ -129,7 +194,7 @@
             mat-icon-button
             (click)="currents.stepBackBig()"
             matTooltip="-6h"
-            matTooltipPosition="top"
+            matTooltipPosition="below"
             style="width: 26px; height: 26px; line-height: 26px"
           >
             <mat-icon style="font-size: 14px">skip_previous</mat-icon>
@@ -138,7 +203,7 @@
             mat-icon-button
             (click)="currents.stepBack()"
             matTooltip="-1h"
-            matTooltipPosition="top"
+            matTooltipPosition="below"
             style="width: 26px; height: 26px; line-height: 26px"
           >
             <mat-icon style="font-size: 14px">chevron_left</mat-icon>
@@ -147,16 +212,18 @@
             mat-icon-button
             (click)="currents.togglePlay()"
             [matTooltip]="currents.isPlaying() ? 'Pause' : 'Play'"
-            matTooltipPosition="top"
+            matTooltipPosition="below"
             style="width: 30px; height: 30px; line-height: 30px"
           >
-            <mat-icon style="font-size: 18px">{{ currents.isPlaying() ? 'pause' : 'play_arrow' }}</mat-icon>
+            <mat-icon style="font-size: 18px"
+              >{{ currents.isPlaying() ? 'pause' : 'play_arrow' }}</mat-icon
+            >
           </button>
           <button
             mat-icon-button
             (click)="currents.stepForward()"
             matTooltip="+1h"
-            matTooltipPosition="top"
+            matTooltipPosition="below"
             style="width: 26px; height: 26px; line-height: 26px"
           >
             <mat-icon style="font-size: 14px">chevron_right</mat-icon>
@@ -165,7 +232,7 @@
             mat-icon-button
             (click)="currents.stepForwardBig()"
             matTooltip="+6h"
-            matTooltipPosition="top"
+            matTooltipPosition="below"
             style="width: 26px; height: 26px; line-height: 26px"
           >
             <mat-icon style="font-size: 14px">skip_next</mat-icon>
@@ -175,15 +242,20 @@
             mat-button
             (click)="currents.resetToNow()"
             matTooltip="Reset to Now"
-            matTooltipPosition="top"
-            style="min-width: unset; padding: 0 8px; font-size: 11px; line-height: 26px; height: 26px"
+            matTooltipPosition="below"
+            style="
+              min-width: unset;
+              padding: 0 8px;
+              font-size: 11px;
+              line-height: 26px;
+              height: 26px;
+            "
           >
             Now
           </button>
         </div>
       </div>
-      }
-      }
+      } }
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/app/modules/skresources/components/weather/weatherlist.ts
+++ b/src/app/modules/skresources/components/weather/weatherlist.ts
@@ -65,7 +65,8 @@ export class WeatherListComponent implements OnDestroy {
     if (!this.dragState) return;
 
     if (!this.dragState.isDragging) {
-      const percent = (e.clientX - this.dragState.elLeft) / this.dragState.barWidth;
+      const percent =
+        (e.clientX - this.dragState.elLeft) / this.dragState.barWidth;
       const hourOffset = (percent - 0.5) * 24;
       const newTime = this.dragState.startTime + hourOffset * 3600_000;
       this.currents.scrubTime.set(newTime);
@@ -93,24 +94,32 @@ export class WeatherListComponent implements OnDestroy {
     const t = this.currents.scrubTime();
     const d = t ? new Date(t) : new Date();
     const now = new Date();
-    const isToday = d.getFullYear() === now.getFullYear() &&
+    const isToday =
+      d.getFullYear() === now.getFullYear() &&
       d.getMonth() === now.getMonth() &&
       d.getDate() === now.getDate();
     const tomorrow = new Date(now);
     tomorrow.setDate(tomorrow.getDate() + 1);
-    const isTomorrow = d.getFullYear() === tomorrow.getFullYear() &&
+    const isTomorrow =
+      d.getFullYear() === tomorrow.getFullYear() &&
       d.getMonth() === tomorrow.getMonth() &&
       d.getDate() === tomorrow.getDate();
     const yesterday = new Date(now);
     yesterday.setDate(yesterday.getDate() - 1);
-    const isYesterday = d.getFullYear() === yesterday.getFullYear() &&
+    const isYesterday =
+      d.getFullYear() === yesterday.getFullYear() &&
       d.getMonth() === yesterday.getMonth() &&
       d.getDate() === yesterday.getDate();
     let day: string;
     if (isToday) day = 'Today';
     else if (isTomorrow) day = 'Tomorrow';
     else if (isYesterday) day = 'Yesterday';
-    else day = d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+    else
+      day = d.toLocaleDateString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric'
+      });
     const p = (n: number) => String(n).padStart(2, '0');
     return `${day} · ${p(d.getHours())}:${p(d.getMinutes())}`;
   }

--- a/src/app/modules/skresources/components/weather/weatherlist.ts
+++ b/src/app/modules/skresources/components/weather/weatherlist.ts
@@ -2,7 +2,9 @@ import {
   Component,
   ChangeDetectionStrategy,
   output,
-  inject
+  inject,
+  NgZone,
+  OnDestroy
 } from '@angular/core';
 
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -13,6 +15,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { AppFacade } from 'src/app/app.facade';
+import { TidalCurrentsService } from 'src/app/modules/map/ol/lib/tidal-currents.service';
 
 @Component({
   selector: 'weather-list',
@@ -29,13 +32,112 @@ import { AppFacade } from 'src/app/app.facade';
     MatSlideToggleModule
   ]
 })
-export class WeatherListComponent {
+export class WeatherListComponent implements OnDestroy {
   closed = output<void>();
 
   protected app = inject(AppFacade);
+  protected currents = inject(TidalCurrentsService);
+  private ngZone = inject(NgZone);
+
+  private dragState: {
+    startX: number;
+    barWidth: number;
+    startTime: number;
+    isDragging: boolean;
+    elLeft: number;
+  } | null = null;
+
+  private onDocPointerMove = (e: PointerEvent) => {
+    if (!this.dragState) return;
+    const dx = e.clientX - this.dragState.startX;
+
+    if (!this.dragState.isDragging && Math.abs(dx) > 3) {
+      this.dragState.isDragging = true;
+    }
+
+    if (this.dragState.isDragging) {
+      const hours = -(dx / this.dragState.barWidth) * 24;
+      this.currents.scrubTime.set(this.dragState.startTime + hours * 3600_000);
+    }
+  };
+
+  private onDocPointerUp = (e: PointerEvent) => {
+    if (!this.dragState) return;
+
+    if (!this.dragState.isDragging) {
+      const percent = (e.clientX - this.dragState.elLeft) / this.dragState.barWidth;
+      const hourOffset = (percent - 0.5) * 24;
+      const newTime = this.dragState.startTime + hourOffset * 3600_000;
+      this.currents.scrubTime.set(newTime);
+    }
+
+    this.dragState = null;
+    document.removeEventListener('pointermove', this.onDocPointerMove);
+    document.removeEventListener('pointerup', this.onDocPointerUp);
+    this.currents.dragEnd$.next();
+  };
+
+  ngOnDestroy() {
+    if (this.dragState) {
+      document.removeEventListener('pointermove', this.onDocPointerMove);
+      document.removeEventListener('pointerup', this.onDocPointerUp);
+    }
+  }
 
   protected close() {
     this.closed.emit();
+  }
+
+  protected fmtScrubTime(): string {
+    const t = this.currents.scrubTime();
+    const d = t ? new Date(t) : new Date();
+    const now = new Date();
+    const isToday = d.getFullYear() === now.getFullYear() &&
+      d.getMonth() === now.getMonth() &&
+      d.getDate() === now.getDate();
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const isTomorrow = d.getFullYear() === tomorrow.getFullYear() &&
+      d.getMonth() === tomorrow.getMonth() &&
+      d.getDate() === tomorrow.getDate();
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const isYesterday = d.getFullYear() === yesterday.getFullYear() &&
+      d.getMonth() === yesterday.getMonth() &&
+      d.getDate() === yesterday.getDate();
+    let day: string;
+    if (isToday) day = 'Today';
+    else if (isTomorrow) day = 'Tomorrow';
+    else if (isYesterday) day = 'Yesterday';
+    else day = d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+    const p = (n: number) => String(n).padStart(2, '0');
+    return `${day} · ${p(d.getHours())}:${p(d.getMinutes())}`;
+  }
+
+  /** Position (0-100) of "now" within the current 24h bar window, or null if now is at center. */
+  protected nowTickPct(): number | null {
+    const st = this.currents.scrubTime();
+    if (st === null) return null;
+    const pct = 50 + ((Date.now() - st) / (24 * 3600_000)) * 100;
+    if (pct < 0 || pct > 100) return null;
+    return pct;
+  }
+
+  // ---- pointer drag handlers for the time bar ----
+
+  protected onBarPointerDown(e: PointerEvent, el: HTMLElement) {
+    const rect = el.getBoundingClientRect();
+    this.dragState = {
+      startX: e.clientX,
+      barWidth: rect.width,
+      startTime: this.currents.scrubTime() ?? Date.now(),
+      isDragging: false,
+      elLeft: rect.left
+    };
+    this.ngZone.runOutsideAngular(() => {
+      document.addEventListener('pointermove', this.onDocPointerMove);
+      document.addEventListener('pointerup', this.onDocPointerUp);
+    });
   }
 
   protected toggleWeatherWind(checked: boolean) {
@@ -51,6 +153,14 @@ export class WeatherListComponent {
       return;
     }
     this.app.config.selections.oceanCurrentsEnabled = checked;
+    this.app.saveConfig();
+  }
+
+  protected toggleTidalCurrents(checked: boolean) {
+    if (!this.app.config?.selections) {
+      return;
+    }
+    this.app.config.selections.tidalCurrentsEnabled = checked;
     this.app.saveConfig();
   }
 }

--- a/src/app/modules/skresources/components/weather/weatherlist.ts
+++ b/src/app/modules/skresources/components/weather/weatherlist.ts
@@ -82,6 +82,7 @@ export class WeatherListComponent implements OnDestroy {
       document.removeEventListener('pointermove', this.onDocPointerMove);
       document.removeEventListener('pointerup', this.onDocPointerUp);
     }
+    this.currents.pause();
   }
 
   protected close() {
@@ -159,6 +160,9 @@ export class WeatherListComponent implements OnDestroy {
   protected toggleTidalCurrents(checked: boolean) {
     if (!this.app.config?.selections) {
       return;
+    }
+    if (!checked) {
+      this.currents.pause();
     }
     this.app.config.selections.tidalCurrentsEnabled = checked;
     this.app.saveConfig();

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -240,6 +240,7 @@ export interface IAppConfig {
     infolayers: string[];
     weatherWindEnabled: boolean;
     oceanCurrentsEnabled: boolean;
+    tidalCurrentsEnabled: boolean;
   };
 }
 


### PR DESCRIPTION
Display tidal current arrow field on the map using `signalk-tidal-currents` plugin data. Includes:

- TidalCurrentsService: state (scrubTime, play/pause), 24h bar tick/label math, API via SignalKClient
- TidalCurrentsLayerComponent: OpenLayers vector layer with speed-colored arrows, auditTime(300) pipe
- Weather panel: clickable/draggable 24h time bar, play/pause/step/reset buttons, pill label
- Feature flag (tidalApi) gated on plugin detection via /signalk/v2/features
- Dark/light theme support via app.uiConfig().invertColor
- Click handling delegated to Freeboard's processMapClick for consistent popovers

## Screenshot
![tidal currents overlay](https://github.com/user-attachments/assets/c2ee0f45-afd6-408c-a630-1652b59a4bec)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tidal currents support across the weather and map experience, including a 24h time scrub bar with playback controls and a new tidal point layer on the map.
  * Added a settings toggle for tidal currents, gated by a SignalK plugin/feature-flag detection.
  * Tidal map clicks now show a compact popover with formatted speed and direction.

* **Bug Fixes**
  * Backfilled missing tidal-currents selection settings to default to off.
  * Improved timeline “now” behavior when not actively scrubbing.

* **Style**
  * Added a compact popover variant for tighter tidal point display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->