### PR TITLE
fix(skstream): restore server trail fetch broken by concurrent-request guard

### DIFF
--- a/src/app/modules/skstream/skstream.worker.spec.ts
+++ b/src/app/modules/skstream/skstream.worker.spec.ts
@@ -1,0 +1,33 @@
+import { expect, describe, it, vi, afterEach } from 'vitest';
+import { apiGet } from './skstream.worker';
+
+// getVesselTrail() fetches the server-side "self" track with several apiGet()
+// calls fired in the same tick and awaited via Promise.all. A shared in-flight
+// guard (added in v2.21.0) made every concurrent call after the first resolve
+// to `undefined`, so Promise.all yielded holes, the trail parse threw, and the
+// server track silently vanished (#492). Guard the concurrency contract:
+// each concurrent call must return a real Promise that resolves with its own
+// payload.
+describe('skstream.worker apiGet — concurrent requests', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves every concurrent call, not just the first', async () => {
+    // Respond after a macrotask so all calls are in flight simultaneously —
+    // reproduces the overlap getVesselTrail() creates.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        Promise.resolve({
+          json: () => new Promise((r) => setTimeout(() => r({ url }), 0))
+        } as unknown as Response)
+      )
+    );
+
+    const urls = ['/self/track?a', '/self/track?b', '/self/track?c'];
+    const results = await Promise.all(urls.map((u) => apiGet(u)));
+
+    expect(results).toEqual(urls.map((url) => ({ url })));
+  });
+});

--- a/src/app/modules/skstream/skstream.worker.ts
+++ b/src/app/modules/skstream/skstream.worker.ts
@@ -367,23 +367,12 @@ function closeStream(fromCommand = false) {
 }
 
 // fetch from api endpoint
-let isFetching = false;
-function apiGet(url: string): Promise<unknown> {
-  if (isFetching) return;
-  return new Promise((resolve, reject) => {
-    isFetching = true;
-    fetch(`${url}`)
-      .then((r: Response) => {
-        isFetching = false;
-        r.json()
-          .then((j) => resolve(j))
-          .catch((err) => reject(err));
-      })
-      .catch((err) => {
-        isFetching = false;
-        reject(err);
-      });
-  });
+// NOTE: must stay safe under concurrency — getVesselTrail() fires several of
+// these in parallel and awaits them with Promise.all. A shared in-flight guard
+// here caused all but the first concurrent call to resolve to undefined, which
+// broke server-side trail/track fetching (#492).
+export function apiGet(url: string): Promise<unknown> {
+  return fetch(url).then((r: Response) => r.json());
 }
 
 // fetch other vessel tracks


### PR DESCRIPTION
## Why

The server-side "self" track stopped rendering after v2.20.0 (reported in #492 with a clean bisection: works on v2.20.0, broken on v2.21.0, no server change). Only the client-side track showed, with `Unable to fetch vessel trail from server.` in the console.

## Cause

v2.21.0 added a module-level in-flight guard to the worker's `apiGet()` (to dedupe feature-resource requests, #340):

```js
let isFetching = false;
function apiGet(url) {
  if (isFetching) return;  // returns undefined, not a Promise
  ...
}
```

`getVesselTrail()` fires several `apiGet()` calls in the same tick and awaits them with `Promise.all`. The first call sets `isFetching = true`; every concurrent call after it hits the guard and returns `undefined`, so `Promise.all` resolves with holes, the trail parse throws, and the server track is dropped.

## Fix

Remove the guard so `apiGet()` always returns a Promise. It is unrelated to #340 — feature resources (routes/waypoints/charts/notes/regions) are fetched on the main thread via `skres`, not through the worker's `apiGet` (whose only callers are `getVesselTrail` and `getAISTracks`). #340's actual dedup is the call-site restructuring in `app.component.ts`, which is untouched, so this cannot reintroduce it.

Adds a co-located vitest regression test (`skstream.worker.spec.ts`) asserting concurrent `apiGet` calls all resolve — fails with the guard, passes without.

Closes #492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for concurrent data requests, so parallel lookups now return complete results instead of occasionally missing values.
  * Fixed request handling to better support multiple in-flight calls at the same time.

* **Tests**
  * Added coverage for concurrent request behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->