### PR TITLE
feat(map): render meteo targets as wind barbs

### DIFF
--- a/src/app/modules/icons/atons.spec.ts
+++ b/src/app/modules/icons/atons.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { meteoWindBucket, METEO_WIND_MAX_KTS, getAtoNDefs } from './atons';
+
+/**
+ * `meteoWindBucket` selects the wind-barb glyph for a meteo target (#490). It
+ * takes speed in m/s (Signal K native), returns null when no speed is reported,
+ * 0 for calm (below the first bucket → plain windsock), else the 5-knot bucket.
+ * 1 m/s ≈ 1.94384 kn.
+ */
+describe('meteoWindBucket (#490)', () => {
+  it('returns null when no finite speed is reported', () => {
+    expect(meteoWindBucket(null)).toBeNull();
+    expect(meteoWindBucket(undefined)).toBeNull();
+    expect(meteoWindBucket(NaN)).toBeNull();
+    expect(meteoWindBucket(Infinity)).toBeNull();
+  });
+
+  it('returns 0 (windsock) below the first 5-knot bucket', () => {
+    expect(meteoWindBucket(0)).toBe(0);
+    expect(meteoWindBucket(2)).toBe(0); // ≈ 3.9 kn
+  });
+
+  it('rounds down to the nearest 5-knot bucket', () => {
+    expect(meteoWindBucket(2.7)).toBe(5); // ≈ 5.2 kn
+    expect(meteoWindBucket(6)).toBe(10); // ≈ 11.7 kn
+    expect(meteoWindBucket(10)).toBe(15); // ≈ 19.4 kn
+  });
+
+  it('clamps to the maximum bucket for very high speeds', () => {
+    expect(meteoWindBucket(50)).toBe(METEO_WIND_MAX_KTS); // ≈ 97 kn
+  });
+});
+
+describe('getAtoNDefs — bundled wind barbs (#490)', () => {
+  it('provides a barb def for every bucket, for real and virtual', () => {
+    const defs = getAtoNDefs();
+    for (let kts = 5; kts <= METEO_WIND_MAX_KTS; kts += 5) {
+      const id = `weatherStation-${kts}`;
+      expect(defs['real'][id]?.path).toContain(`${id}.svg`);
+      expect(defs['virtual'][id]?.path).toContain(`${id}.svg`);
+    }
+  });
+});

--- a/src/app/modules/icons/atons.ts
+++ b/src/app/modules/icons/atons.ts
@@ -2,6 +2,7 @@
 
 import { AppIconSet } from './app.icons';
 import { MapIconDef } from '../map/ol/lib/map-image-registry.service';
+import { Convert } from 'src/app/lib/convert';
 
 export const AtoNsType1: AppIconSet = {
   path: './assets/img/atons',
@@ -70,6 +71,44 @@ const WeatherStation: MapIconDef = {
   scale: 0.75
 };
 
+// Wind barbs for meteo targets (issue #490). Standard notation — half feather
+// = 5 kn, full = 10 kn, pennant = 50 kn — bundled per 5-knot bucket. Drawn
+// north-up and anchored at the staff base so the renderer rotates each one to
+// the station's reported environment.wind.directionTrue.
+export const METEO_WIND_MIN_KTS = 5;
+export const METEO_WIND_MAX_KTS = 75;
+export const METEO_WIND_STEP_KTS = 5;
+
+const WindBarb = (kts: number): MapIconDef => ({
+  path: `./assets/img/wind/barbs/weatherStation-${kts}.svg`,
+  anchor: [13, 42],
+  scale: 0.75
+});
+
+/**
+ * Wind-speed bucket (knots, in `METEO_WIND_STEP_KTS` steps) selecting the barb
+ * glyph for a meteo target's reported speed. Single source of truth shared by
+ * icon selection and barb rotation.
+ * @param tws reported wind speed in m/s (Signal K native unit)
+ * @returns `null` when no speed is reported, `0` for calm (below the first
+ *   bucket → plain windsock), otherwise the bucket in `[MIN..MAX]` knots.
+ */
+export const meteoWindBucket = (
+  tws: number | null | undefined
+): number | null => {
+  if (typeof tws !== 'number' || !Number.isFinite(tws)) {
+    return null;
+  }
+  const kn = Convert.transform(tws, 'm/s', 'kn');
+  if (kn < METEO_WIND_MIN_KTS) {
+    return 0;
+  }
+  return Math.min(
+    Math.floor(kn / METEO_WIND_STEP_KTS) * METEO_WIND_STEP_KTS,
+    METEO_WIND_MAX_KTS
+  );
+};
+
 /**
  * @description Build MapIcon definitions for use by MapImageRegistry
  */
@@ -94,5 +133,16 @@ export const getAtoNDefs = () => {
   addToList(AtoNsType2);
   atonList['real']['weatherStation'] = WeatherStation;
   atonList['virtual']['weatherStation'] = WeatherStation;
+  // Bundled default barbs — real and virtual share the same artwork; a symbol
+  // provider may override any bucket via a `<variant>-weatherStation-<kts>` alias.
+  for (
+    let kts = METEO_WIND_MIN_KTS;
+    kts <= METEO_WIND_MAX_KTS;
+    kts += METEO_WIND_STEP_KTS
+  ) {
+    const def = WindBarb(kts);
+    atonList['real'][`weatherStation-${kts}`] = def;
+    atonList['virtual'][`weatherStation-${kts}`] = def;
+  }
   return atonList;
 };

--- a/src/app/modules/map/ol/lib/map-image-registry.service.spec.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { MapImageRegistry } from './map-image-registry.service';
+
+/**
+ * `getMeteoIcon` picks the wind-barb glyph for a meteo target by reported wind
+ * speed (m/s), falling back to the plain windsock below the first bucket or when
+ * no speed is reported (#490). The registry has no Angular dependencies, so a
+ * plain `new` suffices.
+ */
+describe('MapImageRegistry.getMeteoIcon (#490)', () => {
+  const reg = new MapImageRegistry();
+
+  it('selects the bucketed barb for a reported speed', () => {
+    expect(reg.getMeteoIcon(6).getSrc()).toContain('weatherStation-10.svg');
+  });
+
+  it('clamps very high speeds to the maximum barb', () => {
+    expect(reg.getMeteoIcon(50).getSrc()).toContain('weatherStation-75.svg');
+  });
+
+  it('falls back to the windsock for calm and for no reported speed', () => {
+    expect(reg.getMeteoIcon(2).getSrc()).toContain('weather_station.png');
+    expect(reg.getMeteoIcon(null).getSrc()).toContain('weather_station.png');
+  });
+
+  it('uses the shared barb artwork for virtual meteo targets', () => {
+    expect(reg.getMeteoIcon(6, true).getSrc()).toContain(
+      'weatherStation-10.svg'
+    );
+  });
+});

--- a/src/app/modules/map/ol/lib/map-image-registry.service.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.ts
@@ -7,7 +7,8 @@ import {
   getVesselDefs,
   getWaypointDefs,
   AIS_TYPE_IDS,
-  AIS_MOORED_STYLE_IDS
+  AIS_MOORED_STYLE_IDS,
+  meteoWindBucket
 } from 'src/app/modules/icons';
 
 interface MapImageCollection {
@@ -68,7 +69,34 @@ export class MapImageRegistry {
    * @returns Icon object
    */
   getAtoN(id: number | string, virtual?: boolean): Icon {
-    const vid = ATON_TYPE_IDS[id] ?? 'aton';
+    return this.resolveAtoN(ATON_TYPE_IDS[id] ?? 'aton', virtual);
+  }
+
+  /**
+   * @description Returns the barb/windsock image for a meteo (weather-station)
+   * target, chosen by its reported wind speed. Barbs are bundled per 5-knot
+   * bucket (`weatherStation-5..75`) and a provider may override any bucket via a
+   * `<variant>-weatherStation-<kts>` symbol. Below the first bucket, or with no
+   * wind reported, the plain windsock (`weatherStation`) is used.
+   * @param tws reported wind speed in m/s (Signal K native unit), or null/undefined
+   * @param virtual true = virtual AtoN variant
+   * @returns Icon object
+   */
+  getMeteoIcon(tws: number | null | undefined, virtual?: boolean): Icon {
+    const bucket = meteoWindBucket(tws);
+    const vid = bucket ? `weatherStation-${bucket}` : 'weatherStation';
+    return this.resolveAtoN(vid, virtual, 'weatherStation');
+  }
+
+  /**
+   * Resolve an AtoN/meteo icon by its variant id: external symbol override
+   * first, then the bundled artwork, then the supplied fallback id.
+   */
+  private resolveAtoN(
+    vid: string,
+    virtual?: boolean,
+    fallbackVid = 'aton'
+  ): Icon {
     const variant = virtual ? 'virtual' : 'real';
     const defs = virtual ? this.atonImageDefs.virtual : this.atonImageDefs.real;
     // External symbol override keyed by "real-<vid>" / "virtual-<vid>"
@@ -83,9 +111,9 @@ export class MapImageRegistry {
     if (!this.icons.atons[key]) {
       this.buildIcon(this.icons.atons, defs, vid, false, key);
     }
-    const fallback = `${variant}-aton`;
+    const fallback = `${variant}-${fallbackVid}`;
     if (!this.icons.atons[fallback]) {
-      this.buildIcon(this.icons.atons, defs, 'aton', false, fallback);
+      this.buildIcon(this.icons.atons, defs, fallbackVid, false, fallback);
     }
     return this.icons.atons[key] ?? this.icons.atons[fallback];
   }

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets.component.spec.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets.component.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { AISTargetsLayerComponent } from './layer-aistargets.component';
+import { SKTarget } from './ais-base.component';
+
+/**
+ * `targetRotation` decides how a target's icon is rotated (#490). Meteo
+ * (weather-station) targets rotate their wind barb to the reported wind
+ * direction, but only when a barb is actually shown (speed in a bucket ≥ the
+ * first) and a direction is known; every other target keeps its fixed
+ * orientation. It reads only plain fields, so exercise it on a bare prototype
+ * instance (same approach as ais-base.component.spec).
+ */
+function layer(targetContext: string) {
+  const c = Object.create(
+    AISTargetsLayerComponent.prototype
+  ) as AISTargetsLayerComponent;
+  Object.assign(c, { targetContext });
+  return c as unknown as { targetRotation: (t: SKTarget) => number };
+}
+
+describe('AISTargetsLayerComponent.targetRotation (#490)', () => {
+  it('uses the fixed orientation for non-meteo targets', () => {
+    const c = layer('atons');
+    expect(c.targetRotation({ orientation: 1.5 } as SKTarget)).toBe(1.5);
+  });
+
+  it('rotates a meteo barb to the reported wind direction', () => {
+    const c = layer('meteo');
+    expect(c.targetRotation({ tws: 6, twd: 1.2 } as SKTarget)).toBe(1.2);
+  });
+
+  it('does not rotate the calm windsock (speed below the first bucket)', () => {
+    const c = layer('meteo');
+    expect(c.targetRotation({ tws: 2, twd: 1.2 } as SKTarget)).toBe(0);
+  });
+
+  it('does not rotate when the wind direction is unknown or invalid', () => {
+    const c = layer('meteo');
+    expect(c.targetRotation({ tws: 6 } as SKTarget)).toBe(0);
+    expect(c.targetRotation({ tws: null, twd: null } as SKTarget)).toBe(0);
+    expect(c.targetRotation({ tws: 6, twd: NaN } as SKTarget)).toBe(0);
+  });
+});

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets.component.ts
@@ -10,6 +10,8 @@ import { fromLonLat } from 'ol/proj';
 import { MapComponent } from '../map.component';
 import { AISBaseLayerComponent, SKTarget } from './ais-base.component';
 import { MapImageRegistry } from '../map-image-registry.service';
+import { SKMeteo } from 'src/app/modules';
+import { meteoWindBucket } from 'src/app/modules/icons';
 
 // ** Signal K non-vessel targets **
 @Component({
@@ -56,7 +58,7 @@ export class AISTargetsLayerComponent extends AISBaseLayerComponent {
               f.set('name', label, true);
               f.setStyle(
                 this.setTextLabel(
-                  this.setRotation(s, target.orientation),
+                  this.setRotation(s, this.targetRotation(target)),
                   label
                 )
               );
@@ -99,15 +101,33 @@ export class AISTargetsLayerComponent extends AISBaseLayerComponent {
       f.set('name', label, true);
       const s = this.buildStyle(target).clone();
       f.setStyle(
-        this.setTextLabel(this.setRotation(s, target.orientation), label)
+        this.setTextLabel(
+          this.setRotation(s, this.targetRotation(target)),
+          label
+        )
       );
       this.source.addFeature(f);
     }
   }
 
+  // Meteo (weather-station) targets render a wind barb rotated to the reported
+  // wind direction; every other target keeps its fixed orientation.
+  private targetRotation(target: SKTarget): number {
+    if (this.targetContext !== 'meteo') {
+      return target.orientation;
+    }
+    const meteo = target as SKMeteo;
+    return meteoWindBucket(meteo.tws) && Number.isFinite(meteo.twd)
+      ? meteo.twd
+      : 0;
+  }
+
   // build target style
   buildStyle(target: SKTarget): Style {
-    const icon = this.mapImages.getAtoN(target.type?.id, target.virtual);
+    const icon =
+      this.targetContext === 'meteo'
+        ? this.mapImages.getMeteoIcon((target as SKMeteo).tws, target.virtual)
+        : this.mapImages.getAtoN(target.type?.id, target.virtual);
     if (icon && typeof this.targetStyles === 'undefined') {
       if (icon) {
         return new Style({

--- a/src/assets/img/wind/barbs/weatherStation-10.svg
+++ b/src/assets/img/wind/barbs/weatherStation-10.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-15.svg
+++ b/src/assets/img/wind/barbs/weatherStation-15.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="7.5" y2="10" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-20.svg
+++ b/src/assets/img/wind/barbs/weatherStation-20.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-25.svg
+++ b/src/assets/img/wind/barbs/weatherStation-25.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="7.5" y2="15" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-30.svg
+++ b/src/assets/img/wind/barbs/weatherStation-30.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="2" y2="12" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-35.svg
+++ b/src/assets/img/wind/barbs/weatherStation-35.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="2" y2="12" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="23" x2="7.5" y2="20" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-40.svg
+++ b/src/assets/img/wind/barbs/weatherStation-40.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="2" y2="12" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="23" x2="2" y2="17" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-45.svg
+++ b/src/assets/img/wind/barbs/weatherStation-45.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="2" y2="12" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="23" x2="2" y2="17" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="28" x2="7.5" y2="25" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-5.svg
+++ b/src/assets/img/wind/barbs/weatherStation-5.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="7.5" y2="10" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-50.svg
+++ b/src/assets/img/wind/barbs/weatherStation-50.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-55.svg
+++ b/src/assets/img/wind/barbs/weatherStation-55.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
+  <line x1="13" y1="20" x2="7.5" y2="17" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-60.svg
+++ b/src/assets/img/wind/barbs/weatherStation-60.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
+  <line x1="13" y1="20" x2="2" y2="14" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-65.svg
+++ b/src/assets/img/wind/barbs/weatherStation-65.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
+  <line x1="13" y1="20" x2="2" y2="14" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="25" x2="7.5" y2="22" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-70.svg
+++ b/src/assets/img/wind/barbs/weatherStation-70.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
+  <line x1="13" y1="20" x2="2" y2="14" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="25" x2="2" y2="19" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/img/wind/barbs/weatherStation-75.svg
+++ b/src/assets/img/wind/barbs/weatherStation-75.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
+  <line x1="13" y1="20" x2="2" y2="14" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="25" x2="2" y2="19" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="30" x2="7.5" y2="27" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## What problem does this solve?

Weather-station (`meteo.*`) targets render as a static windsock that conveys
neither wind speed nor direction. A skipper can't read the wind field around the
boat at a glance — every station has to be tapped individually.

## How does it work?

Meteo targets now render as standard **wind barbs** — half feather = 5 kn, full
= 10 kn, pennant = 50 kn — selected from the station's reported
`environment.wind.averageSpeed` in 5-knot buckets (5–75 kn, clamped) and rotated
to `environment.wind.directionTrue` (reusing the same per-feature rotation the
AIS layer already uses for vessel heading). Below 5 kn, or when no wind is
reported, the existing windsock is kept, unrotated.

The 15 barb glyphs ship bundled, so it works with no setup, and each bucket is
overridable through the symbol provider for custom art — e.g. a symbol aliased
`fsk:real-weatherStation-25` replaces the 25-kn barb for real stations
(`fsk:virtual-weatherStation-25` for virtual), where `-25` is one of the 5-kn
buckets `5`–`75`. Because it keys off the shared `meteo` context, it
applies to every weather target — AIS Met/Hydro buoys and plugin-published shore
stations (e.g. signalk-viva) alike. Barbs use the same olive as the vessel's own
true-wind indicator so they read as one system.

## How was this tested?

`npm run test:ci` (155 pass, incl. new specs) covering the speed→bucket
selection, the barb-vs-windsock fallback, and the rotation gating (rotate only
when a barb is shown and a valid direction is known). Build green. Verified
on-chart against a live server: a weather station cycling through the full speed
ladder renders the correct barb per bucket and rotates to the reported direction.

## Checklist

- [x] One logical change; version numbers untouched.
- [x] Skimmed DEV-LESSONS-LEARNED.md for traps relevant to this change.
- [x] Tests added/updated for new behaviour and `npm run test:ci` passes.

Closes #490
