### PR TITLE
feat(charts): make image adjustment a modeless draggable palette

### DIFF
--- a/src/app/lib/components/dialogs/image-adjustment-dialog.ts
+++ b/src/app/lib/components/dialogs/image-adjustment-dialog.ts
@@ -8,6 +8,7 @@ import {
   MatDialogRef,
   MAT_DIALOG_DATA
 } from '@angular/material/dialog';
+import { CdkDrag, CdkDragHandle } from '@angular/cdk/drag-drop';
 import { ChartImageAdjustment } from 'src/app/types';
 
 export interface ImageAdjustmentDialogResult {
@@ -32,31 +33,44 @@ const toRatio = (percent: number) => percent / 100;
     MatIconModule,
     MatButtonModule,
     MatDialogModule,
-    MatTooltipModule
+    MatTooltipModule,
+    CdkDrag,
+    CdkDragHandle
   ],
   template: `
-    <div class="_ap-image-adjustment">
-      <div style="display:flex;">
-        <div style="padding: 15px 0 0 10px;">
-          <mat-icon>tune</mat-icon>
+    <div
+      class="_ap-image-adjustment"
+      style="overflow: hidden;"
+      cdkDrag
+      cdkDragRootElement=".cdk-overlay-pane"
+    >
+      <div
+        cdkDragHandle
+        style="display:flex; align-items:center; cursor:move; padding: 4px 4px 4px 12px;"
+      >
+        <mat-icon style="opacity:0.6;">tune</mat-icon>
+        <div style="flex: 1 1 auto; padding-left: 8px;">
+          <div style="font-weight:500;">
+            {{ data.title ?? 'Image Adjustment' }}
+          </div>
+          @if (data.text) {
+            <div style="font-size: 11px; opacity: 0.7;">{{ data.text }}</div>
+          }
         </div>
-        <div style="flex: 1 1 auto;">
-          <h1 mat-dialog-title>{{ data.title ?? 'Image Adjustment' }}</h1>
-        </div>
-        <div style="width:50px;padding: 15px 0 0 10px;">
-          <button mat-icon-button (click)="handleClose(false)">
-            <mat-icon>close</mat-icon>
-          </button>
-        </div>
+        <button mat-icon-button aria-label="Close" (click)="handleClose(false)">
+          <mat-icon>close</mat-icon>
+        </button>
       </div>
 
-      <mat-dialog-content style="padding-top: 5px;">
-        <div style="display: flex; align-items: center; margin-bottom: 8px">
-          <div style="flex: 1 1 auto">{{ data.text }}</div>
-        </div>
+      <mat-dialog-content style="padding-top: 0; overflow-x: hidden;">
         <div style="display: flex; align-items: center">
-          <div style="width: 80px">Brightness</div>
-          <mat-slider style="flex: 1 1 auto" [min]="0" [max]="200" [step]="1">
+          <div style="width: 72px; font-size: 13px;">Brightness</div>
+          <mat-slider
+            style="flex: 1 1 auto; min-width: 0"
+            [min]="0"
+            [max]="200"
+            [step]="1"
+          >
             <input
               matSliderThumb
               aria-label="Brightness"
@@ -64,13 +78,18 @@ const toRatio = (percent: number) => percent / 100;
               (input)="onBrightnessChange($event)"
             />
           </mat-slider>
-          <div style="min-width: 48px; text-align: right">
+          <div style="min-width: 44px; text-align: right; font-size: 13px;">
             {{ brightness() }}%
           </div>
         </div>
         <div style="display: flex; align-items: center">
-          <div style="width: 80px">Contrast</div>
-          <mat-slider style="flex: 1 1 auto" [min]="0" [max]="200" [step]="1">
+          <div style="width: 72px; font-size: 13px;">Contrast</div>
+          <mat-slider
+            style="flex: 1 1 auto; min-width: 0"
+            [min]="0"
+            [max]="200"
+            [step]="1"
+          >
             <input
               matSliderThumb
               aria-label="Contrast"
@@ -78,7 +97,7 @@ const toRatio = (percent: number) => percent / 100;
               (input)="onContrastChange($event)"
             />
           </mat-slider>
-          <div style="min-width: 48px; text-align: right">
+          <div style="min-width: 44px; text-align: right; font-size: 13px;">
             {{ contrast() }}%
           </div>
         </div>
@@ -86,7 +105,7 @@ const toRatio = (percent: number) => percent / 100;
       <mat-dialog-actions>
         <button mat-button (click)="reset()">RESET</button>
         <span style="flex: 1 1 auto"></span>
-        <button mat-raised-button (click)="handleClose(true)">APPLY</button>
+        <button mat-raised-button (click)="handleClose(true)">SAVE</button>
       </mat-dialog-actions>
     </div>
   `

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -24,7 +24,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { AppFacade } from 'src/app/app.facade';
 import { SKResourceService, SKResourceType } from '../../resources.service';
 import { ChartLayers } from './chart-layers.component';
-import { FBCharts, FBChart, ChartImageAdjustment } from 'src/app/types';
+import { FBCharts, FBChart } from 'src/app/types';
 import { WMTSDialog } from './wmts-dialog';
 import { WMSDialog } from './wms-dialog';
 import { JsonMapSourceDialog } from './jsonmapsource-dialog';
@@ -34,9 +34,7 @@ import { FBMapInteractService } from 'src/app/modules/map/fbmap-interact.service
 import {
   SingleSelectListDialog,
   SliderInputDialog,
-  SliderInputDialogResult,
-  ImageAdjustmentDialog,
-  ImageAdjustmentDialogResult
+  SliderInputDialogResult
 } from 'src/app/lib/components';
 import { SKResourceGroupService } from '../groups/groups.service';
 import { SKChart } from '../../resource-classes';
@@ -302,40 +300,10 @@ export class ChartListComponent extends ResourceListBase {
   }
 
   protected itemImageAdjustment(chart: FBChart) {
-    const original: ChartImageAdjustment = {
-      brightness: 1,
-      contrast: 1,
-      ...(this.app.config.selections.chartImageAdjustment[chart[0]] ??
-        chart[1]?.imageAdjustment)
-    };
-
-    this.dialog
-      .open(ImageAdjustmentDialog, {
-        disableClose: true,
-        backdropClass: 'transparent-backdrop',
-        data: {
-          title: 'Image Adjustment',
-          text: chart[1]?.name ?? '',
-          value: { ...original },
-          onChange: (value: ChartImageAdjustment) => {
-            this.skres.chartSetImageAdjustment(chart[0], value);
-          }
-        }
-      })
-      .afterClosed()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((result: ImageAdjustmentDialogResult) => {
-        if (result?.apply) {
-          const adj = result.value;
-          this.app.config.selections.chartImageAdjustment[chart[0]] = adj;
-          chart[1].imageAdjustment = adj;
-          this.updateFullList(chart);
-          this.app.saveConfig();
-        } else {
-          // cancelled - restore the pre-edit adjustment
-          this.skres.chartSetImageAdjustment(chart[0], original);
-        }
-      });
+    // The palette is modeless and owned by the service so it survives the chart
+    // list closing, which frees the map for the live adjustment preview.
+    this.skres.openImageAdjustment(chart);
+    this.close();
   }
 
   updateFullList(chart: FBChart) {

--- a/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
+++ b/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { of } from 'rxjs';
+import { SKResourceService } from './resources.service';
+import { ChartImageAdjustment, FBChart } from 'src/app/types';
+import { ImageAdjustmentDialogResult } from 'src/app/lib/components';
+
+/**
+ * Behaviour tests for the modeless Image Adjustment palette owned by the service
+ * (#457). SAVE persists per-chart and updates the render cache; cancelling
+ * reverts the live preview to the pre-edit value. `openImageAdjustment` only
+ * touches `app`, `dialog` and `chartSetImageAdjustment`, so exercise it on a bare
+ * prototype instance with those three stubbed — no Angular DI needed.
+ */
+function svcWithResult(result: ImageAdjustmentDialogResult | undefined) {
+  const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+  const saveConfig = vi.fn();
+  const chartImageAdjustment: Record<string, ChartImageAdjustment> = {};
+  (svc as unknown as { app: unknown }).app = {
+    config: { selections: { chartImageAdjustment } },
+    saveConfig
+  };
+  (svc as unknown as { dialog: unknown }).dialog = {
+    open: () => ({ afterClosed: () => of(result) })
+  };
+  const setSpy = vi.fn();
+  svc.chartSetImageAdjustment = setSpy;
+  return { svc, saveConfig, chartImageAdjustment, setSpy };
+}
+
+const chart = (): FBChart =>
+  ['c1', { name: 'Aerial' }, true] as unknown as FBChart;
+
+describe('openImageAdjustment (#457)', () => {
+  it('SAVE persists the value to config and applies it to the cache', () => {
+    const value: ChartImageAdjustment = { brightness: 1.3, contrast: 0.8 };
+    const { svc, saveConfig, chartImageAdjustment, setSpy } = svcWithResult({
+      apply: true,
+      value
+    });
+
+    svc.openImageAdjustment(chart());
+
+    expect(chartImageAdjustment['c1']).toEqual(value);
+    expect(saveConfig).toHaveBeenCalledOnce();
+    expect(setSpy).toHaveBeenLastCalledWith('c1', value);
+  });
+
+  it('cancel reverts to the pre-edit adjustment and persists nothing', () => {
+    const { svc, saveConfig, chartImageAdjustment, setSpy } = svcWithResult({
+      apply: false,
+      value: { brightness: 1.9, contrast: 0.2 }
+    });
+    chartImageAdjustment['c1'] = { brightness: 1.1, contrast: 1.2 };
+
+    svc.openImageAdjustment(chart());
+
+    // config untouched, no save, live preview restored to the stored value
+    expect(chartImageAdjustment['c1']).toEqual({
+      brightness: 1.1,
+      contrast: 1.2
+    });
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(setSpy).toHaveBeenLastCalledWith('c1', {
+      brightness: 1.1,
+      contrast: 1.2
+    });
+  });
+
+  it('cancel falls back to the chart adjustment when config has no entry', () => {
+    const { svc, saveConfig, chartImageAdjustment, setSpy } = svcWithResult({
+      apply: false,
+      value: { brightness: 1.9, contrast: 0.2 }
+    });
+    // no chartImageAdjustment['c2'] entry -> original comes from the chart itself
+    const chartWithAdj = (): FBChart =>
+      [
+        'c2',
+        { name: 'Bathy', imageAdjustment: { brightness: 1.4, contrast: 0.6 } },
+        true
+      ] as unknown as FBChart;
+
+    svc.openImageAdjustment(chartWithAdj());
+
+    expect(chartImageAdjustment['c2']).toBeUndefined();
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(setSpy).toHaveBeenLastCalledWith('c2', {
+      brightness: 1.4,
+      contrast: 0.6
+    });
+  });
+});

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -63,6 +63,10 @@ import { ActionResult, PathValue } from 'src/app/types';
 import { groupBy } from 'rxjs/operators';
 import { SKWorkerService } from '../skstream/skstream.service';
 import { ChartSeedJobDialog } from './components/charts/chart-seedjob-dialog';
+import {
+  ImageAdjustmentDialog,
+  ImageAdjustmentDialogResult
+} from 'src/app/lib/components';
 
 export type SKResourceType =
   'routes' | 'waypoints' | 'regions' | 'notes' | 'charts' | 'tracks';
@@ -845,6 +849,52 @@ export class SKResourceService {
         });
       });
     }
+  }
+
+  /**
+   * @description Open the modeless, draggable Image Adjustment palette for a
+   * chart. Sliders take effect live; SAVE persists per-chart, closing (cancel)
+   * reverts to the pre-edit values. Owned here (not the chart list) so it
+   * survives the chart list closing to free the map.
+   * @param chart Chart to adjust
+   */
+  public openImageAdjustment(chart: FBChart) {
+    const id = chart[0];
+    const original: ChartImageAdjustment = {
+      brightness: 1,
+      contrast: 1,
+      ...(this.app.config.selections.chartImageAdjustment[id] ??
+        chart[1]?.imageAdjustment)
+    };
+
+    this.dialog
+      .open(ImageAdjustmentDialog, {
+        hasBackdrop: false,
+        disableClose: true,
+        autoFocus: false,
+        restoreFocus: false,
+        position: { top: '70px', left: '8px' },
+        width: '290px',
+        data: {
+          title: 'Image Adjustment',
+          text: chart[1]?.name ?? '',
+          value: { ...original },
+          onChange: (value: ChartImageAdjustment) => {
+            this.chartSetImageAdjustment(id, value);
+          }
+        }
+      })
+      .afterClosed()
+      .subscribe((result: ImageAdjustmentDialogResult) => {
+        if (result?.apply) {
+          this.app.config.selections.chartImageAdjustment[id] = result.value;
+          this.chartSetImageAdjustment(id, result.value);
+          this.app.saveConfig();
+        } else {
+          // cancelled - restore the pre-edit adjustment
+          this.chartSetImageAdjustment(id, original);
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
Reworks the Image Adjustment control based on feedback on #457.

Previously it was a centred, modal dialog that covered the area of interest and blocked the map. Now:

- **Modeless & draggable** — a compact palette anchored top-left with no backdrop, so panning and zooming stay available while adjusting. Drag it by the title bar to reposition.
- **Opens with the chart list closed** — clicking the adjust control closes the chart list to free the map. Ownership moved to `SKResourceService` so the palette outlives the chart list.
- **Compact** — smaller footprint; keeps a title + chart-layer name for context.
- Sliders stay live; **SAVE** persists per-chart, cancel reverts, **RESET** returns to neutral.

## Screenshot
![Modeless image adjustment palette](https://raw.githubusercontent.com/joelkoz/freeboard-sk/pr457-assets/fsk-image-adjust.jpg)

Addresses the UX points raised on #457. Tests cover the relocated save/cancel persistence (including the config-vs-chart fallback).
