### PR TITLE
feat(plotterext): implement nightMode capability in the reference host

### DIFF
--- a/dev-tools/fsk-mcp/src/tools.js
+++ b/dev-tools/fsk-mcp/src/tools.js
@@ -266,6 +266,34 @@ const TOOLS = [
     ),
     run: (hub, a) =>
       hub.call('chart.setOrder', { order: a.order }, { session: a.session })
+  },
+  {
+    name: 'fsk_get_night_mode',
+    description:
+      "Read Freeboard-SK's night-mode state: { enabled, auto }. `enabled` is whether the dimmed night-vision display is currently applied; `auto` is whether it follows the server's environment.mode (day/night).",
+    inputSchema: withSession(),
+    run: (hub, a) => hub.call('nightMode.get', {}, { session: a.session })
+  },
+  {
+    name: 'fsk_set_night_mode',
+    description:
+      "Control Freeboard-SK's night mode. Force on with { enabled: true }, force off with { enabled: false }, or follow the server's environment.mode with { auto: true }. Setting `enabled` is a manual override and turns `auto` off. Supply at least one field.",
+    inputSchema: withSession({
+      enabled: {
+        type: 'boolean',
+        description: 'Force night mode on (true) or off (false). Implies auto:false.'
+      },
+      auto: {
+        type: 'boolean',
+        description: 'Follow the server environment.mode (true) or stop following (false).'
+      }
+    }),
+    run: (hub, a) => {
+      const params = {};
+      if (typeof a.enabled === 'boolean') params.enabled = a.enabled;
+      if (typeof a.auto === 'boolean') params.auto = a.auto;
+      return hub.call('nightMode.set', params, { session: a.session });
+    }
   }
 ];
 

--- a/docs/freeboard/freeboard-plotter-ext-support.md
+++ b/docs/freeboard/freeboard-plotter-ext-support.md
@@ -37,8 +37,8 @@ package; Freeboard depends on it (`^0.8.0`) and imports its host entry point
 ### Capabilities Freeboard advertises (`HOST_CAPABILITIES`)
 
 `widgets`, `panels.iframe`, `buttons`, `signalk.stream`, `signalk.put`, `units`,
-`map`, `resources`, `resources.filter`, `routes`, `charts`, `background.iframe`,
-`ui`.
+`map`, `resources`, `resources.filter`, `routes`, `charts`, `nightMode`,
+`background.iframe`, `ui`.
 
 (The authoritative list is `HOST_CAPABILITIES` in
 `src/app/modules/plotterext/types.ts`.)
@@ -170,6 +170,59 @@ re-read `chart.list` for the full snapshot.
 | `src/app/modules/plotterext/chart-methods.ts` | the `chart.*` handlers + param validation + `FBChart`→`ChartLayer` mapping |
 | `src/app/modules/plotterext/plotterext.service.ts` | binds the handlers to the service and emits `chart.*` events (`emitChartChanges`) |
 | `src/app/modules/skresources/resources.service.ts` | `chartsForHostApi` / `setChartsVisibility` / `setChartsOpacity` / `setChartsOrder` |
+
+## The `nightMode` capability
+
+`nightMode` lets an extension read and control Freeboard's night-vision display
+mode — the dimmed low-light appearance the user toggles from the display settings
+or that tracks the server's `environment.mode`. It exists so an embedded panel
+(e.g. an instrument gauge) can match the host instead of glowing white on a dark
+bridge, and it is the first step in moving the bespoke KIP integration onto the
+standard API.
+
+### The night-mode model
+
+The applied night state (the `app-night` class) is
+`stream.selfNightMode() || uiCtrl().forceNightMode`: the **auto** path
+(`config.display.nightMode`, the "Auto-set Night Mode" setting) turns night on when
+`environment.mode === 'night'`, and the **force** path (`uiCtrl().forceNightMode`)
+is a manual override. The capability maps these to `{ enabled, auto }`:
+
+- **`enabled`** — the resolved applied state (`selfNightMode() || forceNightMode`).
+- **`auto`** — the "Auto-set Night Mode" setting (`config.display.nightMode`).
+
+### Methods
+
+`nightMode.get` → `{ enabled, auto }`; `nightMode.set({ enabled?, auto? })`. The
+three effective requests: force on (`{enabled:true}`), force off
+(`{enabled:false}`), follow the server (`{auto:true}`). Setting `enabled` is a
+manual override — it clears `auto`; setting `{auto:true}` clears any manual force
+so the state purely tracks `environment.mode`. `applyNightMode` calls
+`SKStreamFacade.refreshSelfNightMode()` so an `auto` change takes effect
+immediately rather than on the next delta. The handlers are a pure factory
+(`nightmode-methods.ts`) over service accessors.
+
+### Events (`nightMode.changed`)
+
+`nightMode.changed` (`{ enabled, auto }`) is emitted for **every** change
+regardless of origin — a host `nightMode.set`, the user's own display setting, or
+the server's `environment.mode` flipping while `auto` is on. A reactive `effect`
+covers server/force-driven changes; `applyNightMode` also emits directly so an
+`auto`-only change (which may not move the resolved state) is not missed.
+`emitNightModeChange` de-dupes so each real change fires exactly once.
+
+### Error reasons
+
+`nightMode.badRequest` (malformed params — a non-boolean `enabled`/`auto`, or
+neither field present), `nightMode.notSupported`.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `src/app/modules/plotterext/nightmode-methods.ts` | the `nightMode.*` handlers + param validation |
+| `src/app/modules/plotterext/plotterext.service.ts` | binds the handlers (`readNightMode`/`applyNightMode`) and emits `nightMode.changed` (`emitNightModeChange`) |
+| `src/app/modules/skstream/skstream.facade.ts` | `selfNightMode` signal + `refreshSelfNightMode()` |
 
 ## Extending the host API? Update the agent bridge
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@signalk/server-api": "^2.24.0",
         "geolib": "^3.3.3",
         "google-protobuf": "^4.0.1",
-        "signalk-plotterext-bus": "^0.8.0",
+        "signalk-plotterext-bus": "^0.9.0",
         "tslib": "^2.0.0",
         "uuid": "^14.0.1"
       },
@@ -10723,9 +10723,9 @@
       }
     },
     "node_modules/signalk-plotterext-bus": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.8.0.tgz",
-      "integrity": "sha512-xSVAJI2u1ZQD4ky0GW9qfUQzA1ClIWBI//ugIOayyuCZ86509M8nkyLIGh3+FYMAXeG8Q8SLDpkWMpzz50lW/w==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.9.0.tgz",
+      "integrity": "sha512-5gh47QdvkUqVGB3WMQlH0KVtrErrwjI8hHGZ5kNaIkxCw60vgV0RhJF8awEIZbmdrT0vjBWojASWDdjZklDaNA==",
       "license": "MIT"
     },
     "node_modules/sigstore": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@signalk/server-api": "^2.24.0",
     "geolib": "^3.3.3",
     "google-protobuf": "^4.0.1",
-    "signalk-plotterext-bus": "^0.8.0",
+    "signalk-plotterext-bus": "^0.9.0",
     "tslib": "^2.0.0",
     "uuid": "^14.0.1"
   },

--- a/src/app/modules/plotterext/nightmode-methods.spec.ts
+++ b/src/app/modules/plotterext/nightmode-methods.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RpcError } from 'signalk-plotterext-bus/host';
+import { createNightModeMethods } from './nightmode-methods';
+
+function setup(state = { enabled: false, auto: false }) {
+  const deps = {
+    getState: vi.fn(() => state),
+    setState: vi.fn()
+  };
+  const methods = createNightModeMethods(deps);
+  // The bus dispatches handlers as (params, ctx); ctx is unused here.
+  const call = async (name: string, params?: unknown) =>
+    methods[name](params, {} as never);
+  return { deps, call };
+}
+
+describe('nightMode.get', () => {
+  it('returns the current { enabled, auto } state', async () => {
+    const { call } = setup({ enabled: true, auto: true });
+    expect(await call('nightMode.get')).toEqual({ enabled: true, auto: true });
+  });
+});
+
+describe('nightMode.set', () => {
+  it('forwards a force-on request', async () => {
+    const { deps, call } = setup();
+    expect(await call('nightMode.set', { enabled: true })).toEqual({});
+    expect(deps.setState).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it('forwards a force-off request', async () => {
+    const { deps, call } = setup();
+    await call('nightMode.set', { enabled: false });
+    expect(deps.setState).toHaveBeenCalledWith({ enabled: false });
+  });
+
+  it('forwards a follow-server request', async () => {
+    const { deps, call } = setup();
+    await call('nightMode.set', { auto: true });
+    expect(deps.setState).toHaveBeenCalledWith({ auto: true });
+  });
+
+  it('forwards both fields when supplied together', async () => {
+    const { deps, call } = setup();
+    await call('nightMode.set', { enabled: true, auto: false });
+    expect(deps.setState).toHaveBeenCalledWith({ enabled: true, auto: false });
+  });
+
+  it('rejects an empty set with nightMode.badRequest', async () => {
+    const { deps, call } = setup();
+    await expect(call('nightMode.set', {})).rejects.toMatchObject({
+      reason: 'nightMode.badRequest'
+    });
+    expect(deps.setState).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-boolean enabled', async () => {
+    const { call } = setup();
+    const err = await call('nightMode.set', { enabled: 'yes' }).catch(
+      (e: RpcError) => e
+    );
+    expect(err).toBeInstanceOf(RpcError);
+    expect((err as RpcError).reason).toBe('nightMode.badRequest');
+  });
+
+  it('rejects a non-boolean auto', async () => {
+    const { call } = setup();
+    await expect(call('nightMode.set', { auto: 1 })).rejects.toMatchObject({
+      reason: 'nightMode.badRequest'
+    });
+  });
+});

--- a/src/app/modules/plotterext/nightmode-methods.ts
+++ b/src/app/modules/plotterext/nightmode-methods.ts
@@ -1,0 +1,62 @@
+import {
+  RPC_ERRORS,
+  RpcError,
+  type MethodHandler,
+  type NightModeState
+} from 'signalk-plotterext-bus/host';
+
+/**
+ * Host method handlers for the `nightMode` capability — read and control
+ * Freeboard's night-vision display mode (the dimmed low-light appearance the
+ * user toggles from the display settings, or that tracks the server's
+ * `environment.mode`).
+ *
+ * A pure factory over injected accessors so the handlers are unit-testable
+ * without the Angular host service, matching the {@link createChartMethods}
+ * pattern; the service spreads the result into each extension context's method
+ * table.
+ */
+export interface NightModeMethodsDeps {
+  /** Current resolved state: whether night mode is applied and whether it follows the server. */
+  getState: () => NightModeState;
+  /**
+   * Apply a change. `auto` follows the server's `environment.mode`; `enabled`
+   * forces the resolved state and is a manual override (implies `auto: false`).
+   * At least one field is always present (validated before this is called).
+   */
+  setState: (next: Partial<NightModeState>) => void | Promise<void>;
+}
+
+export function createNightModeMethods(
+  deps: NightModeMethodsDeps
+): Record<string, MethodHandler> {
+  const badRequest = (message: string) =>
+    new RpcError(message, {
+      code: RPC_ERRORS.INVALID_PARAMS,
+      reason: 'nightMode.badRequest'
+    });
+
+  return {
+    'nightMode.get': async () => deps.getState(),
+
+    'nightMode.set': async (params) => {
+      const p = (params ?? {}) as { enabled?: unknown; auto?: unknown };
+      const hasEnabled = p.enabled !== undefined;
+      const hasAuto = p.auto !== undefined;
+      if (!hasEnabled && !hasAuto) {
+        throw badRequest('nightMode.set requires enabled and/or auto');
+      }
+      if (hasEnabled && typeof p.enabled !== 'boolean') {
+        throw badRequest('enabled must be a boolean');
+      }
+      if (hasAuto && typeof p.auto !== 'boolean') {
+        throw badRequest('auto must be a boolean');
+      }
+      const next: Partial<NightModeState> = {};
+      if (hasAuto) next.auto = p.auto as boolean;
+      if (hasEnabled) next.enabled = p.enabled as boolean;
+      await deps.setState(next);
+      return {};
+    }
+  };
+}

--- a/src/app/modules/plotterext/nightmode.service.spec.ts
+++ b/src/app/modules/plotterext/nightmode.service.spec.ts
@@ -1,0 +1,120 @@
+import { TestBed } from '@angular/core/testing';
+import { signal, WritableSignal } from '@angular/core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MatDialog } from '@angular/material/dialog';
+import { SignalKClient } from 'signalk-client-angular';
+
+import { PlotterExtensionService } from './plotterext.service';
+import { RouteBufferRegistry } from './route-buffer.registry';
+import { AppFacade } from '../../app.facade';
+import { SKResourceService } from '../skresources/resources.service';
+import { MapService } from '../map/ol/lib/map.service';
+import { SKStreamFacade } from '../skstream/skstream.facade';
+
+// The `nightMode` capability's FSK mapping: get reports the resolved state, and
+// set maps { enabled, auto } onto config.display.nightMode (auto) and
+// uiCtrl.forceNightMode (force), matching the app-night resolution
+// (selfNightMode() || forceNightMode).
+describe('PlotterExtensionService nightMode capability', () => {
+  let appStub: {
+    config: {
+      display: { nightMode: boolean };
+      plotterExtensions: { widgets: [] };
+    };
+    uiCtrl: WritableSignal<{ forceNightMode: boolean }>;
+    uiConfig: WritableSignal<{ autoNightMode: boolean }>;
+    debug: () => void;
+  };
+  let envMode: 'day' | 'night';
+  let nightSig: WritableSignal<boolean>;
+  let call: (name: string, params?: unknown) => Promise<unknown>;
+
+  // Mirrors SKStreamFacade.refreshSelfNightMode against the stub's env + config.
+  const setEnv = (mode: 'day' | 'night') => {
+    envMode = mode;
+    nightSig.set(
+      mode === 'night' && (appStub.config.display.nightMode ?? false)
+    );
+  };
+
+  beforeEach(() => {
+    envMode = 'day';
+    nightSig = signal(false);
+    appStub = {
+      config: {
+        display: { nightMode: false },
+        plotterExtensions: { widgets: [] }
+      },
+      uiCtrl: signal({ forceNightMode: false }),
+      uiConfig: signal({ autoNightMode: false }),
+      debug: () => {}
+    };
+    const streamStub = {
+      selfNightMode: nightSig,
+      refreshSelfNightMode: () =>
+        nightSig.set(
+          envMode === 'night' && (appStub.config.display.nightMode ?? false)
+        )
+    } as unknown as SKStreamFacade;
+
+    TestBed.configureTestingModule({
+      providers: [
+        PlotterExtensionService,
+        RouteBufferRegistry,
+        { provide: AppFacade, useValue: appStub },
+        { provide: SignalKClient, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        {
+          provide: SKResourceService,
+          useValue: { routes: signal([]), charts: signal([]) }
+        },
+        { provide: MapService, useValue: {} },
+        { provide: SKStreamFacade, useValue: streamStub }
+      ]
+    });
+    const service = TestBed.inject(PlotterExtensionService);
+    // The capability's handler table, wired to the real read/apply logic.
+    const methods = (
+      service as unknown as {
+        nightModeMethods: () => Record<
+          string,
+          (p: unknown, c: unknown) => Promise<unknown>
+        >;
+      }
+    ).nightModeMethods();
+    call = (name, params) => methods[name](params, {});
+  });
+
+  it('force on: enabled:true applies night and clears auto', async () => {
+    await call('nightMode.set', { enabled: true });
+    expect(await call('nightMode.get')).toEqual({ enabled: true, auto: false });
+  });
+
+  it('force off wins even while auto + server say night', async () => {
+    setEnv('night');
+    await call('nightMode.set', { auto: true });
+    expect(await call('nightMode.get')).toEqual({ enabled: true, auto: true });
+    await call('nightMode.set', { enabled: false });
+    expect(await call('nightMode.get')).toEqual({
+      enabled: false,
+      auto: false
+    });
+  });
+
+  it('follow server: auto:true derives enabled from environment.mode', async () => {
+    setEnv('day');
+    await call('nightMode.set', { auto: true });
+    expect(await call('nightMode.get')).toEqual({ enabled: false, auto: true });
+    // A server mode flip while auto is on moves the resolved state.
+    setEnv('night');
+    expect(await call('nightMode.get')).toEqual({ enabled: true, auto: true });
+  });
+
+  it('stopping auto without a target holds the current resolved state', async () => {
+    setEnv('night');
+    await call('nightMode.set', { auto: true });
+    expect(await call('nightMode.get')).toEqual({ enabled: true, auto: true });
+    await call('nightMode.set', { auto: false });
+    expect(await call('nightMode.get')).toEqual({ enabled: true, auto: false });
+  });
+});

--- a/src/app/modules/plotterext/plotterext.occupancy.spec.ts
+++ b/src/app/modules/plotterext/plotterext.occupancy.spec.ts
@@ -9,6 +9,7 @@ import { RouteBufferRegistry } from './route-buffer.registry';
 import { AppFacade } from '../../app.facade';
 import { SKResourceService } from '../skresources/resources.service';
 import { MapService } from '../map/ol/lib/map.service';
+import { SKStreamFacade } from '../skstream/skstream.facade';
 import {
   HOST_API_VERSION,
   PlacedWidget,
@@ -73,7 +74,14 @@ describe('PlotterExtensionService occupancy (#433)', () => {
         { provide: SignalKClient, useValue: {} },
         { provide: MatDialog, useValue: {} },
         { provide: SKResourceService, useValue: { routes: signal([]) } },
-        { provide: MapService, useValue: {} }
+        { provide: MapService, useValue: {} },
+        {
+          provide: SKStreamFacade,
+          useValue: {
+            selfNightMode: signal(false),
+            refreshSelfNightMode: () => {}
+          }
+        }
       ]
     });
     service = TestBed.inject(PlotterExtensionService);

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -32,6 +32,7 @@ import { FBCharts, FBNotes, LineString, Position } from 'src/app/types';
 import {
   HostConnection,
   MethodHandler,
+  type NightModeState,
   RoutePoint,
   RpcError,
   RPC_ERRORS,
@@ -60,6 +61,8 @@ import {
 import { RouteBufferRegistry } from './route-buffer.registry';
 import { createRouteMethods } from './route-methods';
 import { createChartMethods } from './chart-methods';
+import { createNightModeMethods } from './nightmode-methods';
+import { SKStreamFacade } from 'src/app/modules/skstream/skstream.facade';
 
 const STATE_STORAGE_KEY = 'fb-plotterext-state';
 const SK_PATH_PERIOD = 1000; // default delta period (ms) for relayed paths
@@ -565,7 +568,8 @@ export class PlotterExtensionService {
     private dialog: MatDialog,
     private skres: SKResourceService,
     private mapService: MapService,
-    private routeRegistry: RouteBufferRegistry
+    private routeRegistry: RouteBufferRegistry,
+    private stream: SKStreamFacade
   ) {
     if (isDevMode()) {
       // console handle for exercising the host API during development
@@ -586,6 +590,11 @@ export class PlotterExtensionService {
     // Emit `chart.*` events for every change to the displayed charts, whether it
     // came from a host method or the user's own chart controls (origin-transparent).
     effect(() => this.emitChartChanges(this.skres.charts()));
+    // Emit `nightMode.changed` when the resolved night state changes from a
+    // server `environment.mode` flip (while auto-night is on) or a manual force.
+    // Auto-only changes that don't move the resolved state are emitted directly
+    // by applyNightMode; emitNightModeChange dedups so each real change fires once.
+    effect(() => this.emitNightModeChange(this.readNightMode()));
   }
 
   /**
@@ -734,6 +743,80 @@ export class PlotterExtensionService {
       setOpacity: (ids, opacity) => this.skres.setChartsOpacity(ids, opacity),
       setOrder: (order) => this.skres.setChartsOrder(order)
     });
+  }
+
+  /** Host API handlers for the `nightMode` capability. */
+  private nightModeMethods(): Record<string, MethodHandler> {
+    return createNightModeMethods({
+      getState: () => this.readNightMode(),
+      setState: (next) => this.applyNightMode(next)
+    });
+  }
+
+  /**
+   * The resolved night-mode state. `enabled` mirrors the `app-night` display
+   * class (the auto-derived state OR a manual force); `auto` is the "Auto-set
+   * Night Mode" setting that tracks the server's `environment.mode`.
+   */
+  private readNightMode(): NightModeState {
+    return {
+      enabled: this.stream.selfNightMode() || this.app.uiCtrl().forceNightMode,
+      auto: this.app.config.display.nightMode ?? false
+    };
+  }
+
+  /**
+   * Apply a `nightMode.set`. `auto` toggles server-following (and, when turned
+   * on, clears any manual force so it purely tracks `environment.mode`); an
+   * explicit `enabled` is a manual override that takes control off the server
+   * (auto → false) and forces the resolved state. Recomputes the auto-derived
+   * state immediately so the change takes effect now, then emits.
+   */
+  private applyNightMode(next: Partial<NightModeState>): void {
+    const auto = next.auto;
+    if (typeof auto === 'boolean') {
+      if (auto) {
+        // Following the server: drop any manual force so it purely tracks
+        // environment.mode.
+        this.app.uiCtrl.update((c) => ({ ...c, forceNightMode: false }));
+      } else if (typeof next.enabled !== 'boolean') {
+        // Stop following without an explicit target: hold the current resolved
+        // state by pinning it as a manual force (read before we clear auto).
+        const held = this.readNightMode().enabled;
+        this.app.uiCtrl.update((c) => ({ ...c, forceNightMode: held }));
+      }
+      this.app.config.display.nightMode = auto;
+      this.app.uiConfig.update((c) => ({ ...c, autoNightMode: auto }));
+    }
+    const enabled = next.enabled;
+    if (typeof enabled === 'boolean') {
+      this.app.config.display.nightMode = false;
+      this.app.uiConfig.update((c) => ({ ...c, autoNightMode: false }));
+      this.app.uiCtrl.update((c) => ({ ...c, forceNightMode: enabled }));
+    }
+    this.stream.refreshSelfNightMode();
+    this.emitNightModeChange(this.readNightMode());
+  }
+
+  /** Last night-mode state broadcast, for de-duping `nightMode.changed`. */
+  private prevNightMode: NightModeState | null = null;
+
+  /**
+   * Broadcast `nightMode.changed` when the resolved state changes, from any
+   * origin. Seeds silently on the first run (matching the chart-event pattern)
+   * and de-dupes so the reactive effect and the imperative applyNightMode path
+   * together emit exactly once per real change.
+   */
+  private emitNightModeChange(state: NightModeState): void {
+    const prev = this.prevNightMode;
+    this.prevNightMode = state;
+    if (prev === null) {
+      return;
+    }
+    if (prev.enabled === state.enabled && prev.auto === state.auto) {
+      return;
+    }
+    this.broadcastMessage('nightMode.changed', state);
   }
 
   /** Topmost-first id order + per-chart opacity of the last displayed-chart set,
@@ -1423,6 +1506,7 @@ export class PlotterExtensionService {
         ...this.mapMethods(),
         ...this.routeMethods(),
         ...this.chartMethods(),
+        ...this.nightModeMethods(),
         ...this.uiPanelMethods(placed.extension),
         'ui.openConfigPanel': async () => {
           this.openConfigPanel(placed);
@@ -1479,6 +1563,7 @@ export class PlotterExtensionService {
         ...this.mapMethods(),
         ...this.routeMethods(),
         ...this.chartMethods(),
+        ...this.nightModeMethods(),
         ...this.uiPanelMethods(opts.extension),
         'ui.closePanel': async () => {
           opts.close();
@@ -1525,6 +1610,7 @@ export class PlotterExtensionService {
         ...this.mapMethods(),
         ...this.routeMethods(),
         ...this.chartMethods(),
+        ...this.nightModeMethods(),
         ...this.uiPanelMethods(opts.extension)
       },
       onError: (err) => console.warn('plotterext background error', err)

--- a/src/app/modules/plotterext/types.ts
+++ b/src/app/modules/plotterext/types.ts
@@ -20,6 +20,7 @@ export const HOST_CAPABILITIES = [
   'resources.filter',
   'routes',
   'charts',
+  'nightMode',
   'background.iframe',
   'ui'
 ];

--- a/src/app/modules/skstream/skstream.facade.ts
+++ b/src/app/modules/skstream/skstream.facade.ts
@@ -50,6 +50,19 @@ export class SKStreamFacade {
   private nightModeSignal = signal<boolean>(false);
   readonly selfNightMode = this.nightModeSignal.asReadonly();
 
+  /**
+   * Recompute the resolved auto-night state from the current `environment.mode`
+   * and the "Auto-set Night Mode" setting. Runs on each self delta; also called
+   * when the setting itself changes (e.g. a `nightMode.set({ auto })` host call)
+   * so the change takes effect immediately instead of on the next delta.
+   */
+  refreshSelfNightMode(): void {
+    this.nightModeSignal.set(
+      this.app.data.vessels.self?.environment?.mode === 'night' &&
+        (this.app.config.display.nightMode ?? false)
+    );
+  }
+
   private aisLifecycle = signal<{
     updated: string[];
     stale: string[];
@@ -366,12 +379,7 @@ export class SKStreamFacade {
       };
     });
 
-    this.nightModeSignal.update(() => {
-      return (
-        v.environment.mode === 'night' &&
-        (this.app.config.display.nightMode ?? false)
-      );
-    });
+    this.refreshSelfNightMode();
   }
 
   private parseSelfRacing(v: SKVessel) {


### PR DESCRIPTION
Implements the agnostic `nightMode` capability (spec merged in #504; wire
contract in `signalk-plotterext-bus` 0.9.0) in the Freeboard reference host — the
first step in moving the bespoke KIP integration onto the standard API.

**What:** an extension can now read, set and follow Freeboard's night-vision
display mode.
- `nightMode.get` → `{ enabled, auto }`.
- `nightMode.set({ enabled?, auto? })` — force on, force off, or follow the
  server's `environment.mode`. Setting `enabled` is a manual override (implies
  `auto: false`), so an explicit off wins over the server.
- `nightMode.changed` — emitted origin-transparently for every change (a host
  `set`, the user's display setting, or a server mode flip while `auto` is on).

**How:** `{ enabled, auto }` maps onto the existing night model —
`config.display.nightMode` (auto) and `uiCtrl.forceNightMode` (force) — with
`enabled` resolving as the `app-night` class does (`selfNightMode() ||
forceNightMode`). `SKStreamFacade.refreshSelfNightMode()` makes a `set` take
effect immediately rather than on the next delta. Handlers are a pure factory
(`nightmode-methods.ts`) matching the `charts` pattern. The `fsk-mcp` dev bridge
and host docs are updated in step. The bespoke KIP `postMessage` bridge is
untouched — retiring it is a separate later step.

Tests: pure-factory validation + a service-level spec (force-off-wins,
follow-server + env-flip, hold-on-auto-off).

Closes #502.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added night-mode support for extensions, including controls to enable, disable, or automatically follow environmental conditions.
  * Made night-mode state available consistently across widgets, configuration panels, and background extensions.
  * Added curated tools for reading and updating night-mode settings.

* **Documentation**
  * Documented the night-mode capability, methods, events, and possible errors.

* **Bug Fixes**
  * Improved night-mode updates when vessel environment data or display settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->