### PR TITLE
feat(plotterext): support reverse embedding (embedding host)

### DIFF
--- a/docs/freeboard/freeboard-plotter-ext-support.md
+++ b/docs/freeboard/freeboard-plotter-ext-support.md
@@ -43,6 +43,27 @@ package; Freeboard depends on it (`^0.8.0`) and imports its host entry point
 (The authoritative list is `HOST_CAPABILITIES` in
 `src/app/modules/plotterext/types.ts`.)
 
+### Embedding hosts (reverse embedding)
+
+Freeboard can also run **inside** another application's iframe (an *embedding
+host*, e.g. KIP) and expose the same host API to that parent — the reverse of the
+usual topology. See the API spec's *Embedding Hosts* section for the contract.
+
+- `PlotterExtensionService.attachEmbeddingHost()` registers one `HostConnection`
+  whose `windowPort` targets `window.parent`, with the full method set and a
+  `kind: 'embedding-host'` context. `init()` calls it once, only when embedded
+  (`!app.isTopWindow()`). Freeboard only stands up the endpoint — the **embedding
+  application initiates** the handshake by calling `connectExtension` from the
+  parent frame.
+- **Same-origin only.** The port pins the origin to Freeboard's own
+  (`window.location.origin`) — a cross-origin embedder is refused. A same-origin
+  embedder already shares the user's session, so this grants no new authority.
+- **Caller identity.** `adoptCallerId: true` adopts the id the embedder asserts in
+  `bus.ready` as the handshake `context.id`; `state.*` stays under a single
+  `embedding-host` scope (one embedder per server in practice).
+- The legacy parent-`postMessage` night-mode bridge in `app.facade.ts`
+  (`parseMessageFromParent`) is retained for backward compatibility.
+
 ## The `routes` capability
 
 `routes` lets an extension create and edit routes on the chart — e.g. an

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@signalk/server-api": "^2.24.0",
         "geolib": "^3.3.3",
         "google-protobuf": "^4.0.1",
-        "signalk-plotterext-bus": "^0.9.0",
+        "signalk-plotterext-bus": "^0.10.0",
         "tslib": "^2.0.0",
         "uuid": "^14.0.1"
       },
@@ -10723,9 +10723,9 @@
       }
     },
     "node_modules/signalk-plotterext-bus": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.9.0.tgz",
-      "integrity": "sha512-5gh47QdvkUqVGB3WMQlH0KVtrErrwjI8hHGZ5kNaIkxCw60vgV0RhJF8awEIZbmdrT0vjBWojASWDdjZklDaNA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.10.0.tgz",
+      "integrity": "sha512-KhUICGdTRJVQcRFR62phxUfUg2qeQpUg9HdcNqLmiSjVF1QKakYWcxwjYGPuHZileovnJV9h0+e4VxUzCklGDg==",
       "license": "MIT"
     },
     "node_modules/sigstore": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@signalk/server-api": "^2.24.0",
     "geolib": "^3.3.3",
     "google-protobuf": "^4.0.1",
-    "signalk-plotterext-bus": "^0.9.0",
+    "signalk-plotterext-bus": "^0.10.0",
     "tslib": "^2.0.0",
     "uuid": "^14.0.1"
   },

--- a/src/app/modules/plotterext/plotterext.embedding-host.spec.ts
+++ b/src/app/modules/plotterext/plotterext.embedding-host.spec.ts
@@ -1,0 +1,121 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MatDialog } from '@angular/material/dialog';
+import { SignalKClient } from 'signalk-client-angular';
+import { messagePort } from 'signalk-plotterext-bus/host';
+import {
+  connectExtension,
+  ExtensionClient
+} from 'signalk-plotterext-bus/extension';
+
+import { PlotterExtensionService } from './plotterext.service';
+import { RouteBufferRegistry } from './route-buffer.registry';
+import { AppFacade } from '../../app.facade';
+import { SKResourceService } from '../skresources/resources.service';
+import { MapService } from '../map/ol/lib/map.service';
+import { SKStreamFacade } from '../skstream/skstream.facade';
+
+// #507: reverse embedding. When Freeboard is embedded in another app's iframe,
+// attachEmbeddingHost() exposes the full host API to that parent — the plotter
+// stays the API host, the embedder is the caller and initiates the handshake.
+describe('PlotterExtensionService embedding host (reverse embedding, #507)', () => {
+  let service: PlotterExtensionService;
+  const detachers: Array<() => void> = [];
+  const clients: ExtensionClient[] = [];
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      providers: [
+        PlotterExtensionService,
+        RouteBufferRegistry,
+        {
+          provide: AppFacade,
+          useValue: {
+            // Deep enough for the constructor effects (which an async test
+            // flushes, unlike a synchronous spec): readNightMode() reads
+            // uiCtrl() and config.display.nightMode.
+            config: {
+              plotterExtensions: { widgets: [] },
+              display: { nightMode: false }
+            },
+            debug: () => {},
+            isTopWindow: () => false,
+            uiCtrl: signal({ forceNightMode: false })
+          }
+        },
+        { provide: SignalKClient, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        {
+          provide: SKResourceService,
+          useValue: { routes: signal([]), charts: signal([]) }
+        },
+        { provide: MapService, useValue: {} },
+        {
+          provide: SKStreamFacade,
+          useValue: {
+            selfNightMode: signal(false),
+            refreshSelfNightMode: () => {}
+          }
+        }
+      ]
+    });
+    service = TestBed.inject(PlotterExtensionService);
+  });
+
+  afterEach(() => {
+    while (clients.length) clients.pop()!.close();
+    while (detachers.length) detachers.pop()!();
+  });
+
+  // Drive a real caller against the service's embedding-host connection over a
+  // MessageChannel — the same seam the bus's own conformance suite uses.
+  async function connect(id?: string): Promise<ExtensionClient> {
+    const channel = new MessageChannel();
+    detachers.push(service.attachEmbeddingHost(messagePort(channel.port1)));
+    const client = await connectExtension({
+      port: messagePort(channel.port2),
+      id,
+      timeoutMs: 2000,
+      onError: () => {}
+    });
+    clients.push(client);
+    return client;
+  }
+
+  it('hands the embedder an embedding-host context and adopts its asserted id', async () => {
+    const client = await connect('kip');
+    expect(client.context.kind).toBe('embedding-host');
+    expect(client.context.id).toBe('kip');
+    expect(client.context.instanceId).toBe(null);
+  });
+
+  it('defaults context.id to embedding-host when the caller asserts none', async () => {
+    const client = await connect();
+    expect(client.context.id).toBe('embedding-host');
+  });
+
+  it('exposes the full host API surface to the embedder', async () => {
+    const client = await connect('kip');
+    for (const cap of [
+      'signalk.stream',
+      'signalk.put',
+      'units',
+      'map',
+      'resources',
+      'routes',
+      'charts',
+      'nightMode',
+      'ui'
+    ]) {
+      expect(client.hasCapability(cap)).toBe(true);
+    }
+  });
+
+  it('serves host state methods over the connection', async () => {
+    const client = await connect('kip');
+    await client.state.set({ demo: 42 });
+    await expect(client.state.get(['demo'])).resolves.toEqual({ demo: 42 });
+  });
+});

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -30,6 +30,7 @@ import { SKResourceService } from 'src/app/modules/skresources/resources.service
 import { MapService } from 'src/app/modules/map/ol/lib/map.service';
 import { FBCharts, FBNotes, LineString, Position } from 'src/app/types';
 import {
+  type BusPort,
   HostConnection,
   MethodHandler,
   type NightModeState,
@@ -65,6 +66,10 @@ import { createNightModeMethods } from './nightmode-methods';
 import { SKStreamFacade } from 'src/app/modules/skstream/skstream.facade';
 
 const STATE_STORAGE_KEY = 'fb-plotterext-state';
+// Fixed state/scope key for the embedding-host connection (reverse embedding).
+// The caller's asserted id is adopted into the handshake context.id, but state
+// stays under this single scope — one embedder per server in practice.
+const EMBEDDING_HOST_ID = 'embedding-host';
 const SK_PATH_PERIOD = 1000; // default delta period (ms) for relayed paths
 
 // Recognised resources.setFilter condition operators (see ResourceFilterCondition).
@@ -555,6 +560,8 @@ export class PlotterExtensionService {
   }
 
   private contexts = new Set<LiveContext>();
+  // Detach handle for the embedding-host connection, if one was stood up.
+  private embeddingHostDetach: (() => void) | null = null;
 
   // ---- Signal K delta relay (one WS for all widget contexts) ----
   private ws: WebSocket | null = null;
@@ -1135,6 +1142,7 @@ export class PlotterExtensionService {
     }
     this.refreshActiveWidgets();
     this.initialized.set(true);
+    this.attachEmbeddingHostOnce();
   }
 
   // ---------- discovery ----------
@@ -1617,6 +1625,66 @@ export class PlotterExtensionService {
     });
     this.contexts.add(ctx);
     return () => this.detach(ctx);
+  }
+
+  /**
+   * Reverse embedding: when Freeboard is itself running inside another
+   * application's iframe (an "embedding host", e.g. KIP), expose the full host
+   * API to that parent over the same bus. Freeboard stays the API host but
+   * points its port at `window.parent`; the embedding host is the caller and
+   * initiates the handshake. The origin is pinned to Freeboard's own origin, so
+   * only a same-origin embedder — already sharing the user's session — is
+   * served; a cross-origin embedder is refused (see the API spec, *Embedding
+   * Hosts*). The caller's asserted id is adopted as the handshake `context.id`;
+   * `state.*` stays under a single `embedding-host` scope (one embedder per
+   * server in practice).
+   */
+  attachEmbeddingHost(
+    port: BusPort = windowPort(window.parent, {
+      origin: window.location.origin
+    })
+  ): () => void {
+    const id = EMBEDDING_HOST_ID;
+    const ctx: LiveContext = {
+      extension: id,
+      conn: null as unknown as HostConnection,
+      skSubs: new Map(),
+      skSubSeq: 0
+    };
+    ctx.conn = new HostConnection({
+      port,
+      hostInfo: this.hostInfo(),
+      adoptCallerId: true,
+      context: {
+        kind: 'embedding-host',
+        id,
+        instanceId: null
+      },
+      methods: {
+        ...this.stateMethods(id, null),
+        ...this.signalkMethods(ctx),
+        ...this.unitsMethods(),
+        ...this.resourcesMethods(id),
+        ...this.mapMethods(),
+        ...this.routeMethods(),
+        ...this.chartMethods(),
+        ...this.nightModeMethods(),
+        ...this.uiPanelMethods(id)
+      },
+      onError: (err) => console.warn('plotterext embedding-host error', err)
+    });
+    this.contexts.add(ctx);
+    return () => this.detach(ctx);
+  }
+
+  /**
+   * Stand up the embedding-host connection once, only when Freeboard is embedded
+   * in a parent frame. Idempotent — `init()` may run several times (e.g. a
+   * re-discovery after authentication).
+   */
+  private attachEmbeddingHostOnce(): void {
+    if (this.embeddingHostDetach || this.app.isTopWindow()) return;
+    this.embeddingHostDetach = this.attachEmbeddingHost();
   }
 
   private detach(ctx: LiveContext) {


### PR DESCRIPTION
When Freeboard runs inside another application's iframe (an "embedding host", e.g. KIP), expose the full host API to that parent over the Plotter Extensions bus — the reverse of the usual topology. Freeboard stays the API host but points its port at `window.parent`; the embedding host is the caller and initiates the handshake. This lets an embedder drive Freeboard through the full negotiated surface instead of the bespoke night-mode-only `postMessage` bridge.

- `attachEmbeddingHost()` stands up one `HostConnection` targeting `window.parent`, origin-pinned to Freeboard's own origin (same-origin embedders only — they already share the user's session), with `adoptCallerId: true` so the caller's asserted id becomes the handshake `context.id`. `init()` calls it once, only when embedded (`!isTopWindow()`).
- The legacy `parseMessageFromParent` night-mode bridge is retained for backward compatibility.

Implements the reference-host side of the API spec's *Embedding Hosts* section (added in #506); requires `signalk-plotterext-bus@^0.10.0`.

Closes #507.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Freeboard can now run inside another application’s iframe while exposing its Plotter Extensions host API to the embedding application.
  * Added support for embedding-host contexts, caller identity adoption, state sharing, and the full host capability set.
  * Same-origin access is enforced for embedded connections.

* **Documentation**
  * Added guidance for configuring and using reverse embedding, including state scoping and legacy night-mode compatibility.

* **Tests**
  * Added coverage for embedded connections, host capabilities, caller IDs, and state synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->