### PR TITLE
feat(charts): trim image adjustment palette and remember its position

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -44,6 +44,9 @@ export function cleanConfig(
       settings.ui.showNotes = true;
     }
   }
+  if (typeof settings.imageAdjustPalettePos === 'undefined') {
+    settings.imageAdjustPalettePos = null;
+  }
 
   if (typeof settings.display === 'undefined') {
     settings.display = {
@@ -458,6 +461,7 @@ export function defaultConfig(): IAppConfig {
       showNotes: true, // show/hide notes
       autoNightMode: false
     },
+    imageAdjustPalettePos: null,
     display: {
       fab: 'wpt', // default FAB button
       disableWakelock: false,

--- a/src/app/lib/components/dialogs/image-adjustment-dialog.ts
+++ b/src/app/lib/components/dialogs/image-adjustment-dialog.ts
@@ -8,8 +8,8 @@ import {
   MatDialogRef,
   MAT_DIALOG_DATA
 } from '@angular/material/dialog';
-import { CdkDrag, CdkDragHandle } from '@angular/cdk/drag-drop';
-import { ChartImageAdjustment } from 'src/app/types';
+import { CdkDrag, CdkDragEnd, CdkDragHandle } from '@angular/cdk/drag-drop';
+import { ChartImageAdjustment, PalettePosition } from 'src/app/types';
 
 export interface ImageAdjustmentDialogResult {
   apply: boolean;
@@ -43,27 +43,26 @@ const toRatio = (percent: number) => percent / 100;
       style="overflow: hidden;"
       cdkDrag
       cdkDragRootElement=".cdk-overlay-pane"
+      [cdkDragFreeDragPosition]="initialPosition"
+      (cdkDragEnded)="onDragEnded($event)"
     >
       <div
         cdkDragHandle
-        style="display:flex; align-items:center; cursor:move; padding: 4px 4px 4px 12px;"
+        style="display:flex; align-items:center; cursor:move; padding: 4px 4px 0 12px;"
       >
         <mat-icon style="opacity:0.6;">tune</mat-icon>
-        <div style="flex: 1 1 auto; padding-left: 8px;">
-          <div style="font-weight:500;">
-            {{ data.title ?? 'Image Adjustment' }}
-          </div>
-          @if (data.text) {
-            <div style="font-size: 11px; opacity: 0.7;">{{ data.text }}</div>
-          }
+        <div style="flex: 1 1 auto; padding-left: 8px; font-weight: 500;">
+          {{ data.text }}
         </div>
         <button mat-icon-button aria-label="Close" (click)="handleClose(false)">
           <mat-icon>close</mat-icon>
         </button>
       </div>
 
-      <mat-dialog-content style="padding-top: 0; overflow-x: hidden;">
-        <div style="display: flex; align-items: center">
+      <mat-dialog-content
+        style="padding: 0 24px; overflow: hidden; margin-top: -4px;"
+      >
+        <div style="display: flex; align-items: center; margin: -11px 0">
           <div style="width: 72px; font-size: 13px;">Brightness</div>
           <mat-slider
             style="flex: 1 1 auto; min-width: 0"
@@ -82,7 +81,7 @@ const toRatio = (percent: number) => percent / 100;
             {{ brightness() }}%
           </div>
         </div>
-        <div style="display: flex; align-items: center">
+        <div style="display: flex; align-items: center; margin: -11px 0">
           <div style="width: 72px; font-size: 13px;">Contrast</div>
           <mat-slider
             style="flex: 1 1 auto; min-width: 0"
@@ -102,10 +101,10 @@ const toRatio = (percent: number) => percent / 100;
           </div>
         </div>
       </mat-dialog-content>
-      <mat-dialog-actions>
+      <mat-dialog-actions style="min-height: 38px; padding: 0 8px 2px;">
         <button mat-button (click)="reset()">RESET</button>
         <span style="flex: 1 1 auto"></span>
-        <button mat-raised-button (click)="handleClose(true)">SAVE</button>
+        <button mat-button (click)="handleClose(true)">SAVE</button>
       </mat-dialog-actions>
     </div>
   `
@@ -118,11 +117,19 @@ export class ImageAdjustmentDialog implements OnInit {
     MatDialogRef<ImageAdjustmentDialog, ImageAdjustmentDialogResult>
   );
   protected data = inject<{
-    title: string;
     text: string;
     value: ChartImageAdjustment;
+    position: PalettePosition | null;
     onChange: (value: ChartImageAdjustment) => void;
+    onMoved: (position: PalettePosition) => void;
   }>(MAT_DIALOG_DATA);
+
+  // Stable reference so cdkDragFreeDragPosition isn't re-applied (and the palette
+  // reset to origin) on every change-detection pass.
+  protected initialPosition: PalettePosition = this.data.position ?? {
+    x: 0,
+    y: 0
+  };
 
   ngOnInit() {
     this.brightness.set(toPercent(this.data.value?.brightness ?? 1));
@@ -143,6 +150,12 @@ export class ImageAdjustmentDialog implements OnInit {
     this.brightness.set(NEUTRAL_PERCENT);
     this.contrast.set(NEUTRAL_PERCENT);
     this.emitChange();
+  }
+
+  protected onDragEnded(e: CdkDragEnd) {
+    if (typeof this.data?.onMoved === 'function') {
+      this.data.onMoved(e.source.getFreeDragPosition());
+    }
   }
 
   private currentValue(): ChartImageAdjustment {

--- a/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
+++ b/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
@@ -11,20 +11,38 @@ import { ImageAdjustmentDialogResult } from 'src/app/lib/components';
  * touches `app`, `dialog` and `chartSetImageAdjustment`, so exercise it on a bare
  * prototype instance with those three stubbed — no Angular DI needed.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function svcWithResult(result: ImageAdjustmentDialogResult | undefined) {
   const svc = Object.create(SKResourceService.prototype) as SKResourceService;
   const saveConfig = vi.fn();
   const chartImageAdjustment: Record<string, ChartImageAdjustment> = {};
-  (svc as unknown as { app: unknown }).app = {
-    config: { selections: { chartImageAdjustment } },
-    saveConfig
+  const config: {
+    selections: { chartImageAdjustment: Record<string, ChartImageAdjustment> };
+    imageAdjustPalettePos: { x: number; y: number } | null;
+  } = {
+    selections: { chartImageAdjustment },
+    imageAdjustPalettePos: null
   };
+  (svc as unknown as { app: unknown }).app = { config, saveConfig };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let openedData: any;
   (svc as unknown as { dialog: unknown }).dialog = {
-    open: () => ({ afterClosed: () => of(result) })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    open: (_cmp: unknown, cfg: any) => {
+      openedData = cfg.data;
+      return { afterClosed: () => of(result) };
+    }
   };
   const setSpy = vi.fn();
   svc.chartSetImageAdjustment = setSpy;
-  return { svc, saveConfig, chartImageAdjustment, setSpy };
+  return {
+    svc,
+    saveConfig,
+    chartImageAdjustment,
+    config,
+    setSpy,
+    getData: () => openedData
+  };
 }
 
 const chart = (): FBChart =>
@@ -87,5 +105,30 @@ describe('openImageAdjustment (#457)', () => {
       brightness: 1.4,
       contrast: 0.6
     });
+  });
+
+  it('opens the palette at the remembered position', () => {
+    const { svc, config, getData } = svcWithResult({
+      apply: false,
+      value: { brightness: 1, contrast: 1 }
+    });
+    config.imageAdjustPalettePos = { x: 120, y: 40 };
+
+    svc.openImageAdjustment(chart());
+
+    expect(getData().position).toEqual({ x: 120, y: 40 });
+  });
+
+  it('persists the palette position when dragged', () => {
+    const { svc, config, saveConfig, getData } = svcWithResult({
+      apply: false,
+      value: { brightness: 1, contrast: 1 }
+    });
+
+    svc.openImageAdjustment(chart());
+    getData().onMoved({ x: 200, y: 90 });
+
+    expect(config.imageAdjustPalettePos).toEqual({ x: 200, y: 90 });
+    expect(saveConfig).toHaveBeenCalledOnce();
   });
 });

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -45,6 +45,7 @@ import {
   Regions,
   ChartResource,
   ChartImageAdjustment,
+  PalettePosition,
   FBChart,
   FBCharts,
   FBRegion,
@@ -876,11 +877,15 @@ export class SKResourceService {
         position: { top: '70px', left: '8px' },
         width: '290px',
         data: {
-          title: 'Image Adjustment',
           text: chart[1]?.name ?? '',
           value: { ...original },
+          position: this.app.config.imageAdjustPalettePos,
           onChange: (value: ChartImageAdjustment) => {
             this.chartSetImageAdjustment(id, value);
+          },
+          onMoved: (position: PalettePosition) => {
+            this.app.config.imageAdjustPalettePos = position;
+            this.app.saveConfig();
           }
         }
       })

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -62,6 +62,8 @@ export type LengthUnitDef = 'm' | 'foot';
 export type SpeedUnitDef = 'kn' | 'm/s' | 'km/h' | 'mph';
 export type DistanceUnitDef = 'kilometer' | 'naut-mile';
 
+export type PalettePosition = { x: number; y: number };
+
 export interface IAppConfig {
   ui: {
     mapNorthUp: boolean;
@@ -74,6 +76,7 @@ export interface IAppConfig {
     showNotes: boolean; // show/hide notes
     autoNightMode: boolean;
   };
+  imageAdjustPalettePos: PalettePosition | null; // remembered drag offset of the chart Image Adjustment palette
   display: {
     fab: MFBAction; // FAB button selection
     disableWakelock: boolean;


### PR DESCRIPTION
Follow-up refinements to the modeless Image Adjustment palette (#497), addressing further feedback on #457.

- **Header trimmed** — drops the redundant "Image Adjustment" title and shows just the chart-layer name.
- **Tighter layout** — reduced whitespace between the slider rows and around the action bar; RESET/SAVE are flat text buttons.
- **Remembers its position** — the palette reopens where it was last dragged; the drag offset is persisted in app config so it survives reloads and sessions.

Tests cover the position persistence (opens at the remembered offset; persists on drag).

## Before / after

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/joelkoz/freeboard-sk/pr457-assets/img-adj-before.jpg) | ![after](https://raw.githubusercontent.com/joelkoz/freeboard-sk/pr457-assets/img-adj-after.jpg) |
