### PR TITLE
fix(map): improve meteo wind-barb visibility

### DIFF
--- a/src/app/modules/icons/atons.ts
+++ b/src/app/modules/icons/atons.ts
@@ -82,7 +82,7 @@ export const METEO_WIND_STEP_KTS = 5;
 const WindBarb = (kts: number): MapIconDef => ({
   path: `./assets/img/wind/barbs/weatherStation-${kts}.svg`,
   anchor: [13, 42],
-  scale: 0.75
+  scale: 0.9
 });
 
 /**

--- a/src/assets/img/wind/barbs/weatherStation-10.svg
+++ b/src/assets/img/wind/barbs/weatherStation-10.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-15.svg
+++ b/src/assets/img/wind/barbs/weatherStation-15.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="13" x2="7.5" y2="10" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="7.5" y2="10" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-20.svg
+++ b/src/assets/img/wind/barbs/weatherStation-20.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-25.svg
+++ b/src/assets/img/wind/barbs/weatherStation-25.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="18" x2="7.5" y2="15" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="7.5" y2="15" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-30.svg
+++ b/src/assets/img/wind/barbs/weatherStation-30.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="18" x2="2" y2="12" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="2" y2="12" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-35.svg
+++ b/src/assets/img/wind/barbs/weatherStation-35.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="18" x2="2" y2="12" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="23" x2="7.5" y2="20" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="2" y2="12" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="23" x2="7.5" y2="20" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-40.svg
+++ b/src/assets/img/wind/barbs/weatherStation-40.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="18" x2="2" y2="12" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="23" x2="2" y2="17" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="2" y2="12" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="23" x2="2" y2="17" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-45.svg
+++ b/src/assets/img/wind/barbs/weatherStation-45.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="8" x2="2" y2="2" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="13" x2="2" y2="7" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="18" x2="2" y2="12" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="23" x2="2" y2="17" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="28" x2="7.5" y2="25" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="8" x2="2" y2="2" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="2" y2="7" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="18" x2="2" y2="12" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="23" x2="2" y2="17" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="28" x2="7.5" y2="25" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-5.svg
+++ b/src/assets/img/wind/barbs/weatherStation-5.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="13" x2="7.5" y2="10" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="13" x2="7.5" y2="10" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-50.svg
+++ b/src/assets/img/wind/barbs/weatherStation-50.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#800000"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-55.svg
+++ b/src/assets/img/wind/barbs/weatherStation-55.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
-  <line x1="13" y1="20" x2="7.5" y2="17" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#800000"/>
+  <line x1="13" y1="20" x2="7.5" y2="17" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-60.svg
+++ b/src/assets/img/wind/barbs/weatherStation-60.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
-  <line x1="13" y1="20" x2="2" y2="14" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#800000"/>
+  <line x1="13" y1="20" x2="2" y2="14" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-65.svg
+++ b/src/assets/img/wind/barbs/weatherStation-65.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
-  <line x1="13" y1="20" x2="2" y2="14" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="25" x2="7.5" y2="22" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#800000"/>
+  <line x1="13" y1="20" x2="2" y2="14" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="25" x2="7.5" y2="22" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-70.svg
+++ b/src/assets/img/wind/barbs/weatherStation-70.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
-  <line x1="13" y1="20" x2="2" y2="14" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="25" x2="2" y2="19" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#800000"/>
+  <line x1="13" y1="20" x2="2" y2="14" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="25" x2="2" y2="19" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/src/assets/img/wind/barbs/weatherStation-75.svg
+++ b/src/assets/img/wind/barbs/weatherStation-75.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="26" height="44" viewBox="0 0 26 44">
-  <line x1="13" y1="42" x2="13" y2="8" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#808000"/>
-  <line x1="13" y1="20" x2="2" y2="14" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="25" x2="2" y2="19" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
-  <line x1="13" y1="30" x2="7.5" y2="27" stroke="#808000" stroke-width="2" stroke-linecap="round"/>
+  <line x1="13" y1="42" x2="13" y2="8" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <path d="M 13 8 L 1 9 L 13 16 Z" fill="#800000"/>
+  <line x1="13" y1="20" x2="2" y2="14" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="25" x2="2" y2="19" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
+  <line x1="13" y1="30" x2="7.5" y2="27" stroke="#800000" stroke-width="3" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## What problem does this solve?

Users reported the meteo wind barbs (added in #495) are hard to see on the chart —
too thin and too light-coloured to read at a glance from the helm.

## How does it work?

Recolours the bundled barb glyphs to maroon (`#800000`), thickens the strokes
(2 → 3 px), and bumps the icon scale (0.75 → 0.9) for legibility. No behavioural
change — same speed buckets, same rotation, same override refs.

## How was this tested?

`npm run test:ci` (build + unit tests green) and verified on-chart against a live
server: barbs are clearly legible across the full speed ladder.

## Checklist

- [x] One logical change; version numbers untouched.
- [x] Skimmed DEV-LESSONS-LEARNED.md for traps relevant to this change.
- [x] `npm run test:ci` passes (visual/asset change to an already-tested feature; existing specs still cover bucket selection and rotation).

Closes #490

@coderabbitai ignore
