### PR TITLE
feat(notes): add option to open note details on single click

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -308,6 +308,7 @@
                       id: $event
                     })
                   "
+                  (move)="onNoteMove($event)"
                   (panTo)="centerAndZoom($event.center, $event.zoomLevel)"
                 />
               }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1161,6 +1161,16 @@ export class AppComponent {
     }
   }
 
+  /** Start moving a Note from the info panel (close the panel first so the
+   * map's Modify interaction is unobstructed). */
+  protected onNoteMove(id: string) {
+    if (this.infoPanel.opened()) {
+      this.infoPanel.close();
+      this.closeDrawer();
+    }
+    this.skres.startNoteModify(id);
+  }
+
   // ********* MAIN MENU ACTIONS *************
 
   // ** open about dialog **

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -66,6 +66,7 @@ export function cleanConfig(
         favourites: []
       },
       preferInfoPanel: true,
+      singleClickNoteDetails: false,
       statusBar: {
         liveEta: false,
         referenceSpeed: 6
@@ -74,6 +75,9 @@ export function cleanConfig(
   } else {
     if (typeof settings.display.preferInfoPanel === 'undefined') {
       settings.display.preferInfoPanel = true;
+    }
+    if (typeof settings.display.singleClickNoteDetails === 'undefined') {
+      settings.display.singleClickNoteDetails = false;
     }
     if (typeof settings.display.statusBar === 'undefined') {
       settings.display.statusBar = {
@@ -476,6 +480,7 @@ export function defaultConfig(): IAppConfig {
         favourites: []
       },
       preferInfoPanel: true,
+      singleClickNoteDetails: false,
       statusBar: {
         liveEta: false,
         referenceSpeed: 6

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -1551,7 +1551,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.title = 'Note';
         poData.resource = item;
         poData.show = true;
-        if (this.infoPanel.opened()) {
+        // Single-click-to-details: skip the interim options popover and open the
+        // Note details surface (info panel or dialog) straight away.
+        if (this.app.config.display.singleClickNoteDetails) {
+          poData.show = false;
+          this.overlay.set(poData);
+          this.popoverInfo();
+        } else if (this.infoPanel.opened()) {
           this.overlay.set(poData);
           this.popoverInfo();
         }

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -250,7 +250,7 @@ export class FBMapInteractService {
   }
 
   /** Start modifying mode */
-  startModifying(overlay: IPopover) {
+  startModifying(overlay: Pick<IPopover, 'type'>) {
     this.app.debug(`startModifying()...`);
     if (this.draw.features.getLength() === 0) {
       return;

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -83,6 +83,16 @@
                       Prefer Info-Panel
                     </mat-checkbox>
                   </div>
+                  <div class="setting-card-row-item">
+                    <mat-checkbox
+                      [(ngModel)]="facade.settings.display.singleClickNoteDetails"
+                      (change)="persistModel()"
+                      label="after"
+                      matTooltip="Open Note details with a single click instead of showing the pop-up options"
+                    >
+                      Single Click for Note Details
+                    </mat-checkbox>
+                  </div>
                 </div>
               </mat-card-content>
             </mat-card>

--- a/src/app/modules/skresources/components/notes/note-dialog.html
+++ b/src/app/modules/skresources/components/notes/note-dialog.html
@@ -130,7 +130,15 @@
             >
               <mat-icon>edit</mat-icon>
             </button>
-            &nbsp;
+            &nbsp; @if(data.note.position) {
+            <button
+              mat-icon-button
+              (click)="dialogRef.close({result:true, data: 'move'})"
+              matTooltip="Move Note"
+            >
+              <mat-icon>touch_app</mat-icon>
+            </button>
+            &nbsp; }
             <button
               mat-icon-button
               (click)="dialogRef.close({result:true, data: 'delete'})"

--- a/src/app/modules/skresources/components/notes/note-panel.html
+++ b/src/app/modules/skresources/components/notes/note-panel.html
@@ -84,6 +84,16 @@
         &nbsp;
         <button
           mat-button
+          [disabled]="_note().properties?.readOnly || interacting()"
+          (click)="onMove()"
+          matTooltip="Move Note"
+        >
+          <mat-icon>touch_app</mat-icon>
+          MOVE
+        </button>
+        &nbsp;
+        <button
+          mat-button
           [disabled]="_note().properties?.readOnly  || interacting()"
           (click)="onDelete()"
           matTooltip="Delete Note"

--- a/src/app/modules/skresources/components/notes/note-panel.ts
+++ b/src/app/modules/skresources/components/notes/note-panel.ts
@@ -47,6 +47,7 @@ export class NotePanel {
   protected _note = linkedSignal(() => this.note());
 
   edit = output<string>();
+  move = output<string>();
   panTo = output<{
     center: Position;
     zoomLevel: number;
@@ -76,6 +77,10 @@ export class NotePanel {
 
   onEdit() {
     this.edit.emit(this.id());
+  }
+
+  onMove() {
+    this.move.emit(this.id());
   }
 
   onDelete() {

--- a/src/app/modules/skresources/note-move.spec.ts
+++ b/src/app/modules/skresources/note-move.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Collection, Feature } from 'ol';
+import { SKResourceService } from './resources.service';
+
+/**
+ * Regression test for #501 — the "Move" action on the Note details surfaces
+ * must start the map Modify interaction on the *actual rendered note feature*
+ * that the opening map click loaded into the draw collection. Modifying that
+ * feature (not a reconstructed copy) is what visually moves the icon and yields
+ * the coordinates the save persists. When no such feature is present (details
+ * reached without a map click), Move is a no-op.
+ *
+ * It only touches `this.mapInteract`, so exercise it on a bare prototype
+ * instance — no Angular DI (same approach as note-details-sizing.spec.ts).
+ */
+type FakeMapInteract = {
+  draw: { features: Collection<Feature> };
+  startModifying: ReturnType<typeof vi.fn>;
+};
+
+function noteFeature(id: string): Feature {
+  const f = new Feature();
+  f.setId(id);
+  return f;
+}
+
+function svc(mapInteract: FakeMapInteract) {
+  const s = Object.create(SKResourceService.prototype) as SKResourceService;
+  Object.assign(s as unknown as Record<string, unknown>, { mapInteract });
+  return s;
+}
+
+describe('startNoteModify (#501)', () => {
+  it('modifies the note feature loaded by the map click', () => {
+    const feature = noteFeature('note.note-1');
+    const mapInteract: FakeMapInteract = {
+      draw: { features: new Collection([feature]) },
+      startModifying: vi.fn()
+    };
+
+    svc(mapInteract).startNoteModify('note-1');
+
+    expect(mapInteract.startModifying).toHaveBeenCalledWith({ type: 'note' });
+    // the same rendered feature object is what gets modified
+    expect(mapInteract.draw.features.item(0)).toBe(feature);
+  });
+
+  it('restricts the interaction to the target note feature', () => {
+    const target = noteFeature('note.note-1');
+    const mapInteract: FakeMapInteract = {
+      draw: { features: new Collection([target, noteFeature('note.note-2')]) },
+      startModifying: vi.fn()
+    };
+
+    svc(mapInteract).startNoteModify('note-1');
+
+    expect(mapInteract.draw.features.getLength()).toBe(1);
+    expect(mapInteract.draw.features.item(0)).toBe(target);
+  });
+
+  it('does nothing when the target note feature is not loaded', () => {
+    const mapInteract: FakeMapInteract = {
+      draw: { features: new Collection([noteFeature('route.r-1')]) },
+      startModifying: vi.fn()
+    };
+
+    svc(mapInteract).startNoteModify('note-1');
+
+    expect(mapInteract.startModifying).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no feature is loaded (no map click)', () => {
+    const mapInteract: FakeMapInteract = {
+      draw: { features: new Collection([]) },
+      startModifying: vi.fn()
+    };
+
+    svc(mapInteract).startNoteModify('note-1');
+
+    expect(mapInteract.startModifying).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -3,10 +3,12 @@ import { moveItemInArray } from '@angular/cdk/drag-drop';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatDialog } from '@angular/material/dialog';
 import ngeohash from 'ngeohash';
+import { Collection, Feature } from 'ol';
 
 import { SignalKClient } from 'signalk-client-angular';
 import { AppFacade } from 'src/app/app.facade';
 import { GeoUtils } from 'src/app/lib/geoutils';
+import { FBMapInteractService } from '../map/fbmap-interact.service';
 
 import {
   NoteDialog,
@@ -83,6 +85,7 @@ export class SKResourceService {
   private dialog = inject(MatDialog);
   private signalk = inject(SignalKClient);
   private worker = inject(SKWorkerService);
+  private mapInteract = inject(FBMapInteractService);
 
   constructor() {
     this.worker
@@ -2115,6 +2118,28 @@ export class SKResourceService {
   }
 
   /**
+   * @description Start the map Modify interaction to reposition a Note.
+   * Operates on the actual rendered note feature loaded into the draw collection
+   * by the map click that opened the details surface — modifying that feature is
+   * what visually moves the icon and yields the coordinates the save persists.
+   * If it is absent (details reached without a map click, e.g. from a list) there
+   * is nothing to move, so this is a no-op.
+   * @param id Note identifier
+   */
+  public startNoteModify(id: string) {
+    const features = this.mapInteract.draw.features as Collection<Feature>;
+    const target = features
+      ?.getArray?.()
+      .find((f: Feature) => f.getId() === 'note.' + id);
+    if (!target) {
+      return;
+    }
+    // Restrict the interaction to the target note feature.
+    this.mapInteract.draw.features = new Collection([target]);
+    this.mapInteract.startModifying({ type: 'note' });
+  }
+
+  /**
    * @description Create note resource on the server
    * @param note SKNote object
    */
@@ -2412,6 +2437,9 @@ export class SKResourceService {
           }
           if (r.data === 'edit') {
             this.showNoteEditor({ id: id });
+          }
+          if (r.data === 'move') {
+            this.startNoteModify(id);
           }
           if (r.data === 'delete') {
             this.deleteNote(id);

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -91,6 +91,7 @@ export interface IAppConfig {
       favourites: string[];
     };
     preferInfoPanel: boolean;
+    singleClickNoteDetails: boolean;
     statusBar: {
       liveEta: boolean; // show cursor bearing/distance/ETA in the status bar (mouse only)
       referenceSpeed: number; // fallback boat speed (in display speed units) for ETA when SOG is ~0


### PR DESCRIPTION
Adds an off-by-default **"Single Click for Note Details"** display setting
(Settings → Display, beside *Prefer Info-Panel*). When enabled, clicking a note
on the chart opens its details surface directly instead of showing the interim
options popover. It honours *Prefer Info-Panel* — the info panel when that is on,
otherwise the details dialog. Default off, so existing behaviour is unchanged
unless the user opts in.

To keep the details surface as capable as the popover it replaces, a **Move**
action is added to both the note details dialog and the info-panel note view (for
editable, positioned notes; Delete/Edit were already present). Move drives the
map's existing Modify interaction on the note feature that the opening click
loaded, so dragging repositions the actual icon and the new coordinates persist —
the same flow as the popover's Move.

Regression test added (`note-move.spec.ts`).

Closes #501


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for moving note markers directly from the note panel or details dialog.
  * Added a “Single Click for Note Details” display setting.
  * Note details can now open immediately when enabled.

* **Bug Fixes**
  * Improved note movement behavior by ensuring only the selected note is modified.
  * Added safeguards when the selected note is unavailable on the map.

* **Tests**
  * Added regression coverage for note movement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->