### PR TITLE
fix(settings): exclude plotterExtensions and symbols from custom-resource list

### DIFF
--- a/src/app/app.facade.spec.ts
+++ b/src/app/app.facade.spec.ts
@@ -15,6 +15,23 @@ describe('AppFacade app version (#458)', () => {
   });
 });
 
+describe('AppFacade.IGNORE_RESOURCES (#514)', () => {
+  let app: AppFacade;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    app = TestBed.inject(AppFacade);
+  });
+
+  // plotterExtensions and symbols are consumed by dedicated subsystems, not
+  // rendered as user-selectable layers — they must be filtered out of the
+  // Settings › Resources › Custom Resources selection list.
+  it('excludes plotterExtensions and symbols from the custom-resource list', () => {
+    expect(app.IGNORE_RESOURCES).toContain('plotterExtensions');
+    expect(app.IGNORE_RESOURCES).toContain('symbols');
+  });
+});
+
 describe('AppFacade.formatValueForDisplay', () => {
   let app: AppFacade;
 

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -50,6 +50,8 @@ import {
 
 import { WELCOME_MESSAGES } from './app.messages';
 import { getSvgList } from './modules/icons';
+import { PLOTTER_EXTENSIONS_RESOURCE } from './modules/plotterext/types';
+import { SYMBOL_RESOURCE_TYPE } from './types/symbols';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Extent } from 'ol/extent';
 import { GeoUtils } from './lib/geoutils';
@@ -130,7 +132,7 @@ export class AppFacade extends InfoService {
   public get IGNORE_RESOURCES() {
     return this.STANDARD_RESOURCES.concat(
       this.CUSTOM_RESOURCES.map((i) => i.name),
-      ['buddies']
+      ['buddies', PLOTTER_EXTENSIONS_RESOURCE, SYMBOL_RESOURCE_TYPE]
     );
   }
 


### PR DESCRIPTION
`plotterExtensions` and `symbols` are consumed by dedicated FSK subsystems — the
Plotter Extensions host and the symbols service — not rendered as user-selectable
map layers. Exposing them as checkboxes in **Settings › Resources › Custom
Resources** does nothing when toggled and confuses users.

This filters them out of the selection list by adding them to `IGNORE_RESOURCES`
(via the existing exported constants `PLOTTER_EXTENSIONS_RESOURCE` and
`SYMBOL_RESOURCE_TYPE`), so they behave like the other internally-handled
collections (`tracks`, `infolayers`, `groups`, `buddies`).

Regression test added on the `IGNORE_RESOURCES` getter (fails before, passes after).

Closes #514


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Custom Resources selection list to exclude plotter extensions and symbols, along with other non-selectable resource types.
  * Added coverage to verify these resource types remain filtered out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->