### PR TITLE
fix(map): render MOB alarm icon above AIS vessel layers

### DIFF
--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -731,11 +731,12 @@
     <fb-cpa-alarms [cpaLines]="dfeat.closest" [zIndex]="350"> </fb-cpa-alarms>
   }
 
-  <!-- MOB alarms -->
+  <!-- MOB alarms: above the AIS vessel/target layers (900-985) so a survival-craft
+       beacon's own AIS icon can't bury the distress marker; below self vessel (999) -->
   <fb-alarms
     [alarms]="notiMgr.mobAlerts()"
     [alarmStyles]="featureStyles.alarm"
-    [zIndex]="310"
+    [zIndex]="995"
   >
   </fb-alarms>
 


### PR DESCRIPTION
The MOB/SART distress marker layer (`fb-alarms`) was declared with `zIndex`
310 — below the AIS vessel (980), flag (985) and SAR (920) layers. When a
survival-craft beacon (MOB/SART/EPIRB) transmits a position, its own generic
AIS icon renders at the same coordinate and buries the distress marker,
leaving what looks like an ordinary AIS contact exactly when it matters most.

Raise `fb-alarms` to `zIndex` 995 — above all AIS layers, below the self
vessel (999) so own-ship stays visible during a recovery.

Render ordering is OpenLayers runtime layer order with no unit-test seam, so
there's no accompanying spec; verified against the reporter's synthetic-SART
reproduction.

Closes #515

@coderabbitai ignore
