### PR TITLE
fix(map): render CPA alarm lines above AIS vessel layers

### DIFF
--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -728,7 +728,9 @@
     </fb-anchor-alarm>
   }
   @if (dfeat.closest.length !== 0) {
-    <fb-cpa-alarms [cpaLines]="dfeat.closest" [zIndex]="350"> </fb-cpa-alarms>
+    <!-- CPA lines above the AIS vessel/target layers (900-985) so the collision cue
+         isn't obscured by the AIS icon it refers to; below MOB alarm (995) -->
+    <fb-cpa-alarms [cpaLines]="dfeat.closest" [zIndex]="994"> </fb-cpa-alarms>
   }
 
   <!-- MOB alarms: above the AIS vessel/target layers (900-985) so a survival-craft


### PR DESCRIPTION
Follow-up to #517. The CPA alarm layer (`fb-cpa-alarms`) was declared with
`zIndex` 350 — below the AIS vessel (980), flag (985) and SAR (920) layers — so
a CPA collision cue could be obscured by the very AIS icon it refers to.

Raise `fb-cpa-alarms` to `zIndex` 994 — above all AIS layers, below the MOB
alarm (995) and the self vessel (999).

Render ordering is OpenLayers runtime layer order with no unit-test seam, so
there's no accompanying spec.

Closes #518

@coderabbitai ignore
