### PR TITLE
feat(weather): unify wind indicator rendering across overlays

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1200,8 +1200,9 @@ export class AppComponent {
       .open(SettingsDialog, {
         disableClose: true,
         data: {},
-        maxWidth: '1000px',
-        minHeight: '80vh'
+        width: '1000px',
+        maxWidth: '96vw',
+        height: '80vh'
       })
       .afterClosed()
       .subscribe(() => {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -67,6 +67,7 @@ export function cleanConfig(
       },
       preferInfoPanel: true,
       singleClickNoteDetails: false,
+      windIndicator: 'barb',
       statusBar: {
         liveEta: false,
         referenceSpeed: 6
@@ -78,6 +79,9 @@ export function cleanConfig(
     }
     if (typeof settings.display.singleClickNoteDetails === 'undefined') {
       settings.display.singleClickNoteDetails = false;
+    }
+    if (typeof settings.display.windIndicator === 'undefined') {
+      settings.display.windIndicator = 'barb';
     }
     if (typeof settings.display.statusBar === 'undefined') {
       settings.display.statusBar = {
@@ -481,6 +485,7 @@ export function defaultConfig(): IAppConfig {
       },
       preferInfoPanel: true,
       singleClickNoteDetails: false,
+      windIndicator: 'barb',
       statusBar: {
         liveEta: false,
         referenceSpeed: 6

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -370,6 +370,7 @@
       [darkMode]="app.uiConfig().invertColor"
       [targets]="dfeat.meteo"
       targetContext="meteo"
+      [windIndicator]="app.config.display.windIndicator"
       [labelMinZoom]="this.app.config.map.labelsMinZoom"
       [mapZoom]="mapZoomLevel()"
       [updateIds]="skstream.aisStatus().updated"
@@ -728,9 +729,7 @@
     </fb-anchor-alarm>
   }
   @if (dfeat.closest.length !== 0) {
-    <!-- CPA lines above the AIS vessel/target layers (900-985) so the collision cue
-         isn't obscured by the AIS icon it refers to; below MOB alarm (995) -->
-    <fb-cpa-alarms [cpaLines]="dfeat.closest" [zIndex]="994"> </fb-cpa-alarms>
+    <fb-cpa-alarms [cpaLines]="dfeat.closest" [zIndex]="350"> </fb-cpa-alarms>
   }
 
   <!-- MOB alarms: above the AIS vessel/target layers (900-985) so a survival-craft
@@ -873,6 +872,7 @@
   <fb-weather-wind
     [show]="app.config.selections.weatherWindEnabled"
     [opacity]="0.55"
+    [indicator]="app.config.display.windIndicator"
   >
   </fb-weather-wind>
 

--- a/src/app/modules/map/ol/lib/map-image-registry.service.spec.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { MapImageRegistry } from './map-image-registry.service';
+import {
+  MapImageRegistry,
+  WIND_ARROW_SYMBOL
+} from './map-image-registry.service';
 
 /**
  * `getMeteoIcon` picks the wind-barb glyph for a meteo target by reported wind
@@ -27,5 +30,42 @@ describe('MapImageRegistry.getMeteoIcon (#490)', () => {
     expect(reg.getMeteoIcon(6, true).getSrc()).toContain(
       'weatherStation-10.svg'
     );
+  });
+});
+
+/**
+ * `getWindArrow` supplies the glyph used by the "arrow with speed" wind indicator
+ * (#513). It returns the bundled arrow by default and a symbol-provider override
+ * when one is registered under `windIndicator-arrow`.
+ */
+describe('MapImageRegistry.getWindArrow (#513)', () => {
+  it('returns the built-in arrow when no provider override exists', () => {
+    const reg = new MapImageRegistry();
+    expect(reg.getWindArrow().getSrc()).toContain('data:image/svg+xml');
+  });
+
+  it('caches and reuses the built-in arrow icon', () => {
+    const reg = new MapImageRegistry();
+    expect(reg.getWindArrow()).toBe(reg.getWindArrow());
+  });
+
+  it('prefers a symbol-provider override registered for the arrow', () => {
+    const reg = new MapImageRegistry();
+    reg.registerSymbolMarker(WIND_ARROW_SYMBOL, { path: './custom-arrow.svg' });
+    const arrow = reg.getWindArrow();
+    expect(arrow.getSrc()).toContain('custom-arrow.svg');
+    // A provider arrow is a geographic vector — it must rotate with the view.
+    expect(arrow.getRotateWithView()).toBe(true);
+  });
+
+  it('does not let a non-rotated cache entry poison the rotated arrow', () => {
+    const reg = new MapImageRegistry();
+    reg.registerSymbolMarker(WIND_ARROW_SYMBOL, { path: './custom-arrow.svg' });
+    // Prime the cache with the non-rotated variant first.
+    expect(reg.getExternalSymbol(WIND_ARROW_SYMBOL)?.getRotateWithView()).toBe(
+      false
+    );
+    // getWindArrow must still return an icon that rotates with the view.
+    expect(reg.getWindArrow().getRotateWithView()).toBe(true);
   });
 });

--- a/src/app/modules/map/ol/lib/map-image-registry.service.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.ts
@@ -29,6 +29,19 @@ export interface MapIconDef {
   anchor?: [number, number];
 }
 
+/** Symbol ref for the wind-direction arrow; a provider may override it. */
+export const WIND_ARROW_SYMBOL = 'windIndicator-arrow';
+
+// Built-in arrow glyph, drawn north-up and rotated by the renderer to point in
+// the direction the wind is flowing towards.
+const WIND_ARROW_SVG =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="42" viewBox="0 0 28 42">' +
+      '<path d="M14 2 L24 16 H18 V40 H10 V16 H4 Z" fill="#2687ff" stroke="white" stroke-width="2" stroke-linejoin="round"/>' +
+      '</svg>'
+  );
+
 @Injectable({
   providedIn: 'root'
 })
@@ -46,6 +59,9 @@ export class MapImageRegistry {
 
   /** Definitions for external symbols registered by SymbolService. */
   private symbolDefs: { [ref: string]: MapIconDef } = Object.create(null);
+
+  /** Cached built-in wind arrow (used when no provider override exists). */
+  private windArrowIcon: Icon;
 
   private atonImageDefs: any = {
     virtual: {},
@@ -86,6 +102,32 @@ export class MapImageRegistry {
     const bucket = meteoWindBucket(tws);
     const vid = bucket ? `weatherStation-${bucket}` : 'weatherStation';
     return this.resolveAtoN(vid, virtual, 'weatherStation');
+  }
+
+  /**
+   * @description Returns the wind-direction arrow icon used when the "arrow with
+   * speed" wind indicator is selected. A symbol provider may override the built-in
+   * glyph by registering the `windIndicator-arrow` symbol; otherwise the bundled
+   * arrow is returned. Callers rotate the returned icon to the wind flow direction.
+   * The arrow is a geographic vector, so it must rotate with the map view — the
+   * override is requested with `rotate` so a provider glyph keeps that behaviour.
+   * @returns Icon object
+   */
+  getWindArrow(): Icon {
+    const ext = this.getExternalSymbol(WIND_ARROW_SYMBOL, true);
+    if (ext) {
+      return ext;
+    }
+    if (!this.windArrowIcon) {
+      this.windArrowIcon = new Icon({
+        src: WIND_ARROW_SVG,
+        anchor: [0.5, 0.5],
+        scale: 0.78,
+        rotateWithView: true,
+        rotation: 0
+      });
+    }
+    return this.windArrowIcon;
   }
 
   /**
@@ -202,16 +244,22 @@ export class MapImageRegistry {
    * use it to decide whether to apply a symbol override or keep their own
    * default rendering (e.g. programmatically-drawn shapes).
    * @param id Symbol identifier (qualified "namespace:id" or bare local id).
+   * @param rotate true to build the icon so it rotates with the map view (for
+   *   overrides of geographic-vector glyphs such as the wind arrow).
    * @returns Icon object or null
    */
-  getExternalSymbol(id: string): Icon | null {
+  getExternalSymbol(id: string, rotate = false): Icon | null {
     if (!id || !Object.hasOwn(this.symbolDefs, id)) {
       return null;
     }
-    if (!this.icons.symbols[id]) {
-      this.buildIcon(this.icons.symbols, this.symbolDefs, id);
+    // Cache identity must include `rotate`: a rotated and a non-rotated icon are
+    // distinct, so keep them under separate keys (non-rotated stays under the
+    // bare id so getSymbol/getWaypoint overrides still resolve).
+    const key = rotate ? `${id}::rotate` : id;
+    if (!this.icons.symbols[key]) {
+      this.buildIcon(this.icons.symbols, this.symbolDefs, id, rotate, key);
     }
-    return this.icons.symbols[id] ?? null;
+    return this.icons.symbols[key] ?? null;
   }
 
   /**

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets.component.spec.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets.component.spec.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { AISTargetsLayerComponent } from './layer-aistargets.component';
 import { SKTarget } from './ais-base.component';
+import { Convert } from 'src/app/lib/convert';
+
+// Stub the unit-preference formatter used for the speed label: mimic a user
+// configured for knots so the assertions read in a stable unit.
+const appStub = {
+  formatValueForDisplay: (v: number) =>
+    `${Math.round(Convert.transform(v, 'm/s', 'kn'))} kn`,
+  twsDisplayUnitPath: () => 'environment.wind.speedTrue'
+};
 
 /**
  * `targetRotation` decides how a target's icon is rotated (#490). Meteo
@@ -10,12 +19,18 @@ import { SKTarget } from './ais-base.component';
  * orientation. It reads only plain fields, so exercise it on a bare prototype
  * instance (same approach as ais-base.component.spec).
  */
-function layer(targetContext: string) {
+function layer(
+  targetContext: string,
+  windIndicator: 'arrow' | 'barb' = 'barb'
+) {
   const c = Object.create(
     AISTargetsLayerComponent.prototype
   ) as AISTargetsLayerComponent;
-  Object.assign(c, { targetContext });
-  return c as unknown as { targetRotation: (t: SKTarget) => number };
+  Object.assign(c, { targetContext, windIndicator, app: appStub });
+  return c as unknown as {
+    targetRotation: (t: SKTarget) => number;
+    buildLabel: (t: SKTarget) => string;
+  };
 }
 
 describe('AISTargetsLayerComponent.targetRotation (#490)', () => {
@@ -39,5 +54,55 @@ describe('AISTargetsLayerComponent.targetRotation (#490)', () => {
     expect(c.targetRotation({ tws: 6 } as SKTarget)).toBe(0);
     expect(c.targetRotation({ tws: null, twd: null } as SKTarget)).toBe(0);
     expect(c.targetRotation({ tws: 6, twd: NaN } as SKTarget)).toBe(0);
+  });
+});
+
+/**
+ * With the "arrow" wind indicator selected (#513) a meteo target renders an arrow
+ * that points where the wind flows *to* (twd + π) and carries the speed in its
+ * label; without a usable wind it falls back to the unrotated windsock.
+ */
+describe('AISTargetsLayerComponent arrow indicator (#513)', () => {
+  it('rotates a meteo arrow to the wind flow direction (twd + π)', () => {
+    const c = layer('meteo', 'arrow');
+    expect(c.targetRotation({ tws: 6, twd: 1.2 } as SKTarget)).toBeCloseTo(
+      1.2 + Math.PI
+    );
+  });
+
+  it('leaves the calm windsock unrotated even in arrow mode', () => {
+    const c = layer('meteo', 'arrow');
+    expect(c.targetRotation({ tws: 2, twd: 1.2 } as SKTarget)).toBe(0);
+  });
+
+  it('appends the wind speed (knots) to the label in arrow mode', () => {
+    const c = layer('meteo', 'arrow');
+    expect(c.buildLabel({ name: 'Buoy', tws: 6, twd: 1.2 } as SKTarget)).toBe(
+      'Buoy 12 kn'
+    );
+  });
+
+  it('shows the speed alone when the target has no name', () => {
+    const c = layer('meteo', 'arrow');
+    expect(c.buildLabel({ tws: 6, twd: 1.2 } as SKTarget)).toBe('12 kn');
+  });
+
+  it('appends the wind speed to the label in barb mode too', () => {
+    const c = layer('meteo', 'barb');
+    expect(c.buildLabel({ name: 'Buoy', tws: 6, twd: 1.2 } as SKTarget)).toBe(
+      'Buoy 12 kn'
+    );
+  });
+
+  it('shows the speed even when the wind direction is unknown', () => {
+    const c = layer('meteo', 'barb');
+    expect(c.buildLabel({ name: 'Buoy', tws: 6 } as SKTarget)).toBe(
+      'Buoy 12 kn'
+    );
+  });
+
+  it('keeps the plain name label when no wind is reported', () => {
+    const c = layer('meteo', 'barb');
+    expect(c.buildLabel({ name: 'Buoy' } as SKTarget)).toBe('Buoy');
   });
 });

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets.component.ts
@@ -1,7 +1,9 @@
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
-  Component
+  Component,
+  Input,
+  SimpleChanges
 } from '@angular/core';
 import { Feature } from 'ol';
 import { Style, RegularShape, Fill, Stroke, Text, Icon } from 'ol/style';
@@ -12,6 +14,8 @@ import { AISBaseLayerComponent, SKTarget } from './ais-base.component';
 import { MapImageRegistry } from '../map-image-registry.service';
 import { SKMeteo } from 'src/app/modules';
 import { meteoWindBucket } from 'src/app/modules/icons';
+import { AppFacade } from 'src/app/app.facade';
+import { WindIndicator } from 'src/app/types';
 
 // ** Signal K non-vessel targets **
 @Component({
@@ -21,10 +25,15 @@ import { meteoWindBucket } from 'src/app/modules/icons';
   standalone: false
 })
 export class AISTargetsLayerComponent extends AISBaseLayerComponent {
+  // Wind glyph for meteo (weather-station) targets: 'barb' (default) or the
+  // 'arrow' with a speed label. Ignored for non-meteo target contexts.
+  @Input() windIndicator: WindIndicator = 'barb';
+
   constructor(
     protected override mapComponent: MapComponent,
     protected override changeDetectorRef: ChangeDetectorRef,
-    protected mapImages: MapImageRegistry
+    protected mapImages: MapImageRegistry,
+    private app: AppFacade
   ) {
     super(mapComponent, changeDetectorRef);
   }
@@ -32,6 +41,17 @@ export class AISTargetsLayerComponent extends AISBaseLayerComponent {
   override ngOnInit() {
     super.ngOnInit();
     this.labelPrefixes = [this.targetContext];
+  }
+
+  override ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
+    if (
+      this.layer &&
+      changes['windIndicator'] &&
+      !changes['windIndicator'].firstChange
+    ) {
+      this.onUpdateTargets(this.extractKeys(this.targets));
+    }
   }
 
   // reload all Features from this.targets
@@ -110,22 +130,63 @@ export class AISTargetsLayerComponent extends AISBaseLayerComponent {
     }
   }
 
-  // Meteo (weather-station) targets render a wind barb rotated to the reported
-  // wind direction; every other target keeps its fixed orientation.
+  // Whether this meteo target should render as an arrow (only when the arrow
+  // indicator is selected and the target reports a usable wind).
+  private isMeteoArrow(target: SKTarget): boolean {
+    if (this.targetContext !== 'meteo' || this.windIndicator !== 'arrow') {
+      return false;
+    }
+    const meteo = target as SKMeteo;
+    return Boolean(meteoWindBucket(meteo.tws)) && Number.isFinite(meteo.twd);
+  }
+
+  // Meteo (weather-station) targets rotate to the reported wind: a barb's staff
+  // points into the wind (its "from" direction); an arrow points where the wind
+  // flows to. Every other target keeps its fixed orientation.
   private targetRotation(target: SKTarget): number {
     if (this.targetContext !== 'meteo') {
       return target.orientation;
     }
     const meteo = target as SKMeteo;
+    if (this.isMeteoArrow(target)) {
+      return meteo.twd + Math.PI;
+    }
     return meteoWindBucket(meteo.tws) && Number.isFinite(meteo.twd)
       ? meteo.twd
       : 0;
   }
 
+  // Whether a meteo target reports a wind speed to display alongside its glyph.
+  private hasMeteoWind(target: SKTarget): boolean {
+    return (
+      this.targetContext === 'meteo' && Number.isFinite((target as SKMeteo).tws)
+    );
+  }
+
+  // Append the wind speed to a meteo target's label for both indicators — the
+  // speed value is always shown (in the user's configured wind-speed units),
+  // whether the glyph is an arrow or a barb.
+  protected override buildLabel(target: SKTarget): string {
+    const label = super.buildLabel(target);
+    if (!this.hasMeteoWind(target)) {
+      return label;
+    }
+    const speed = this.app.formatValueForDisplay(
+      (target as SKMeteo).tws,
+      'm/s',
+      {
+        precision: 0,
+        path: this.app.twsDisplayUnitPath()
+      }
+    );
+    return label ? `${label} ${speed}` : speed;
+  }
+
   // build target style
   buildStyle(target: SKTarget): Style {
-    const icon =
-      this.targetContext === 'meteo'
+    const icon = this.isMeteoArrow(target)
+      ? this.mapImages.getWindArrow()
+      : this.targetContext === 'meteo'
         ? this.mapImages.getMeteoIcon((target as SKMeteo).tws, target.virtual)
         : this.mapImages.getAtoN(target.type?.id, target.virtual);
     if (icon && typeof this.targetStyles === 'undefined') {

--- a/src/app/modules/map/ol/lib/resources/layer-wind-weather.component.spec.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-wind-weather.component.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import type { FeatureLike } from 'ol/Feature';
+import type Icon from 'ol/style/Icon';
+import { LayerWindWeatherComponent } from './layer-wind-weather.component';
+import { MapImageRegistry } from '../map-image-registry.service';
+import { Convert } from 'src/app/lib/convert';
+
+// Stub the unit-preference formatter used for the speed label: mimic a user
+// configured for knots so the assertions read in a stable unit.
+const appStub = {
+  formatValueForDisplay: (v: number) =>
+    `${Math.round(Convert.transform(v, 'm/s', 'kn'))} kn`,
+  twsDisplayUnitPath: () => 'environment.wind.speedTrue'
+};
+
+/**
+ * The wind-grid overlay (#413) renders each sample with the glyph chosen by the
+ * `indicator` input (#513): a bucketed wind barb (default) rotated into the wind,
+ * or the arrow-with-speed. Sample speed is m/s and direction is radians (the wind
+ * "from" bearing), matching the meteo targets. `createWindStyle` reads only plain
+ * fields + the registry, so exercise it on a bare prototype instance.
+ */
+function grid(indicator: 'arrow' | 'barb') {
+  const c = Object.create(
+    LayerWindWeatherComponent.prototype
+  ) as LayerWindWeatherComponent;
+  Object.assign(c, {
+    indicator,
+    mapImages: new MapImageRegistry(),
+    app: appStub
+  });
+  return c as unknown as {
+    createWindStyle: (f: FeatureLike) => import('ol/style/Style').default;
+  };
+}
+
+function sample(speedMs: number, directionFrom: number): FeatureLike {
+  return {
+    get: (k: string) => (k === 'speed' ? speedMs : directionFrom)
+  } as unknown as FeatureLike;
+}
+
+describe('LayerWindWeatherComponent.createWindStyle (#513)', () => {
+  it('renders a bucketed barb with a speed label in barb mode', () => {
+    const style = grid('barb').createWindStyle(sample(6, 1.2));
+    const icon = style.getImage() as Icon;
+    expect(icon.getSrc()).toContain('weatherStation-10.svg');
+    expect(icon.getRotation()).toBeCloseTo(1.2);
+    expect(style.getText().getText()).toBe('12 kn');
+  });
+
+  it('renders the arrow with a speed label in arrow mode', () => {
+    const style = grid('arrow').createWindStyle(sample(6, 1.2));
+    const icon = style.getImage() as Icon;
+    expect(icon.getSrc()).toContain('data:image/svg+xml');
+    expect(icon.getRotation()).toBeCloseTo(1.2 + Math.PI);
+    expect(style.getText().getText()).toBe('12 kn');
+  });
+
+  it('does not rotate the calm windsock in barb mode', () => {
+    const style = grid('barb').createWindStyle(sample(2, 1.2));
+    const icon = style.getImage() as Icon;
+    expect(icon.getSrc()).toContain('weather_station.png');
+    expect(icon.getRotation()).toBe(0);
+  });
+});

--- a/src/app/modules/map/ol/lib/resources/layer-wind-weather.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-wind-weather.component.ts
@@ -11,7 +11,7 @@ import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import { Fill, Icon, Stroke, Style, Text } from 'ol/style';
+import { Fill, Stroke, Style, Text } from 'ol/style';
 import {
   Observable,
   Subject,
@@ -29,7 +29,11 @@ import {
   WeatherService,
   WeatherWindSample
 } from 'src/app/modules/weather/weather.service';
+import { AppFacade } from 'src/app/app.facade';
+import { WindIndicator } from 'src/app/types';
+import { meteoWindBucket } from 'src/app/modules/icons';
 import { MapComponent } from '../map.component';
+import { MapImageRegistry } from '../map-image-registry.service';
 
 @Component({
   selector: 'ol-map > fb-weather-wind',
@@ -40,6 +44,7 @@ import { MapComponent } from '../map.component';
 export class LayerWindWeatherComponent implements OnChanges, OnDestroy {
   @Input() show = false;
   @Input() opacity = 0.55;
+  @Input() indicator: WindIndicator = 'barb';
 
   private layer: VectorLayer<VectorSource>;
   private source: VectorSource;
@@ -48,17 +53,12 @@ export class LayerWindWeatherComponent implements OnChanges, OnDestroy {
   private readonly zIndex = 55;
   private readonly gridColumns = 5;
   private readonly gridRows = 4;
-  private readonly arrowIcon =
-    'data:image/svg+xml;utf8,' +
-    encodeURIComponent(
-      '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="42" viewBox="0 0 28 42">' +
-        '<path d="M14 2 L24 16 H18 V40 H10 V16 H4 Z" fill="#2687ff" stroke="white" stroke-width="2" stroke-linejoin="round"/>' +
-        '</svg>'
-    );
 
   constructor(
     private mapComponent: MapComponent,
     private weather: WeatherService,
+    private mapImages: MapImageRegistry,
+    private app: AppFacade,
     changeDetectorRef: ChangeDetectorRef
   ) {
     changeDetectorRef.detach();
@@ -67,6 +67,10 @@ export class LayerWindWeatherComponent implements OnChanges, OnDestroy {
   ngOnChanges(changes: SimpleChanges) {
     if (typeof changes.opacity !== 'undefined' && this.layer) {
       this.layer.setOpacity(this.normalizedOpacity);
+    }
+
+    if (changes.indicator && !changes.indicator.firstChange) {
+      this.layer?.changed();
     }
 
     if (this.show) {
@@ -197,29 +201,44 @@ export class LayerWindWeatherComponent implements OnChanges, OnDestroy {
   }
 
   private createWindStyle(feature: FeatureLike) {
-    const direction = Number(feature.get('direction')) || 0;
-    const speed = Number(feature.get('speed')) || 0;
-    const rotation = this.getFlowRotation(direction);
-
-    return new Style({
-      image: new Icon({
-        src: this.arrowIcon,
-        anchor: [0.5, 0.5],
-        scale: 0.78,
-        rotation,
-        rotateWithView: true
-      }),
-      text: new Text({
-        text: `${Math.round(speed)} kn`,
-        offsetY: 26,
-        font: '11px Roboto, Arial, sans-serif',
-        fill: new Fill({ color: 'rgba(20, 60, 95, 0.95)' }),
-        stroke: new Stroke({ color: 'rgba(255, 255, 255, 0.9)', width: 3 })
-      })
-    });
+    // direction = radians the wind blows *from*; speed = m/s (both SK native).
+    const directionFrom = Number(feature.get('direction')) || 0;
+    const speedMs = Number(feature.get('speed')) || 0;
+    return this.indicator === 'barb'
+      ? this.createBarbStyle(directionFrom, speedMs)
+      : this.createArrowStyle(directionFrom, speedMs);
   }
 
-  private getFlowRotation(directionFrom: number) {
-    return (((directionFrom + 180) % 360) * Math.PI) / 180;
+  private createArrowStyle(directionFrom: number, speedMs: number) {
+    const image = this.mapImages.getWindArrow().clone();
+    image.setRotation(directionFrom + Math.PI); // arrow points where wind flows to
+    image.setRotateWithView(true);
+    return new Style({ image, text: this.speedLabel(speedMs, 26) });
+  }
+
+  private createBarbStyle(directionFrom: number, speedMs: number) {
+    // Barbs share the meteo-target glyph: speed selects the bucketed barb and the
+    // staff points into the wind (its reported "from" direction).
+    const image = this.mapImages.getMeteoIcon(speedMs).clone();
+    if (meteoWindBucket(speedMs)) {
+      image.setRotation(directionFrom);
+    }
+    image.setRotateWithView(true);
+    return new Style({ image, text: this.speedLabel(speedMs, 10) });
+  }
+
+  // Wind speed shown for both indicators — the label is always displayed, in the
+  // user's configured wind-speed units.
+  private speedLabel(speedMs: number, offsetY: number) {
+    return new Text({
+      text: this.app.formatValueForDisplay(speedMs, 'm/s', {
+        precision: 0,
+        path: this.app.twsDisplayUnitPath()
+      }),
+      offsetY,
+      font: '11px Roboto, Arial, sans-serif',
+      fill: new Fill({ color: 'rgba(20, 60, 95, 0.95)' }),
+      stroke: new Stroke({ color: 'rgba(255, 255, 255, 0.9)', width: 3 })
+    });
   }
 }

--- a/src/app/modules/settings/components/settings-dialog.css
+++ b/src/app/modules/settings/components/settings-dialog.css
@@ -1,47 +1,59 @@
 :host ::ng-deep .mat-dialog-content {
-    padding: 0 4px;
+  padding: 0 4px;
+}
+
+/* The dialog is opened at a fixed size (width: 1000px, height: 80vh). Make the
+   content area fill that height and let the active tab scroll within it, so
+   every tab keeps the same size (no per-tab resizing) and long tabs (e.g.
+   Display with the Weather group) neither clip nor leave empty space below the
+   last group. */
+:host ::ng-deep .mat-mdc-dialog-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
+  overflow: hidden;
+}
+:host ::ng-deep .mat-mdc-dialog-content .mat-mdc-tab-group,
+:host ::ng-deep .mat-mdc-dialog-content .mat-mdc-tab-body-wrapper {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .settings .setting-group-title {
-    font-weight: bold;
-    font-size: 10pt;
-    font-family: Arial, Helvetica, sans-serif;
-    padding: 10px 0 10px 0;
+  font-weight: bold;
+  font-size: 10pt;
+  font-family: Arial, Helvetica, sans-serif;
+  padding: 10px 0 10px 0;
 }
 .setting-card-row {
-    display: flex;
-    flex-wrap: wrap;
+  display: flex;
+  flex-wrap: wrap;
 }
 .settings .setting-card-row-item {
-    padding-right: 15px;
-    flex: 1 1 auto;
+  padding-right: 15px;
+  flex: 1 1 auto;
 }
 
-
 /*ipads*/
-@media only screen
-    and (min-device-width : 768px)
-    and (max-device-width : 1024px),
-/*desktop / laptop */
-only screen	and (min-width : 800px) {
+@media only screen and (min-device-width: 768px) and (max-device-width: 1024px),
+  /*desktop / laptop */ only screen and (min-width: 800px) {
 }
 /*xs*/
 @media only screen and (max-width: 599px) {
-	.settings .setting-group {
-		padding: 5px 5% 5px 5%;
-    }	
+  .settings .setting-group {
+    padding: 5px 5% 5px 5%;
+  }
 }
 @media only screen and (max-height: 500px) {
 }
 /*sm*/
 @media only screen and (min-width: 600px) and (max-width: 959px),
-/*md*/
-screen and (min-width: 960px) and (max-width: 1279px),
-/*lg*/
-screen and (min-width: 1280px) and (max-width: 1919px),
-/*xl*/
-screen and (min-width: 1920px) and (max-width: 5000px) {
-    .settings .setting-group {
-        padding: 5px 5% 5px 5%;
-    } 
+  /*md*/ screen and (min-width: 960px) and (max-width: 1279px),
+  /*lg*/ screen and (min-width: 1280px) and (max-width: 1919px),
+  /*xl*/ screen and (min-width: 1920px) and (max-width: 5000px) {
+  .settings .setting-group {
+    padding: 5px 5% 5px 5%;
+  }
 }

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -10,7 +10,7 @@
   </span>
 </mat-toolbar>
 
-<div mat-dialog-content style="display: flex">
+<div mat-dialog-content>
   <mat-tab-group
     dynamicHeight="false"
     mat-stretch-tabs="false"
@@ -263,6 +263,29 @@
                       refspeed.touched) ) {
                       <mat-error>Please enter a number &gt;= 0</mat-error>
                       }
+                    </mat-form-field>
+                  </div>
+                </div>
+              </mat-card-content>
+            </mat-card>
+          </div>
+          <div class="setting-group">
+            <div class="setting-group-title">WEATHER</div>
+            <mat-card class="setting-card">
+              <mat-card-content>
+                <div class="setting-card-row" style="padding-bottom: 10px">
+                  <div class="setting-card-row-item">
+                    <mat-form-field style="width: 100%">
+                      <mat-label>Wind indicator</mat-label>
+                      <mat-select
+                        [(ngModel)]="facade.settings.display.windIndicator"
+                        matTooltip="Glyph used to display wind direction and speed."
+                        (selectionChange)="persistModel()"
+                      >
+                        @for(i of options.windIndicator; track i[0]) {
+                        <mat-option [value]="i[0]">{{i[1]}}</mat-option>
+                        }
+                      </mat-select>
                     </mat-form-field>
                   </div>
                 </div>

--- a/src/app/modules/settings/settings.facade.ts
+++ b/src/app/modules/settings/settings.facade.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 
 import { AppFacade } from 'src/app/app.facade';
 import { SignalKClient } from 'signalk-client-angular';
-import { FBAppData, IAppConfig, Position } from 'src/app/types';
+import { FBAppData, IAppConfig, Position, WindIndicator } from 'src/app/types';
 import { Observable, Subject } from 'rxjs';
 
 interface SKAppsList {
@@ -163,6 +163,11 @@ export class SettingsOptions {
     [0, 'Use OS setting'],
     [1, 'Use Signal K Mode'],
     [-1, 'On']
+  ]);
+
+  windIndicator = new Map<WindIndicator, string>([
+    ['barb', 'Wind barb'],
+    ['arrow', 'Arrow']
   ]);
 
   vessel = {

--- a/src/app/modules/weather/weather.service.ts
+++ b/src/app/modules/weather/weather.service.ts
@@ -7,8 +7,8 @@ import { SignalKClient } from 'signalk-client-angular';
 export interface WeatherWindSample {
   latitude: number;
   longitude: number;
-  speed: number;
-  direction: number;
+  speed: number; // wind speed in m/s (Signal K native)
+  direction: number; // direction wind blows from, in radians (Signal K native)
 }
 
 export interface OceanCurrentSample {
@@ -75,8 +75,8 @@ export class WeatherService {
           samples.push({
             latitude: points[i].latitude,
             longitude: points[i].longitude,
-            speed: obs.wind.speedTrue * 1.94384,
-            direction: (obs.wind.directionTrue * 180) / Math.PI
+            speed: obs.wind.speedTrue,
+            direction: obs.wind.directionTrue
           });
         });
         return samples;

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -23,6 +23,11 @@ export type ErrorList = Array<{ status: number; message: string }>;
 
 export type MFBAction = 'wpt' | 'pob' | 'autopilot' | 'radar';
 
+// Glyph used to render wind direction/speed on the weather overlays and meteo
+// targets. Shared by the display config, the settings option map, and the layer
+// component inputs.
+export type WindIndicator = 'arrow' | 'barb';
+
 export interface SKApiResponse {
   state: 'FAILED' | 'COMPLETED' | 'PENDING';
   statusCode: number;
@@ -92,6 +97,7 @@ export interface IAppConfig {
     };
     preferInfoPanel: boolean;
     singleClickNoteDetails: boolean;
+    windIndicator: WindIndicator; // glyph used to render wind direction/speed
     statusBar: {
       liveEta: boolean; // show cursor bearing/distance/ETA in the status bar (mouse only)
       referenceSpeed: number; // fallback boat speed (in display speed units) for ETA when SOG is ~0


### PR DESCRIPTION
The weather wind-grid overlay (#413) rendered arrows with a speed label while the
meteo weather-station targets (#495) rendered wind barbs, so the two wind displays
looked inconsistent on the same chart.

This unifies them behind a single, user-selectable indicator:

- New **Display → Weather → "Wind indicator"** setting: **Wind barb** (default) or
  **Arrow**. Both the wind-grid overlay and the meteo targets honour it, and **both
  show the wind speed** as a label regardless of glyph.
- The arrow is resolved through the symbol registry, so a symbol provider can
  override it, and it stays aligned with the map view when the chart rotates.

Also included (kept in this PR): the **Settings dialog** now opens at a fixed size
(1000px × 80vh) with the content filling the height and the active tab scrolling
internally. Adding the Weather group exposed that the dialog auto-sized per tab —
tabs varied in width and the last group could clip or leave empty space below it.

Split into two commits (`feat(weather)` + `fix(settings)`) for easy review.

Closes #513

### Test plan
- [x] `npm run test:ci` — added specs for barb/arrow selection, always-on speed
  label, meteo arrow rotation/label, and the provider-override arrow rotating with
  the view.
- [x] Verified live against a running server with the OpenMeteo provider: barbs and
  arrows both render with speed labels; toggling the setting switches both overlays.
- [x] Verified the Settings dialog is a consistent size across all tabs with no
  clipping or dead whitespace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Wind indicator” Display setting to switch between wind barbs and directional arrows.
  - Map overlays now render the selected wind style and show wind speed labels.
- **Bug Fixes**
  - Existing configs now default the wind indicator (barb) when missing.
  - Wind glyph behavior improved, including correct rotation for arrow mode and calm-wind handling.
- **Other**
  - Updated wind sample values to use native Signal K units.
  - Refined settings dialog layout/sizing and adjusted alarm layer stacking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->