### PR TITLE
feat(weather): make current-overlay arrows customizable symbols

### DIFF
--- a/docs/freeboard/freeboard-symbol-support.md
+++ b/docs/freeboard/freeboard-symbol-support.md
@@ -132,9 +132,26 @@ real-aton   / virtual-aton          (generic / fallback AtoN)
 **Route markers:** `route-start`, `route-waypoint` (cloned per segment, rotated
 to bearing), `route-end`.
 
-The route, own-vessel, AIS, and AtoN markers are chosen automatically by
-Freeboard rather than picked per feature, so they override **globally**: create a
-symbol with the matching id and every marker of that kind uses it.
+**Weather indicators** — flow arrows drawn programmatically and rotated to the
+reported direction:
+
+- `windIndicator-arrow` — wind-direction arrow (the "Arrow" wind indicator).
+- `oceanCurrentIndicator-arrow` — ocean-current flow arrow.
+- `tidalCurrentIndicator-arrow` — tidal-current flow arrow.
+
+> **Current arrows are tinted by speed — draw the override with a white fill.**
+> The ocean and tidal overlays recolour the arrow to encode current speed (ocean:
+> a blue→red velocity gradient; tidal: green/yellow/red severity) by applying the
+> icon's `color`, which *multiplies* the glyph's pixels. So a provider override
+> should use a **white/neutral fill** to come out the intended colour (a black
+> outline is preserved; a pre-coloured glyph is multiplied by the speed colour and
+> will look muddy or wrong). The wind arrow is **not** tinted, so its override
+> renders in its own colours.
+
+The route, own-vessel, AIS, AtoN, and weather-indicator markers are chosen
+automatically by Freeboard rather than picked per feature, so they override
+**globally**: create a symbol with the matching id and every marker of that kind
+uses it.
 
 ## What is NOT overridable (and why)
 

--- a/src/app/modules/map/ol/lib/map-image-registry.service.spec.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   MapImageRegistry,
-  WIND_ARROW_SYMBOL
+  WIND_ARROW_SYMBOL,
+  OCEAN_CURRENT_ARROW_SYMBOL,
+  TIDAL_CURRENT_ARROW_SYMBOL
 } from './map-image-registry.service';
 
 /**
@@ -67,5 +69,47 @@ describe('MapImageRegistry.getWindArrow (#513)', () => {
     );
     // getWindArrow must still return an icon that rotates with the view.
     expect(reg.getWindArrow().getRotateWithView()).toBe(true);
+  });
+});
+
+/**
+ * The current-overlay flow arrows are provider-overridable symbols (#521): the
+ * ocean and tidal overlays each resolve a separate ref so they can be customised
+ * independently, falling back to the bundled glyph and rotating with the view.
+ */
+describe('MapImageRegistry current arrows (#521)', () => {
+  it('returns the bundled ocean/tidal arrows that rotate with the view', () => {
+    const reg = new MapImageRegistry();
+    const ocean = reg.getOceanCurrentArrow();
+    const tidal = reg.getTidalCurrentArrow();
+    expect(ocean.getSrc()).toContain('data:image/svg+xml');
+    expect(tidal.getSrc()).toContain('data:image/svg+xml');
+    expect(ocean.getRotateWithView()).toBe(true);
+    expect(tidal.getRotateWithView()).toBe(true);
+    // Distinct glyphs so the two overlays stay distinguishable.
+    expect(ocean.getSrc()).not.toBe(tidal.getSrc());
+  });
+
+  it('caches and reuses each bundled arrow', () => {
+    const reg = new MapImageRegistry();
+    expect(reg.getOceanCurrentArrow()).toBe(reg.getOceanCurrentArrow());
+    expect(reg.getTidalCurrentArrow()).toBe(reg.getTidalCurrentArrow());
+  });
+
+  it('prefers independent provider overrides for each arrow', () => {
+    const reg = new MapImageRegistry();
+    reg.registerSymbolMarker(OCEAN_CURRENT_ARROW_SYMBOL, {
+      path: './custom-ocean.svg'
+    });
+    reg.registerSymbolMarker(TIDAL_CURRENT_ARROW_SYMBOL, {
+      path: './custom-tidal.svg'
+    });
+    const ocean = reg.getOceanCurrentArrow();
+    const tidal = reg.getTidalCurrentArrow();
+    expect(ocean.getSrc()).toContain('custom-ocean.svg');
+    expect(tidal.getSrc()).toContain('custom-tidal.svg');
+    // Overrides are geographic vectors too — they must rotate with the view.
+    expect(ocean.getRotateWithView()).toBe(true);
+    expect(tidal.getRotateWithView()).toBe(true);
   });
 });

--- a/src/app/modules/map/ol/lib/map-image-registry.service.ts
+++ b/src/app/modules/map/ol/lib/map-image-registry.service.ts
@@ -32,13 +32,38 @@ export interface MapIconDef {
 /** Symbol ref for the wind-direction arrow; a provider may override it. */
 export const WIND_ARROW_SYMBOL = 'windIndicator-arrow';
 
-// Built-in arrow glyph, drawn north-up and rotated by the renderer to point in
-// the direction the wind is flowing towards.
+// Symbol refs for the provider-overridable current-flow arrows (issue #521).
+// Kept separate so the ocean-current and tidal-current overlays can be
+// customised independently and stay distinguishable when shown together.
+export const OCEAN_CURRENT_ARROW_SYMBOL = 'oceanCurrentIndicator-arrow';
+export const TIDAL_CURRENT_ARROW_SYMBOL = 'tidalCurrentIndicator-arrow';
+
+// Built-in wind arrow glyph, drawn north-up and rotated by the renderer to
+// point in the direction the wind is flowing towards.
 const WIND_ARROW_SVG =
   'data:image/svg+xml;utf8,' +
   encodeURIComponent(
     '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="42" viewBox="0 0 28 42">' +
       '<path d="M14 2 L24 16 H18 V40 H10 V16 H4 Z" fill="#2687ff" stroke="white" stroke-width="2" stroke-linejoin="round"/>' +
+      '</svg>'
+  );
+
+// Bundled default current arrows. Each overlay clones the returned icon and
+// applies its own per-feature rotation, scale and colour; the neutral white
+// fill lets the overlay tint it to its speed colour while the black outline is
+// preserved.
+const OCEAN_CURRENT_ARROW_SVG =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="34" viewBox="0 0 24 34">' +
+      '<path d="M12 2 L22 14 H15 V32 H9 V14 H2 Z" fill="#ffffff" stroke="#000000" stroke-width="1.5" stroke-linejoin="round"/>' +
+      '</svg>'
+  );
+const TIDAL_CURRENT_ARROW_SVG =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">' +
+      '<path d="M12 2L19 10H14V22H10V10H5L12 2Z" fill="#ffffff" stroke="#000000" stroke-width="1"/>' +
       '</svg>'
   );
 
@@ -56,6 +81,9 @@ export class MapImageRegistry {
     waypoints: Object.create(null),
     symbols: Object.create(null)
   };
+
+  private oceanCurrentArrowIcon: Icon;
+  private tidalCurrentArrowIcon: Icon;
 
   /** Definitions for external symbols registered by SymbolService. */
   private symbolDefs: { [ref: string]: MapIconDef } = Object.create(null);
@@ -260,6 +288,51 @@ export class MapImageRegistry {
       this.buildIcon(this.icons.symbols, this.symbolDefs, id, rotate, key);
     }
     return this.icons.symbols[key] ?? null;
+  }
+
+  /**
+   * @description Returns the flow arrow for the ocean-current overlay, resolving
+   * a `oceanCurrentIndicator-arrow` symbol-provider override before the bundled
+   * glyph. The current arrow is a geographic vector, so callers clone the icon
+   * and apply per-feature rotation/scale/colour and `rotateWithView`.
+   * @returns Icon object
+   */
+  getOceanCurrentArrow(): Icon {
+    const ext = this.getExternalSymbol(OCEAN_CURRENT_ARROW_SYMBOL, true);
+    if (ext) {
+      return ext;
+    }
+    if (!this.oceanCurrentArrowIcon) {
+      this.oceanCurrentArrowIcon = new Icon({
+        src: OCEAN_CURRENT_ARROW_SVG,
+        anchor: [0.5, 0.55],
+        rotateWithView: true
+      });
+    }
+    return this.oceanCurrentArrowIcon;
+  }
+
+  /**
+   * @description Returns the flow arrow for the tidal-current overlay, resolving
+   * a `tidalCurrentIndicator-arrow` symbol-provider override before the bundled
+   * glyph. The bundled arrow is drawn with a neutral fill so the overlay can
+   * tint it to the reported drift's speed bucket. Callers clone the icon and
+   * apply per-feature rotation/scale/colour and `rotateWithView`.
+   * @returns Icon object
+   */
+  getTidalCurrentArrow(): Icon {
+    const ext = this.getExternalSymbol(TIDAL_CURRENT_ARROW_SYMBOL, true);
+    if (ext) {
+      return ext;
+    }
+    if (!this.tidalCurrentArrowIcon) {
+      this.tidalCurrentArrowIcon = new Icon({
+        src: TIDAL_CURRENT_ARROW_SVG,
+        anchor: [0.5, 0.5],
+        rotateWithView: true
+      });
+    }
+    return this.tidalCurrentArrowIcon;
   }
 
   /**

--- a/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
@@ -11,7 +11,7 @@ import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import { Fill, Icon, Stroke, Style, Text } from 'ol/style';
+import { Fill, Stroke, Style, Text } from 'ol/style';
 import {
   Observable,
   Subject,
@@ -30,6 +30,7 @@ import {
   OceanCurrentSample
 } from 'src/app/modules/weather/weather.service';
 import { MapComponent } from '../map.component';
+import { MapImageRegistry } from '../map-image-registry.service';
 
 @Component({
   selector: 'ol-map > fb-weather-currents',
@@ -49,11 +50,10 @@ export class LayerCurrentsWeatherComponent implements OnChanges, OnDestroy {
   private readonly gridColumns = 10;
   private readonly gridRows = 8;
 
-  private readonly arrowIcon = this.buildArrowSvg();
-
   constructor(
     private mapComponent: MapComponent,
     private weather: WeatherService,
+    private mapImages: MapImageRegistry,
     changeDetectorRef: ChangeDetectorRef
   ) {
     changeDetectorRef.detach();
@@ -199,15 +199,14 @@ export class LayerCurrentsWeatherComponent implements OnChanges, OnDestroy {
     const b = Math.round(245 - t * 200);
     const color = `rgb(${r}, ${g}, ${b})`;
 
+    const image = this.mapImages.getOceanCurrentArrow().clone();
+    image.setRotation(rotation);
+    image.setScale(0.65 + Math.min(0.5, velocity / 8));
+    image.setColor(color);
+    image.setRotateWithView(true);
+
     return new Style({
-      image: new Icon({
-        src: this.arrowIcon,
-        anchor: [0.5, 0.55],
-        scale: 0.65 + Math.min(0.5, velocity / 8),
-        rotation,
-        rotateWithView: false,
-        color
-      }),
+      image,
       text: new Text({
         text: `${(velocity / 1.852).toFixed(1)} kn`,
         offsetY: 28,
@@ -220,16 +219,5 @@ export class LayerCurrentsWeatherComponent implements OnChanges, OnDestroy {
 
   private getFlowRotation(directionTo: number) {
     return (directionTo * Math.PI) / 180;
-  }
-
-  private buildArrowSvg() {
-    return (
-      'data:image/svg+xml;utf8,' +
-      encodeURIComponent(
-        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="34" viewBox="0 0 24 34">' +
-          '<path d="M12 2 L22 14 H15 V32 H9 V14 H2 Z" fill="#2687ff" stroke="white" stroke-width="1.5" stroke-linejoin="round"/>' +
-          '</svg>'
-      )
-    );
   }
 }

--- a/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
+++ b/src/app/modules/map/ol/lib/resources/tidal-currents-layer.component.ts
@@ -15,7 +15,7 @@ import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import { Fill, Icon, Stroke, Style, Text } from 'ol/style';
+import { Fill, Stroke, Style, Text } from 'ol/style';
 import {
   Subject,
   Subscription,
@@ -33,6 +33,7 @@ import {
   TidalCurrentGridResponse
 } from '../tidal-currents.service';
 import { MapComponent } from '../map.component';
+import { MapImageRegistry } from '../map-image-registry.service';
 import { AppFacade } from 'src/app/app.facade';
 
 @Component({
@@ -56,6 +57,7 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
     private mapComponent: MapComponent,
     private currents: TidalCurrentsService,
     private app: AppFacade,
+    private mapImages: MapImageRegistry,
     changeDetectorRef: ChangeDetectorRef
   ) {
     changeDetectorRef.detach();
@@ -210,6 +212,8 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
     const setDeg = Number(feature.get('setDeg')) || 0;
     const setRad = (setDeg * Math.PI) / 180;
 
+    // Traffic-light severity by drift; applied as an icon tint so a provider
+    // override is coloured the same way (the bundled arrow has a neutral fill).
     let color = '#28a745';
     if (driftKts >= 2.0) {
       color = '#dc3545';
@@ -217,26 +221,17 @@ export class TidalCurrentsLayerComponent implements OnChanges, OnDestroy {
       color = '#ffc107';
     }
 
-    const svg = `
-      <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path d="M12 2L19 10H14V22H10V10H5L12 2Z" fill="${color}" stroke="#000" stroke-width="1"/>
-      </svg>`;
-
-    const src = `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
     const pixelSize = Math.max(16, Math.min(40, 12 + driftKts * 9));
-    const scale = pixelSize / 24;
-
     const speedLabel = this.currents.formatSpeed(driftKts);
 
+    const image = this.mapImages.getTidalCurrentArrow().clone();
+    image.setRotation(setRad);
+    image.setScale(pixelSize / 24);
+    image.setColor(color);
+    image.setRotateWithView(true);
+
     return new Style({
-      image: new Icon({
-        src: src,
-        rotation: setRad,
-        scale: scale,
-        anchor: [0.5, 0.5],
-        anchorXUnits: 'fraction',
-        anchorYUnits: 'fraction'
-      }),
+      image,
       text: new Text({
         text: speedLabel,
         offsetY: 14,


### PR DESCRIPTION
The ocean-current (#413) and tidal-current (#491) overlays drew their flow arrow
as a hard-coded inline SVG, so — unlike vessels, AtoNs, and meteo wind barbs — it
couldn't be replaced by a symbol provider.

This routes each through the symbol registry under a **separate** ref so they can
be customised independently and stay distinguishable when both overlays are on:

- `oceanCurrentIndicator-arrow` — ocean-current flow arrow
- `tidalCurrentIndicator-arrow` — tidal-current flow arrow

Each falls back to a bundled default when no provider override is registered,
following the `windIndicator-arrow` pattern.

**Also:** both current arrows now **rotate with the map view** (they're geographic
vectors — previously they didn't, which was wrong in heading-up mode). The tidal
glyph is bundled with a neutral fill and tinted to its speed-severity bucket via
the icon, matching its previous colouring.

### Note for symbol providers

The current overlays encode **speed as colour** (ocean: blue→red velocity
gradient; tidal: green/yellow/red severity) by tinting the icon, which *multiplies*
the glyph's pixels. So a custom current symbol should use a **white/neutral fill**
to come out the intended colour (black outlines are preserved; a pre-coloured glyph
goes muddy). This is documented in `docs/freeboard/freeboard-symbol-support.md`. The
wind arrow is not tinted, so its override renders as-is.

Closes #521

### Test plan
- [x] `npm run test:ci` — added registry specs (bundled arrows rotate with view;
  each caches; independent provider overrides resolve).
- [x] Verified live against a running server with current data: ocean and tidal
  arrows render and colour by speed; a white provider override is tinted correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added distinct ocean-current and tidal-current arrow indicators on the map.
  - Current arrows rotate with the map view and use speed-based color tinting for clearer flow visualization.
  - Map providers can override the default weather indicator symbols while preserving rotation and color behavior.

- **Documentation**
  - Expanded symbol customization guidance to include wind, ocean-current, and tidal-current indicators.
  - Added recommendations for configuring current-arrow colors correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->