### PR TITLE
feat(release): generate release notes from the feature ledger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,24 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history + tags for the changelog range
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Generate release notes from the feature ledger
+        env:
+          TAG: ${{ github.ref_name }} # via env — never interpolated into the shell
+        run: node dev-tools/changelog/index.mjs render "$TAG" --out RELEASE_NOTES.md
 
       - uses: softprops/action-gh-release@v3
         with:
-          generate_release_notes: true
+          # Notes are generated from features/changelog.json (see
+          # dev-tools/changelog). generate_release_notes stays OFF so features
+          # aren't listed twice (once rich, once in the auto PR list).
+          body_path: RELEASE_NOTES.md
           prerelease: ${{ contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +38,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # Required for OIDC publish (no NPM_TOKEN needed)
+      id-token: write # Required for OIDC publish (no NPM_TOKEN needed)
       contents: read
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,34 @@
+name: Dev Tools
+
+# The dev-tools/ Node utilities aren't part of the Angular app, so the shared
+# plugin-ci workflow (build:all + test:ci) doesn't cover them. This runs their
+# unit tests when they change.
+
+on:
+  pull_request:
+    paths:
+      - 'dev-tools/**'
+      - '.github/workflows/tools.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  push:
+    branches: [master]
+    paths:
+      - 'dev-tools/**'
+      - '.github/workflows/tools.yml'
+      - 'package.json'
+      - 'package-lock.json'
+
+jobs:
+  test-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false # don't expose the token to PR-controlled npm scripts
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test:tools

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,3 +212,6 @@ it*:
 - [`fsk-mcp.md`](docs/dev-tools/fsk-mcp.md) — one-time setup for the `dev-tools/fsk-mcp`
   MCP bridge that lets an agent drive a running Freeboard-SK (map view, routes,
   filters, live data) during debugging. Read once when wiring it up.
+- [`release-notes.md`](docs/dev-tools/release-notes.md) — the `dev-tools/changelog`
+  generator: `stamp` (fill/graduate `since`) + `render` (grouped Release body) from
+  the feature ledger; wired into `release.yml`.

--- a/dev-tools/changelog/index.mjs
+++ b/dev-tools/changelog/index.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+//
+// Release-notes generator CLI. Two commands:
+//
+//   stamp [version]     Fill blank `since` in features/changelog.json (and, for a
+//                       stable version, graduate its pre-release rows to it).
+//                       Version defaults to the package.json version — the intended
+//                       use is a `version` npm lifecycle hook, which re-stages the
+//                       stamped ledger into the version-bump commit.
+//
+//   render <tag>        Print the GitHub Release body for <tag> to stdout (or to
+//     [--out <file>]    --out <file>). Pure text — never touches GitHub — so
+//                       `render <tag> > preview.md` is a safe dry run.
+//
+// All interpretation lives in lib.mjs (unit-tested); this file is only I/O.
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, basename } from 'node:path';
+import { createRequire } from 'node:module';
+import {
+  stampLedger,
+  serializeLedger,
+  renderNotes,
+  parseCommitSubject,
+  docSummary,
+  previousBoundary
+} from './lib.mjs';
+
+const ROOT = process.cwd();
+const LEDGER = join(ROOT, 'features', 'changelog.json');
+const FEATURES = join(ROOT, 'features');
+
+const readLedger = () =>
+  existsSync(LEDGER) ? JSON.parse(readFileSync(LEDGER, 'utf8')) : [];
+
+// Let git failures surface — a broken `git log` must fail the release, not
+// silently produce empty notes. (A legitimate empty result — no tags, no
+// commits in range — exits 0 and returns '' without throwing.)
+const git = (args) =>
+  execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+
+/** Read each feature doc → { title, summary } for the release-notes headings. */
+function readFeatures() {
+  const map = {};
+  if (!existsSync(FEATURES)) return map;
+  for (const f of readdirSync(FEATURES).filter((n) => n.endsWith('.md'))) {
+    const raw = readFileSync(join(FEATURES, f), 'utf8');
+    const m = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(raw);
+    const fm = {};
+    if (m) {
+      for (const line of m[1].split(/\r?\n/)) {
+        const i = line.indexOf(':');
+        if (i > 0)
+          fm[line.slice(0, i).trim()] = line
+            .slice(i + 1)
+            .trim()
+            .replace(/^["']|["']$/g, '');
+      }
+    }
+    const id = basename(f, '.md');
+    map[id] = { title: fm.title || id, summary: docSummary(m ? m[2] : raw) };
+  }
+  return map;
+}
+
+function stampCmd(version) {
+  const rows = readLedger();
+  const stamped = stampLedger(rows, version);
+  writeFileSync(LEDGER, serializeLedger(stamped));
+  const changed = stamped.filter(
+    (r, i) => (r.since ?? null) !== (rows[i]?.since ?? null)
+  ).length;
+  process.stderr.write(`[changelog] stamped ${changed} row(s) → ${version}\n`);
+}
+
+function renderCmd(tag, outFile) {
+  const ledger = readLedger();
+  const features = readFeatures();
+  const tags = git(['tag', '-l', 'v*'])
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const prev = previousBoundary(tags, tag);
+  const upper = tags.includes(tag) ? tag : 'HEAD';
+  const range = prev ? `${prev}..${upper}` : upper;
+  const commits = git(['log', range, '--no-merges', '--format=%s'])
+    .split('\n')
+    .filter(Boolean)
+    .map(parseCommitSubject)
+    .filter(Boolean);
+  const body = renderNotes({ ledger, features, commits, tag });
+  if (outFile) {
+    writeFileSync(outFile, body);
+    process.stderr.write(`[changelog] wrote release notes → ${outFile}\n`);
+  } else {
+    process.stdout.write(body);
+  }
+}
+
+const withV = (v) => (v.startsWith('v') ? v : `v${v}`);
+// Only the prerelease forms release.yml recognizes (-beta.N / -rc.N).
+const VERSION_RE = /^v\d+\.\d+\.\d+(?:-(?:beta|rc)\.\d+)?$/;
+const requireVersion = (v) => {
+  if (!VERSION_RE.test(v)) {
+    console.error(
+      `[changelog] invalid version "${v}" (expected vX.Y.Z, vX.Y.Z-beta.N or vX.Y.Z-rc.N)`
+    );
+    process.exit(1);
+  }
+  return v;
+};
+
+const [cmd, arg, ...rest] = process.argv.slice(2);
+
+if (cmd === 'stamp') {
+  const require = createRequire(import.meta.url);
+  const version = withV(arg || require(join(ROOT, 'package.json')).version);
+  stampCmd(requireVersion(version));
+} else if (cmd === 'render') {
+  if (!arg) {
+    console.error('usage: changelog render <tag> [--out <file>]');
+    process.exit(1);
+  }
+  const outIdx = rest.indexOf('--out');
+  if (outIdx >= 0 && !rest[outIdx + 1]) {
+    console.error('usage: changelog render <tag> [--out <file>]');
+    process.exit(1);
+  }
+  renderCmd(requireVersion(withV(arg)), outIdx >= 0 ? rest[outIdx + 1] : null);
+} else {
+  console.error(
+    'usage: changelog <stamp [version] | render <tag> [--out <file>]>'
+  );
+  process.exit(1);
+}

--- a/dev-tools/changelog/lib.mjs
+++ b/dev-tools/changelog/lib.mjs
@@ -1,0 +1,206 @@
+// Release-notes generator — pure, deterministic core.
+//
+// No I/O here: every function takes plain data and returns plain data/strings,
+// so it is fully unit-testable. The CLI (index.mjs) does the file/git reads and
+// hands the results to these functions. See docs/freeboard/release-notes.md.
+
+/** A version string carries a pre-release tag when it contains a hyphen. */
+export function isPrerelease(version) {
+  return typeof version === 'string' && version.includes('-');
+}
+
+/** Compare `vX.Y.Z[-pre]` strings; a release outranks its pre-releases. */
+export function compareVersions(a, b) {
+  if (a === b) return 0;
+  const parse = (v) =>
+    String(v)
+      .replace(/^v/i, '')
+      .split(/[.-]/)
+      .map((p) => (/^\d+$/.test(p) ? Number(p) : p));
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i];
+    const y = pb[i];
+    if (x === undefined) return typeof y === 'string' ? 1 : -1;
+    if (y === undefined) return typeof x === 'string' ? -1 : 1;
+    if (x === y) continue;
+    if (typeof x === 'number' && typeof y === 'number') return x < y ? -1 : 1;
+    return String(x) < String(y) ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * The tag that bounds the lower end of a release's range: for a STABLE tag the
+ * previous *stable* tag (so the range spans all its pre-releases); for a
+ * pre-release the previous tag of any kind. Null if there's no earlier tag.
+ */
+export function previousBoundary(tags, tag) {
+  const stableTarget = !isPrerelease(tag);
+  const candidates = tags
+    .filter((t) => t !== tag && compareVersions(t, tag) < 0)
+    .filter((t) => (stableTarget ? !isPrerelease(t) : true))
+    .sort(compareVersions);
+  return candidates.length ? candidates[candidates.length - 1] : null;
+}
+
+/**
+ * Stamp the ledger for a release:
+ *  - fill blank `since` rows with `version`;
+ *  - for a STABLE release, graduate every pre-release of that version
+ *    (`v3.0.0-beta.*` / `-rc.*`) to the stable `version`, so the stable notes
+ *    (and the Feature Browser's "Since") absorb everything from its betas.
+ * `skip` rows are untouched. Returns a new array; unchanged rows are reused.
+ */
+export function stampLedger(rows, version) {
+  const stable = !isPrerelease(version);
+  const preOfThis = `${version}-`; // e.g. "v3.0.0-" → matches v3.0.0-beta.1
+  return rows.map((r) => {
+    if (r.kind === 'skip') return r;
+    const current = r.since ?? null;
+    let next = current;
+    if (!current) next = version;
+    else if (stable && current.startsWith(preOfThis)) next = version;
+    return next === current ? r : { ...r, since: next };
+  });
+}
+
+const FIELD_ORDER = [
+  'feature',
+  'pr',
+  'kind',
+  'since',
+  'date',
+  'title',
+  'reason',
+  'note'
+];
+
+/** Serialize the ledger back to the canonical one-row-per-line JSON format,
+ *  so `stamp` produces a minimal, hand-authored-looking diff. Fields outside
+ *  the canonical order are preserved (appended), never dropped. */
+export function serializeLedger(rows) {
+  const lines = rows.map((r) => {
+    const keys = [
+      ...FIELD_ORDER.filter((k) => k in r),
+      ...Object.keys(r).filter((k) => !FIELD_ORDER.includes(k))
+    ];
+    const parts = keys.map(
+      (k) => `${JSON.stringify(k)}: ${JSON.stringify(r[k])}`
+    );
+    return `  { ${parts.join(', ')} }`;
+  });
+  return `[\n${lines.join(',\n')}\n]\n`;
+}
+
+const TYPE_PREFIX_RE =
+  /^(feat|fix|perf|refactor|docs|test|chore|ci|build|style|revert)(\([^)]*\))?!?:\s*/i;
+
+/** Strip a conventional-commit `type(scope):` prefix from a title. */
+export function stripTypePrefix(title) {
+  return String(title || '')
+    .replace(TYPE_PREFIX_RE, '')
+    .trim();
+}
+
+const SUBJECT_RE = /^([a-z]+)(?:\([^)]*\))?!?:\s*(.*?)(?:\s*\(#(\d+)\))?$/i;
+
+/** Parse a squash-merge commit subject: "feat(map): title (#123)". */
+export function parseCommitSubject(subject) {
+  const m = SUBJECT_RE.exec(String(subject || '').trim());
+  if (!m) return null;
+  return {
+    type: m[1].toLowerCase(),
+    title: m[2].trim(),
+    pr: m[3] ? Number(m[3]) : null
+  };
+}
+
+/** One-line summary of a feature doc body: first sentence, images/markup stripped. */
+export function docSummary(body) {
+  const firstPara =
+    String(body || '')
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // drop images
+      .split(/\n\s*\n/)
+      .map((p) => p.trim())
+      .filter(Boolean)[0] || '';
+  const oneLine = firstPara.replace(/\s+/g, ' ');
+  const sentence = oneLine.match(/^(.+?[.!?])(\s|$)/);
+  return (sentence ? sentence[1] : oneLine).replace(/[*_`]/g, '').trim();
+}
+
+const TYPE_HEADINGS = { fix: '🐛 Bug Fixes' };
+
+/**
+ * Render the full GitHub Release body for `tag` from the (already-stamped)
+ * ledger, the feature docs, and the merged-PR commits in the tag range.
+ *
+ * - New Features: features with a `new` row in this release (doc title + summary).
+ * - Improvements: features enhanced (only) in this release (per enhancement).
+ * - Bug Fixes / Other Changes: merged PRs in range NOT present in the ledger,
+ *   grouped by conventional-commit type.
+ */
+export function renderNotes({ ledger, features, commits, tag }) {
+  const rows = ledger.filter(
+    (r) => r.kind !== 'skip' && r.feature && r.since === tag
+  );
+
+  const byFeature = new Map();
+  for (const r of rows) {
+    const list = byFeature.get(r.feature);
+    if (list) list.push(r);
+    else byFeature.set(r.feature, [r]);
+  }
+
+  const newFeatures = [];
+  const improvements = [];
+  for (const [id, frows] of byFeature) {
+    const doc = features[id] || { title: id, summary: '' };
+    if (frows.some((r) => r.kind === 'new')) {
+      newFeatures.push({ title: doc.title, desc: doc.summary });
+    } else {
+      for (const r of frows) {
+        improvements.push({ title: doc.title, desc: stripTypePrefix(r.title) });
+      }
+    }
+  }
+
+  const ledgerPRs = new Set(ledger.map((r) => r.pr));
+  const byType = new Map();
+  for (const c of commits) {
+    if (c.pr == null || ledgerPRs.has(c.pr)) continue;
+    const key = c.type === 'fix' ? 'fix' : 'other';
+    const bucket = byType.get(key);
+    if (bucket) bucket.push(c);
+    else byType.set(key, [c]);
+  }
+
+  const sections = [];
+  if (newFeatures.length) {
+    sections.push(
+      '## 🚀 New Features\n\n' +
+        newFeatures
+          .map((n) => `- **${n.title}**${n.desc ? ` — ${n.desc}` : ''}`)
+          .join('\n')
+    );
+  }
+  if (improvements.length) {
+    sections.push(
+      '## ✨ Improvements\n\n' +
+        improvements.map((i) => `- **${i.title}** — ${i.desc}`).join('\n')
+    );
+  }
+  const fixList = (key, heading) => {
+    const items = byType.get(key);
+    if (!items || !items.length) return;
+    sections.push(
+      `## ${heading}\n\n` +
+        items.map((c) => `- ${c.title} (#${c.pr})`).join('\n')
+    );
+  };
+  fixList('fix', TYPE_HEADINGS.fix);
+  fixList('other', '🔧 Other Changes');
+
+  return sections.length ? `${sections.join('\n\n')}\n` : '';
+}

--- a/dev-tools/changelog/lib.spec.mjs
+++ b/dev-tools/changelog/lib.spec.mjs
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPrerelease,
+  compareVersions,
+  previousBoundary,
+  stampLedger,
+  serializeLedger,
+  stripTypePrefix,
+  parseCommitSubject,
+  docSummary,
+  renderNotes
+} from './lib.mjs';
+
+describe('isPrerelease', () => {
+  it('detects a pre-release tag', () => {
+    expect(isPrerelease('v3.0.0-beta.1')).toBe(true);
+    expect(isPrerelease('v3.0.0')).toBe(false);
+  });
+});
+
+describe('compareVersions', () => {
+  it('ranks a release above its pre-releases and orders numerically', () => {
+    expect(compareVersions('v3.0.0', 'v3.0.0-beta.1')).toBe(1);
+    expect(compareVersions('v3.0.0-beta.2', 'v3.0.0-beta.10')).toBe(-1);
+    expect(compareVersions('v2.9.0', 'v3.0.0')).toBe(-1);
+  });
+});
+
+describe('previousBoundary', () => {
+  const tags = ['v2.9.0', 'v3.0.0-beta.0', 'v3.0.0-beta.1', 'v3.0.0'];
+  it('uses the previous STABLE tag for a stable release', () => {
+    expect(previousBoundary(tags, 'v3.0.0')).toBe('v2.9.0');
+  });
+  it('uses the previous tag of any kind for a pre-release', () => {
+    expect(previousBoundary(tags, 'v3.0.0-beta.1')).toBe('v3.0.0-beta.0');
+  });
+  it('returns null when there is no earlier stable', () => {
+    expect(previousBoundary(['v3.0.0-beta.0'], 'v3.0.0')).toBeNull();
+  });
+});
+
+describe('stampLedger', () => {
+  const rows = [
+    { feature: 'a', pr: 1, kind: 'new', since: 'v3.0.0-beta.1', title: 'x' },
+    { feature: 'b', pr: 2, kind: 'enhanced', title: 'y' }, // blank since
+    { feature: null, pr: 3, kind: 'skip', reason: 'r' }
+  ];
+
+  it('a pre-release only fills blanks (no graduation)', () => {
+    const out = stampLedger(rows, 'v3.0.0-beta.5');
+    expect(out[0].since).toBe('v3.0.0-beta.1');
+    expect(out[1].since).toBe('v3.0.0-beta.5');
+    expect(out[2]).toEqual(rows[2]); // skip untouched
+  });
+
+  it('a stable release fills blanks AND graduates its pre-releases', () => {
+    const out = stampLedger(rows, 'v3.0.0');
+    expect(out[0].since).toBe('v3.0.0'); // beta.1 graduated
+    expect(out[1].since).toBe('v3.0.0'); // blank filled
+    expect(out[2].kind).toBe('skip');
+  });
+
+  it("does not graduate another version's pre-releases", () => {
+    const out = stampLedger(
+      [{ feature: 'a', pr: 1, kind: 'new', since: 'v2.9.0-beta.1' }],
+      'v3.0.0'
+    );
+    expect(out[0].since).toBe('v2.9.0-beta.1');
+  });
+});
+
+describe('serializeLedger', () => {
+  it('emits one canonical-order row per line', () => {
+    const out = serializeLedger([
+      { pr: 1, feature: 'a', title: 't', kind: 'new', since: 'v1.0.0' },
+      { feature: null, pr: 2, kind: 'skip', reason: 'r' }
+    ]);
+    expect(out).toBe(
+      '[\n' +
+        '  { "feature": "a", "pr": 1, "kind": "new", "since": "v1.0.0", "title": "t" },\n' +
+        '  { "feature": null, "pr": 2, "kind": "skip", "reason": "r" }\n' +
+        ']\n'
+    );
+  });
+
+  it('preserves unrecognized fields instead of dropping them', () => {
+    const out = serializeLedger([
+      { feature: 'a', pr: 1, kind: 'new', custom: 'keep-me' }
+    ]);
+    expect(out).toBe(
+      '[\n  { "feature": "a", "pr": 1, "kind": "new", "custom": "keep-me" }\n]\n'
+    );
+  });
+});
+
+describe('stripTypePrefix / parseCommitSubject / docSummary', () => {
+  it('strips a conventional-commit prefix', () => {
+    expect(stripTypePrefix('feat(map): Do a thing')).toBe('Do a thing');
+    expect(stripTypePrefix('Note: keep this')).toBe('Note: keep this');
+  });
+  it('parses a squash-merge subject', () => {
+    expect(parseCommitSubject('fix(map): guard canvas (#519)')).toEqual({
+      type: 'fix',
+      title: 'guard canvas',
+      pr: 519
+    });
+    expect(parseCommitSubject('not a conventional subject')).toBeNull();
+  });
+  it('summarises a doc body to one sentence, images stripped', () => {
+    expect(
+      docSummary(
+        '![Fig 1](x.jpg)\n\nShows **wind** on the chart. More text here.'
+      )
+    ).toBe('Shows wind on the chart.');
+  });
+});
+
+describe('renderNotes', () => {
+  const ledger = [
+    {
+      feature: 'weather-overlays',
+      pr: 413,
+      kind: 'new',
+      since: 'v3.0.0',
+      title: 'feat(weather): add overlays'
+    },
+    {
+      feature: 'weather-overlays',
+      pr: 520,
+      kind: 'enhanced',
+      since: 'v3.0.0',
+      title: 'feat(weather): unify wind indicator'
+    },
+    {
+      feature: 'anchor-watch',
+      pr: 300,
+      kind: 'enhanced',
+      since: 'v3.0.0',
+      title: 'feat(nav): add drag alarm'
+    },
+    {
+      feature: 'radar',
+      pr: 100,
+      kind: 'new',
+      since: 'v2.0.0',
+      title: 'feat: radar'
+    },
+    { feature: null, pr: 520, kind: 'skip', reason: 'internal' }
+  ];
+  const features = {
+    'weather-overlays': {
+      title: 'Wind and Ocean Currents',
+      summary: 'Display wind and ocean-current vectors on the chart.'
+    },
+    'anchor-watch': { title: 'Anchor Watch', summary: 'Watch the anchor.' },
+    radar: { title: 'Radar', summary: 'Radar overlay.' }
+  };
+  const commits = [
+    { type: 'fix', title: 'guard OffscreenCanvas on non-WebGL', pr: 519 },
+    { type: 'feat', title: 'add overlays', pr: 413 }, // in ledger → excluded
+    { type: 'perf', title: 'speed up tile load', pr: 512 },
+    { type: 'chore', title: 'bump deps', pr: 400 }
+  ];
+
+  it('renders grouped notes for a release', () => {
+    const body = renderNotes({ ledger, features, commits, tag: 'v3.0.0' });
+    expect(body).toBe(
+      '## 🚀 New Features\n\n' +
+        '- **Wind and Ocean Currents** — Display wind and ocean-current vectors on the chart.\n\n' +
+        '## ✨ Improvements\n\n' +
+        '- **Anchor Watch** — add drag alarm\n\n' +
+        '## 🐛 Bug Fixes\n\n' +
+        '- guard OffscreenCanvas on non-WebGL (#519)\n\n' +
+        '## 🔧 Other Changes\n\n' +
+        '- speed up tile load (#512)\n' +
+        '- bump deps (#400)\n'
+    );
+  });
+
+  it('excludes ledger PRs from fixes and skips empty sections', () => {
+    const body = renderNotes({
+      ledger: [
+        { feature: 'x', pr: 1, kind: 'new', since: 'v1.0.0', title: 'feat: x' }
+      ],
+      features: { x: { title: 'X', summary: 'The X.' } },
+      commits: [{ type: 'feat', title: 'x', pr: 1 }], // the only commit is the ledger PR
+      tag: 'v1.0.0'
+    });
+    expect(body).toBe('## 🚀 New Features\n\n- **X** — The X.\n');
+  });
+});

--- a/dev-tools/changelog/vitest.config.mjs
+++ b/dev-tools/changelog/vitest.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+// Standalone config for the dev-tools release-notes generator — plain Node,
+// no Angular setup. Run via `npm run test:tools`.
+export default defineConfig({
+  test: {
+    include: ['**/*.spec.mjs']
+  }
+});

--- a/docs/dev-tools/release-notes.md
+++ b/docs/dev-tools/release-notes.md
@@ -1,0 +1,70 @@
+# Release-notes generator (`dev-tools/changelog`)
+
+Generates a rich **GitHub Release body** from the feature ledger
+(`features/changelog.json`) that powers the [Feature Browser](../freeboard/feature-browser.md).
+The Signal K App Store's "Changelog" tab renders that Release body as Markdown, so
+this is what users read for each release. It replaces GitHub's flat auto-generated
+notes.
+
+Dev-only (in `dev-tools/`, excluded from the npm package). Plain Node — no runtime
+dependencies; it shells out to `git`.
+
+## Commands
+
+```bash
+node dev-tools/changelog/index.mjs stamp [version]      # write since values into the ledger
+node dev-tools/changelog/index.mjs render <tag> [--out <file>]   # print/write the Release body
+```
+
+### `stamp [version]`
+
+Fills the blank `since` on ledger rows with `version` (default: the `package.json`
+version). For a **stable** version it also **graduates** that version's pre-releases —
+every `v3.0.0-beta.*` / `-rc.*` row's `since` is rewritten to `v3.0.0` — so the stable
+release's notes (and the Feature Browser's "Since" column) absorb everything that
+landed across its betas. A pre-release version only fills blanks.
+
+It runs automatically from the **`version` npm lifecycle hook**, which re-stages the
+stamped `features/changelog.json` into the version-bump commit — so `npm version …`
+stamps with no manual step.
+
+### `render <tag>`
+
+Prints the Release body for `<tag>` to **stdout** (or `--out <file>`). It never
+touches GitHub, so `render <tag> > preview.md` is a safe **dry run**. Sections:
+
+- **🚀 New Features** — features with a `new` row in this release (doc title + summary).
+- **✨ Improvements** — features enhanced (only) in this release.
+- **🐛 Bug Fixes / 🔧 Other Changes** — PRs merged in the tag range that are **not** in
+  the ledger, grouped by conventional-commit type.
+
+The tag range's lower bound is the previous **stable** tag for a stable release (so it
+spans all the betas) or the previous tag of any kind for a pre-release. `render` reads
+the ledger as-is, so **stamp first** (the `version` hook does this at release; for a
+manual dry run, `stamp` then `git checkout features/changelog.json` when done).
+
+## Dry run
+
+```bash
+node dev-tools/changelog/index.mjs stamp v3.0.0     # graduates betas (mutates the ledger)
+node dev-tools/changelog/index.mjs render v3.0.0    # preview the notes
+git checkout features/changelog.json                # discard the dry-run stamp
+```
+
+> ⚠️ The final `git checkout` discards **all** uncommitted changes to
+> `features/changelog.json` — not just the dry-run stamp. Commit or stash any
+> pending ledger edits before a dry run (or run it in a throwaway worktree).
+
+## Release wiring
+
+`release.yml` (on a `v*` tag push) runs `render <tag> --out RELEASE_NOTES.md` and passes
+it to `action-gh-release` via `body_path`. `generate_release_notes` stays **off** so
+features aren't listed twice. A bad render is never stuck — the Release body is freely
+editable after publish and is independent of the (immutable) npm publish.
+
+## Tests
+
+Pure logic lives in `lib.mjs` and is unit-tested in `lib.spec.mjs`
+(`npm run test:tools`, a standalone Vitest config). The `.github/workflows/tools.yml`
+job runs it on PRs that touch `dev-tools/` (or the tooling's dependencies/workflow).
+</content>

--- a/docs/freeboard/feature-browser.md
+++ b/docs/freeboard/feature-browser.md
@@ -11,7 +11,8 @@ It is backed by a small **feature corpus** that ships with the package, designed
 serves:
 
 - the **Feature Browser** (this dialog), and
-- the **release-notes generator** (renders GitHub Release notes from the same ledger).
+- the **[release-notes generator](../dev-tools/release-notes.md)** (renders GitHub
+  Release notes from the same ledger).
 
 A future "What's New" indicator and an in-app help/search agent are further consumers of
 the same corpus. The rule of thumb: *write the feature's documentation once, in the

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "build:all": "npm run build:helper && npm run build:web",
     "build:prod": "npm run build:all",
     "prepack": "npm run build:all",
-    "test:ci": "node scripts/test-ci.mjs"
+    "test:ci": "node scripts/test-ci.mjs",
+    "test:tools": "vitest run --config dev-tools/changelog/vitest.config.mjs",
+    "version": "node dev-tools/changelog/index.mjs stamp && git add features/changelog.json"
   },
   "author": "AdrianP",
   "contributors": [


### PR DESCRIPTION
Implements #527 — generate the GitHub Release body from the feature ledger
(`features/changelog.json`) instead of GitHub's flat auto-notes, so each release
documents its new features and improvements up front (from the same corpus that
powers the Feature Browser) and lists fixes/other after.

## What

`dev-tools/changelog` — a plain-Node CLI (no runtime deps; excluded from the npm package):

- **`stamp [version]`** — fills blank `since` in the ledger; for a **stable** release
  it also **graduates** that version's pre-release rows (`v3.0.0-beta.*` → `v3.0.0`),
  so the stable notes *and* the Feature Browser's "Since" absorb everything from its
  betas. Runs from a `version` npm lifecycle hook, which re-stages the stamped ledger
  into the version-bump commit.
- **`render <tag>`** — prints the grouped Release body to stdout (or `--out <file>`):
  New Features / Improvements from the ledger; Bug Fixes / Other Changes from PRs
  merged in the tag range (read from git history) that aren't in the ledger. Pure
  text — never touches GitHub — so `render <tag> > preview.md` is a safe dry run.

The Other Changes section is intentionally exhaustive: it doubles as the maintainer's
"undocumented feature" checklist for the corpus.

## Wiring

- `release.yml` runs `render <tag>` → `body_path`, with `generate_release_notes` off
  (no double-listing).
- Pure logic lives in `lib.mjs` and is unit-tested (`npm run test:tools`); a dedicated
  `tools.yml` workflow runs those tests on PRs touching `dev-tools/` (the shared
  plugin-ci doesn't cover Node tools).

No `src/` changes. Docs: `docs/dev-tools/release-notes.md`.

Closes #527.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes are now generated automatically with grouped features, improvements, and pull request summaries.
  * Beta and release-candidate changes are carried forward and graduated into stable release notes.
  * Published packages now use the appropriate beta tag for pre-releases.

* **Documentation**
  * Added guidance for the release-notes workflow and linked it from the developer documentation.

* **Tests**
  * Added automated coverage for version handling, changelog generation, and release-note formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->