### PR TITLE
fix(weather): cache and de-duplicate ocean-current API requests

### DIFF
--- a/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
@@ -18,12 +18,14 @@ import {
   Subscription,
   catchError,
   debounceTime,
+  distinctUntilChanged,
+  map as rxMap,
   of,
   switchMap,
   tap
 } from 'rxjs';
 import { FeatureLike } from 'ol/Feature';
-import { fromLonLat, transformExtent } from 'ol/proj';
+import { fromLonLat, toLonLat } from 'ol/proj';
 
 import {
   WeatherService,
@@ -31,6 +33,58 @@ import {
 } from 'src/app/modules/weather/weather.service';
 import { MapComponent } from '../map.component';
 import { MapImageRegistry } from '../map-image-registry.service';
+
+export interface CurrentSamplePoint {
+  latitude: number;
+  longitude: number;
+}
+
+// Web Mercator is undefined beyond ~±85.06°; drop grid points past it.
+const MAX_MERCATOR_LATITUDE = 85;
+
+/**
+ * Build the sample grid for a projected (EPSG:3857) viewport extent, snapped to
+ * a stable lattice: at a given zoom the extent's span is invariant to panning,
+ * so a fixed cell size with a snapped origin means panning by less than one cell
+ * yields the *identical* point set. Snapping in projected space (not lon/lat) is
+ * deliberate — Mercator distorts the latitude span, so an equivalent lon/lat
+ * lattice would shift on every north/south pan and defeat de-duplication. Points
+ * are returned in lon/lat with wrapped longitudes normalised to [-180, 180], so
+ * repeated/small moves de-duplicate to the same request (issue #522).
+ */
+export function buildCurrentSampleGrid(
+  extent: number[],
+  columns: number,
+  rows: number,
+  project: (coordinate: number[]) => number[] = toLonLat
+): CurrentSamplePoint[] {
+  const [minX, minY, maxX, maxY] = extent;
+  const cellWidth = (maxX - minX) / columns;
+  const cellHeight = (maxY - minY) / rows;
+  if (!(cellWidth > 0) || !(cellHeight > 0)) {
+    return [];
+  }
+
+  const originX = Math.floor(minX / cellWidth) * cellWidth;
+  const originY = Math.floor(minY / cellHeight) * cellHeight;
+  const round = (n: number) => Number(n.toFixed(4));
+  const points: CurrentSamplePoint[] = [];
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < columns; col++) {
+      const [lon, lat] = project([
+        originX + (col + 0.5) * cellWidth,
+        originY + (row + 0.5) * cellHeight
+      ]);
+      if (lat < -MAX_MERCATOR_LATITUDE || lat > MAX_MERCATOR_LATITUDE) {
+        continue;
+      }
+      const longitude = ((((lon + 180) % 360) + 360) % 360) - 180;
+      points.push({ latitude: round(lat), longitude: round(longitude) });
+    }
+  }
+  return points;
+}
 
 @Component({
   selector: 'ol-map > fb-weather-currents',
@@ -96,8 +150,10 @@ export class LayerCurrentsWeatherComponent implements OnChanges, OnDestroy {
 
     this.refreshSub = this.refresh$
       .pipe(
-        debounceTime(400),
-        switchMap(() => this.fetchCurrents())
+        debounceTime(600),
+        rxMap(() => this.getSamplePoints()),
+        distinctUntilChanged((a, b) => this.pointsKey(a) === this.pointsKey(b)),
+        switchMap((points) => this.fetchCurrents(points))
       )
       .subscribe();
     this.mapComponent.getMap().on('moveend', this.onMoveEnd);
@@ -129,13 +185,8 @@ export class LayerCurrentsWeatherComponent implements OnChanges, OnDestroy {
     return Math.max(0, Math.min(1, this.opacity ?? 1));
   }
 
-  private fetchCurrents() {
-    if (!this.show || !this.source) {
-      return of<OceanCurrentSample[]>([]);
-    }
-
-    const points = this.getSamplePoints();
-    if (points.length === 0) {
+  private fetchCurrents(points: CurrentSamplePoint[]) {
+    if (!this.show || !this.source || points.length === 0) {
       return of<OceanCurrentSample[]>([]);
     }
 
@@ -145,33 +196,24 @@ export class LayerCurrentsWeatherComponent implements OnChanges, OnDestroy {
     );
   }
 
-  private getSamplePoints() {
+  private getSamplePoints(): CurrentSamplePoint[] {
     const map = this.mapComponent.getMap();
     const size = map.getSize();
     if (!size) {
       return [];
     }
 
-    const extent = transformExtent(
+    // Projected (EPSG:3857) extent — its span is pan-invariant at a given zoom,
+    // which is what makes the snapped lattice stable (see buildCurrentSampleGrid).
+    return buildCurrentSampleGrid(
       map.getView().calculateExtent(size),
-      'EPSG:3857',
-      'EPSG:4326'
+      this.gridColumns,
+      this.gridRows
     );
-    const west = Math.max(-180, extent[0]);
-    const south = Math.max(-80, extent[1]);
-    const east = Math.min(180, extent[2]);
-    const north = Math.min(80, extent[3]);
-    const points: Array<{ latitude: number; longitude: number }> = [];
+  }
 
-    for (let row = 0; row < this.gridRows; row++) {
-      const latitude = north - ((north - south) * (row + 0.5)) / this.gridRows;
-      for (let col = 0; col < this.gridColumns; col++) {
-        const longitude =
-          west + ((east - west) * (col + 0.5)) / this.gridColumns;
-        points.push({ latitude, longitude });
-      }
-    }
-    return points;
+  private pointsKey(points: CurrentSamplePoint[]) {
+    return points.map((p) => `${p.latitude},${p.longitude}`).join(';');
   }
 
   private renderCurrents(samples: OceanCurrentSample[]) {

--- a/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
@@ -186,7 +186,13 @@ export class LayerCurrentsWeatherComponent implements OnChanges, OnDestroy {
   }
 
   private fetchCurrents(points: CurrentSamplePoint[]) {
-    if (!this.show || !this.source || points.length === 0) {
+    if (!this.show || !this.source) {
+      return of<OceanCurrentSample[]>([]);
+    }
+    if (points.length === 0) {
+      // Clear stale arrows from the previous viewport (e.g. after panning
+      // beyond the supported latitude range).
+      this.source.clear();
       return of<OceanCurrentSample[]>([]);
     }
 

--- a/src/app/modules/map/ol/lib/resources/layer-currents-weather.grid.spec.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-currents-weather.grid.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildCurrentSampleGrid } from './layer-currents-weather.component';
+
+const COLUMNS = 10;
+const ROWS = 8;
+
+// A deterministic stand-in for ol's toLonLat so the grid maths can be tested
+// without a map/projection. Treats the projected coords as already lon/lat.
+const identity = (c: number[]) => c;
+
+// cellWidth = (11 - 10) / 10 = 0.1 ; cellHeight = (0.8 - 0) / 8 = 0.1
+const EXTENT = [10, 0, 11, 0.8];
+
+describe('buildCurrentSampleGrid (#522 request de-duplication)', () => {
+  it('produces a columns × rows grid', () => {
+    const points = buildCurrentSampleGrid(EXTENT, COLUMNS, ROWS, identity);
+    expect(points).toHaveLength(COLUMNS * ROWS);
+  });
+
+  it('yields the identical grid for a sub-cell pan (so small moves de-dup)', () => {
+    const base = buildCurrentSampleGrid(EXTENT, COLUMNS, ROWS, identity);
+    // Pan by 0.03 — less than the 0.1 cell size — must snap to the same lattice.
+    const nudged = buildCurrentSampleGrid(
+      [EXTENT[0] + 0.03, EXTENT[1] + 0.03, EXTENT[2] + 0.03, EXTENT[3] + 0.03],
+      COLUMNS,
+      ROWS,
+      identity
+    );
+    expect(nudged).toEqual(base);
+  });
+
+  it('yields a different grid once the pan crosses a cell boundary', () => {
+    const base = buildCurrentSampleGrid(EXTENT, COLUMNS, ROWS, identity);
+    // Pan by 0.2 — two cells — must move to a new lattice.
+    const moved = buildCurrentSampleGrid(
+      [EXTENT[0] + 0.2, EXTENT[1] + 0.2, EXTENT[2] + 0.2, EXTENT[3] + 0.2],
+      COLUMNS,
+      ROWS,
+      identity
+    );
+    expect(moved).not.toEqual(base);
+  });
+
+  it('normalises wrapped longitudes into [-180, 180]', () => {
+    const points = buildCurrentSampleGrid(EXTENT, COLUMNS, ROWS, ([, y]) => [
+      190,
+      y
+    ]);
+    expect(points.every((p) => p.longitude === -170)).toBe(true);
+  });
+
+  it('drops points beyond the Web Mercator latitude limit', () => {
+    const points = buildCurrentSampleGrid(EXTENT, COLUMNS, ROWS, ([x]) => [
+      x,
+      88
+    ]);
+    expect(points).toEqual([]);
+  });
+
+  it('returns no points for a degenerate (zero-area) extent', () => {
+    expect(
+      buildCurrentSampleGrid([10, 0, 10, 0], COLUMNS, ROWS, identity)
+    ).toEqual([]);
+  });
+});

--- a/src/app/modules/map/ol/lib/resources/layer-currents-weather.grid.spec.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-currents-weather.grid.spec.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
+import Feature from 'ol/Feature';
+import Point from 'ol/geom/Point';
+import VectorSource from 'ol/source/Vector';
 
-import { buildCurrentSampleGrid } from './layer-currents-weather.component';
+import {
+  buildCurrentSampleGrid,
+  LayerCurrentsWeatherComponent
+} from './layer-currents-weather.component';
 
 const COLUMNS = 10;
 const ROWS = 8;
@@ -62,5 +68,30 @@ describe('buildCurrentSampleGrid (#522 request de-duplication)', () => {
     expect(
       buildCurrentSampleGrid([10, 0, 10, 0], COLUMNS, ROWS, identity)
     ).toEqual([]);
+  });
+});
+
+describe('LayerCurrentsWeatherComponent stale-arrow clearing (#522)', () => {
+  it('clears previously rendered arrows when the viewport yields no points', () => {
+    const component = new LayerCurrentsWeatherComponent(
+      {} as never,
+      {} as never,
+      {} as never,
+      { detach: () => undefined } as never
+    );
+    component.show = true;
+    const source = new VectorSource();
+    source.addFeature(new Feature(new Point([0, 0])));
+    (component as never as { source: VectorSource }).source = source;
+
+    (
+      component as never as {
+        fetchCurrents: (p: unknown[]) => { subscribe: () => void };
+      }
+    )
+      .fetchCurrents([])
+      .subscribe();
+
+    expect(source.getFeatures()).toHaveLength(0);
   });
 });

--- a/src/app/modules/weather/weather.service.spec.ts
+++ b/src/app/modules/weather/weather.service.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting
+} from '@angular/common/http/testing';
+import { beforeEach, afterEach, describe, it, expect } from 'vitest';
+
+import { WeatherService } from './weather.service';
+import { SignalKClient } from 'signalk-client-angular';
+
+const MARINE_URL = 'https://marine-api.open-meteo.com/v1/marine';
+const isMarine = (url: string) => url.startsWith(MARINE_URL);
+
+// All in the same 0.1° lattice cell (lat [25.0,25.1), lon [-80.3,-80.2)),
+// whose canonical centre is 25.0500,-80.2500.
+const CELL_A_P1 = { latitude: 25.01, longitude: -80.29 };
+const CELL_A_P2 = { latitude: 25.09, longitude: -80.21 };
+const CELL_A_P3 = { latitude: 25.05, longitude: -80.27 };
+const CELL_A_CENTER = 'latitude=25.0500&longitude=-80.2500';
+
+// One cell north (lat [25.1,25.2)) — centre 25.1500,-80.2500.
+const CELL_B_P1 = { latitude: 25.11, longitude: -80.29 };
+const CELL_B_CENTER_LAT = '25.1500';
+
+const OK_ITEM = {
+  current: { ocean_current_velocity: 0.5, ocean_current_direction: 90 }
+};
+
+describe('WeatherService ocean-current lattice proxy (#522)', () => {
+  let service: WeatherService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        WeatherService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: SignalKClient, useValue: {} }
+      ]
+    });
+    service = TestBed.inject(WeatherService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('collapses same-cell points into one cell-centre request and serves later points from cache', () => {
+    let first;
+    service
+      .getOceanCurrentSamples([CELL_A_P1, CELL_A_P2])
+      .subscribe((s) => (first = s));
+    const req = httpMock.expectOne((r) => isMarine(r.url));
+    expect(req.request.url).toContain(CELL_A_CENTER);
+    req.flush(OK_ITEM);
+
+    // Both display points valued from the one cell, at their own coordinates.
+    expect(first).toEqual([
+      { ...CELL_A_P1, velocity: 0.5, direction: 90 },
+      { ...CELL_A_P2, velocity: 0.5, direction: 90 }
+    ]);
+
+    // A different display point in the same cell must NOT reach the network.
+    let second;
+    service.getOceanCurrentSamples([CELL_A_P3]).subscribe((s) => (second = s));
+    httpMock.expectNone((r) => isMarine(r.url));
+    expect(second).toEqual([{ ...CELL_A_P3, velocity: 0.5, direction: 90 }]);
+  });
+
+  it('fetches only the cells that are not already cached', () => {
+    service.getOceanCurrentSamples([CELL_A_P1]).subscribe();
+    httpMock.expectOne((r) => isMarine(r.url)).flush(OK_ITEM);
+
+    let samples;
+    service
+      .getOceanCurrentSamples([CELL_A_P1, CELL_B_P1])
+      .subscribe((s) => (samples = s));
+    const req = httpMock.expectOne((r) => isMarine(r.url));
+    expect(req.request.url).toContain(CELL_B_CENTER_LAT);
+    expect(req.request.url).not.toContain('25.0500');
+    req.flush({
+      current: { ocean_current_velocity: 1.2, ocean_current_direction: 180 }
+    });
+
+    expect(samples).toEqual([
+      { ...CELL_A_P1, velocity: 0.5, direction: 90 },
+      { ...CELL_B_P1, velocity: 1.2, direction: 180 }
+    ]);
+  });
+
+  it('negative-caches cells without data (land) so they are not re-requested', () => {
+    let first;
+    service.getOceanCurrentSamples([CELL_A_P1]).subscribe((s) => (first = s));
+    httpMock.expectOne((r) => isMarine(r.url)).flush({ current: {} });
+    expect(first).toEqual([]);
+
+    let second;
+    service.getOceanCurrentSamples([CELL_A_P2]).subscribe((s) => (second = s));
+    httpMock.expectNone((r) => isMarine(r.url));
+    expect(second).toEqual([]);
+  });
+
+  it('does not cache a rate-limited/error response — it stays retryable', () => {
+    let first;
+    service.getOceanCurrentSamples([CELL_A_P1]).subscribe((s) => (first = s));
+    // Open-Meteo returns an error body when the hourly quota is exceeded.
+    httpMock
+      .expectOne((r) => isMarine(r.url))
+      .flush({ error: true, reason: 'Hourly API request limit exceeded.' });
+    expect(first).toEqual([]);
+
+    let second;
+    service.getOceanCurrentSamples([CELL_A_P1]).subscribe((s) => (second = s));
+    httpMock.expectOne((r) => isMarine(r.url)).flush(OK_ITEM);
+    expect(second).toEqual([{ ...CELL_A_P1, velocity: 0.5, direction: 90 }]);
+  });
+
+  it('still renders cached cells when fetching the missing ones fails', () => {
+    service.getOceanCurrentSamples([CELL_A_P1]).subscribe();
+    httpMock.expectOne((r) => isMarine(r.url)).flush(OK_ITEM);
+
+    let samples;
+    service
+      .getOceanCurrentSamples([CELL_A_P1, CELL_B_P1])
+      .subscribe((s) => (samples = s));
+    httpMock
+      .expectOne((r) => isMarine(r.url))
+      .flush('rate limited', { status: 429, statusText: 'Too Many Requests' });
+
+    expect(samples).toEqual([{ ...CELL_A_P1, velocity: 0.5, direction: 90 }]);
+  });
+});

--- a/src/app/modules/weather/weather.service.ts
+++ b/src/app/modules/weather/weather.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { forkJoin, Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, tap } from 'rxjs/operators';
 import { SignalKClient } from 'signalk-client-angular';
 
 export interface WeatherWindSample {
@@ -19,12 +19,16 @@ export interface OceanCurrentSample {
 }
 
 interface OpenMeteoMarineItem {
-  latitude: number;
-  longitude: number;
+  error?: boolean;
   current?: {
     ocean_current_velocity?: number;
     ocean_current_direction?: number;
   };
+}
+
+interface OceanCurrentValue {
+  velocity: number;
+  direction: number;
 }
 
 interface SkObservationWind {
@@ -38,6 +42,20 @@ interface SkObservation {
 
 @Injectable({ providedIn: 'root' })
 export class WeatherService {
+  // Ocean-current requests are resolved against a fixed 0.1° geographic
+  // lattice (~11 km — the marine model's own resolution, so finer sampling
+  // can only return duplicate data) with a per-cell cache. Display code asks
+  // for arbitrary points; only lattice cells never seen (or expired) reach
+  // the rate-limited public Open-Meteo endpoint. `null` marks a cell the
+  // model has no data for (e.g. land) so it is not re-requested every pan.
+  private readonly currentCellDeg = 0.1;
+  private readonly currentsCacheTtlMs = 30 * 60 * 1000;
+  private readonly currentsCacheMax = 512;
+  private currentsCache = new Map<
+    string,
+    { at: number; value: OceanCurrentValue | null }
+  >();
+
   constructor(
     private http: HttpClient,
     private sk: SignalKClient
@@ -84,13 +102,43 @@ export class WeatherService {
     );
   }
 
-  /** Stopgap: currents not yet exposed by the SK Weather API — call Open-Meteo Marine directly.
-   *  Migrate to the SK Weather API once providers expose ocean_current_velocity/direction. */
+  /** Stopgap: currents not yet exposed by the SK Weather API — proxy the public
+   *  Open-Meteo Marine API from the browser, transparently to the display code.
+   *  Once the SK Weather API grows current support this whole retrieval layer
+   *  moves server-side and only this method's internals change.
+   *
+   *  Each display point is resolved to its 0.1° lattice cell; cells with a
+   *  fresh cached value (including "no data") are served locally and only the
+   *  missing cells are fetched — one batched request at canonical cell-center
+   *  coordinates, so every request ever made is for the same stable
+   *  coordinate set regardless of pan or zoom. */
   getOceanCurrentSamples(
     points: Array<{ latitude: number; longitude: number }>
   ): Observable<OceanCurrentSample[]> {
-    const latitudes = points.map((p) => p.latitude.toFixed(4)).join(',');
-    const longitudes = points.map((p) => p.longitude.toFixed(4)).join(',');
+    if (points.length === 0) {
+      return of([]);
+    }
+
+    const now = Date.now();
+    const cellKeys = points.map((p) => this.currentCellKey(p));
+    const missing = new Map<string, { latitude: number; longitude: number }>();
+    cellKeys.forEach((key) => {
+      if (missing.has(key)) {
+        return;
+      }
+      const entry = this.currentsCache.get(key);
+      if (!entry || now - entry.at >= this.currentsCacheTtlMs) {
+        missing.set(key, this.currentCellCenter(key));
+      }
+    });
+
+    if (missing.size === 0) {
+      return of(this.buildCurrentSamples(points, cellKeys));
+    }
+
+    const cells = Array.from(missing.entries());
+    const latitudes = cells.map(([, c]) => c.latitude.toFixed(4)).join(',');
+    const longitudes = cells.map(([, c]) => c.longitude.toFixed(4)).join(',');
     const url =
       'https://marine-api.open-meteo.com/v1/marine' +
       `?latitude=${latitudes}` +
@@ -98,22 +146,76 @@ export class WeatherService {
       '&current=ocean_current_velocity,ocean_current_direction';
 
     return this.http.get<OpenMeteoMarineItem | OpenMeteoMarineItem[]>(url).pipe(
-      catchError(() => of([])),
       map((response) => (Array.isArray(response) ? response : [response])),
-      map((items) =>
-        items
-          .filter(
-            (item) =>
-              typeof item.current?.ocean_current_velocity === 'number' &&
-              typeof item.current?.ocean_current_direction === 'number'
-          )
-          .map((item) => ({
-            latitude: item.latitude,
-            longitude: item.longitude,
-            velocity: item.current!.ocean_current_velocity,
-            direction: item.current!.ocean_current_direction
-          }))
-      )
+      tap((items) => {
+        // Response order mirrors request order. A rate-limit/error body
+        // (error flag, or a count mismatch) must cache NOTHING — otherwise a
+        // transient failure would be pinned as "no data" for the whole TTL.
+        if (items.length !== cells.length || items.some((i) => i?.error)) {
+          return;
+        }
+        items.forEach((item, i) => {
+          const velocity = item?.current?.ocean_current_velocity;
+          const direction = item?.current?.ocean_current_direction;
+          this.cacheCurrentCell(
+            cells[i][0],
+            typeof velocity === 'number' && typeof direction === 'number'
+              ? { velocity, direction }
+              : null
+          );
+        });
+      }),
+      map(() => this.buildCurrentSamples(points, cellKeys)),
+      // Still render whatever is already cached when the fetch fails.
+      catchError(() => of(this.buildCurrentSamples(points, cellKeys)))
     );
+  }
+
+  /** One sample per display point, valued from its lattice cell; points whose
+   *  cell has no data (land, or not yet fetched) yield no sample. */
+  private buildCurrentSamples(
+    points: Array<{ latitude: number; longitude: number }>,
+    cellKeys: string[]
+  ): OceanCurrentSample[] {
+    const samples: OceanCurrentSample[] = [];
+    points.forEach((point, i) => {
+      const value = this.currentsCache.get(cellKeys[i])?.value;
+      if (value) {
+        samples.push({
+          latitude: point.latitude,
+          longitude: point.longitude,
+          velocity: value.velocity,
+          direction: value.direction
+        });
+      }
+    });
+    return samples;
+  }
+
+  private currentCellKey(point: { latitude: number; longitude: number }) {
+    const x = Math.floor(point.longitude / this.currentCellDeg);
+    const y = Math.floor(point.latitude / this.currentCellDeg);
+    return `${x}:${y}`;
+  }
+
+  private currentCellCenter(key: string) {
+    const [x, y] = key.split(':').map(Number);
+    return {
+      latitude: (y + 0.5) * this.currentCellDeg,
+      longitude: (x + 0.5) * this.currentCellDeg
+    };
+  }
+
+  private cacheCurrentCell(key: string, value: OceanCurrentValue | null) {
+    // Re-insert at the newest position so a refreshed entry isn't treated as
+    // oldest by the size-based eviction below.
+    this.currentsCache.delete(key);
+    if (this.currentsCache.size >= this.currentsCacheMax) {
+      const oldest = this.currentsCache.keys().next().value;
+      if (oldest !== undefined) {
+        this.currentsCache.delete(oldest);
+      }
+    }
+    this.currentsCache.set(key, { at: Date.now(), value });
   }
 }


### PR DESCRIPTION
## Why

The ocean-current overlay (#413) called the public Open-Meteo Marine API
directly from the browser on every pan/zoom, with no caching or de-duplication
and only a 400 ms debounce — each request batching an 80-point viewport grid.
Open-Meteo weights multi-location calls by location count and limits the free
tier per-minute/hour/day, so ordinary chart panning quickly exhausted the
quota, after which currents silently disappeared with no feedback (#522).

## How

The retrieval layer is reworked; the display grid and rendering are untouched.

- **Resolve display points against a fixed 0.1° geographic lattice**
  (~11 km — the marine model's own resolution, so finer sampling can only
  return duplicate data). `WeatherService` keeps a per-cell cache (30 min TTL,
  512-cell cap): cells already seen are served locally, and only missing cells
  are fetched — one batched request at canonical cell-centre coordinates, so
  every request ever made is for the same stable coordinate set regardless of
  pan or zoom. Zoomed in, an 80-point viewport collapses to a handful of cells
  (often 1–2); panning fetches only the newly-exposed edge cells.
- **"No data" cells (land) are negative-cached** so they are not re-requested
  on every viewport refresh; rate-limit/error responses cache *nothing*, so a
  throttled response stays retryable, and already-cached cells still render
  while a fetch is failing.
- **Snap the display sample grid to a stable lattice in projected space**
  (`buildCurrentSampleGrid`, pure and unit-tested — projected space because
  Mercator distorts the lat span, which would shift a lon/lat lattice on every
  north/south pan), with `distinctUntilChanged` on the point signature and the
  debounce raised 400→600 ms, so an unchanged viewport never refetches at all.

The proxy boundary is deliberate: currents aren't exposed by the SK Weather
API yet, and when they are, this retrieval layer moves server-side with no
change to the display code.

Surfacing the rate-limit state to the user is left to a separate issue.

Closes #522


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ocean-current map data now loads from a stable, snapped sampling grid for smoother, more consistent updates.
  * Repeated requests for nearby map positions are consolidated to reduce network traffic.
  * Ocean-current results are cached and reused for faster responses.
  * Empty results are remembered, while temporary errors remain eligible for retry.
* **Bug Fixes**
  * Improved handling of map panning, longitude wrapping, invalid latitude ranges, and partial data failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->