### PR TITLE
fix(charts): make image adjustment work on iOS by using CSS canvas filters

### DIFF
--- a/src/app/modules/map/ol/lib/charts/chart-utils-image-adjustment.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils-image-adjustment.spec.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import TileLayer from 'ol/layer/Tile';
 import {
   attachImageAdjustmentFilter,
+  chartLayerClassName,
   imageAdjustmentToFilter
 } from './chart-utils';
 
@@ -33,7 +34,7 @@ describe('imageAdjustmentToFilter (#457)', () => {
   });
 });
 
-/** Minimal OL layer/render-context stand-ins for the prerender/postrender hooks. */
+/** Minimal OL layer stand-in for the postrender hook. */
 function mockLayer() {
   const handlers: Record<string, (e: { context: unknown }) => void> = {};
   const layer = {
@@ -46,42 +47,59 @@ function mockLayer() {
   return { layer, fire };
 }
 
-function mockContext() {
-  return {
-    filter: 'none',
-    save: vi.fn(),
-    restore: vi.fn()
-  } as unknown as CanvasRenderingContext2D & {
-    save: ReturnType<typeof vi.fn>;
-    restore: ReturnType<typeof vi.fn>;
-  };
+/** A real canvas element so the HTMLCanvasElement guard in the helper passes. */
+function canvasContext() {
+  const canvas = document.createElement('canvas');
+  return { canvas, ctx: { canvas } };
 }
 
 describe('attachImageAdjustmentFilter (#457)', () => {
-  it('applies the filter on prerender and restores it on postrender', () => {
+  it('applies the adjustment as a CSS filter on the layer canvas', () => {
     const { layer, fire } = mockLayer();
     const setAdjustment = attachImageAdjustmentFilter(layer);
     setAdjustment({ brightness: 1.2, contrast: 0.8 });
 
-    const ctx = mockContext();
-    fire('prerender', ctx);
-    expect(ctx.save).toHaveBeenCalledOnce();
-    expect(ctx.filter).toBe('brightness(1.2) contrast(0.8)');
-
+    const { canvas, ctx } = canvasContext();
     fire('postrender', ctx);
-    expect(ctx.restore).toHaveBeenCalledOnce();
+    expect(canvas.style.filter).toBe('brightness(1.2) contrast(0.8)');
   });
 
-  it('leaves the context untouched for a neutral adjustment', () => {
+  it('updates the CSS filter immediately once the canvas is known', () => {
     const { layer, fire } = mockLayer();
     const setAdjustment = attachImageAdjustmentFilter(layer);
-    setAdjustment({ brightness: 1, contrast: 1 });
-
-    const ctx = mockContext();
-    fire('prerender', ctx);
+    const { canvas, ctx } = canvasContext();
     fire('postrender', ctx);
-    expect(ctx.save).not.toHaveBeenCalled();
-    expect(ctx.restore).not.toHaveBeenCalled();
-    expect(ctx.filter).toBe('none');
+
+    setAdjustment({ brightness: 1.5, contrast: 1.1 });
+    expect(canvas.style.filter).toBe('brightness(1.5) contrast(1.1)');
+  });
+
+  it('clears the CSS filter for a neutral adjustment', () => {
+    const { layer, fire } = mockLayer();
+    const setAdjustment = attachImageAdjustmentFilter(layer);
+    const { canvas, ctx } = canvasContext();
+    setAdjustment({ brightness: 1.2, contrast: 0.8 });
+    fire('postrender', ctx);
+
+    setAdjustment({ brightness: 1, contrast: 1 });
+    expect(canvas.style.filter).toBe('');
+  });
+
+  it('ignores a non-canvas render context (WebGL layers)', () => {
+    const { layer, fire } = mockLayer();
+    const setAdjustment = attachImageAdjustmentFilter(layer);
+    setAdjustment({ brightness: 1.2, contrast: 0.8 });
+    expect(() => fire('postrender', { canvas: {} })).not.toThrow();
+  });
+});
+
+describe('chartLayerClassName (#457)', () => {
+  it('produces a unique per-chart class retaining ol-layer', () => {
+    expect(chartLayerClassName('my-chart')).toBe('ol-layer chart-my-chart');
+    expect(chartLayerClassName('a')).not.toBe(chartLayerClassName('b'));
+  });
+
+  it('sanitises characters not valid in a class name', () => {
+    expect(chartLayerClassName('a/b.c d')).toBe('ol-layer chart-a-b-c-d');
   });
 });

--- a/src/app/modules/map/ol/lib/charts/chart-utils.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils.ts
@@ -25,37 +25,47 @@ export function imageAdjustmentToFilter(adj?: ChartImageAdjustment): string {
 }
 
 /**
- * Apply a per-chart brightness/contrast filter to a raster (canvas) tile layer
- * by wrapping each render pass in a canvas `filter`. Returns a setter the caller
- * invokes whenever the chart's adjustment changes; a subsequent `map.render()`
- * repaints with the new values. WebGL tile layers have no 2D context and must
- * not be passed here.
+ * Apply a per-chart brightness/contrast adjustment to a raster (canvas) tile
+ * layer as a CSS filter on the layer's canvas element. A CSS element filter is
+ * used (rather than a `CanvasRenderingContext2D.filter`) because WebKit ships
+ * the context filter disabled by default, making it a silent no-op on iOS
+ * browsers. The layer MUST have a unique `className` (see
+ * `chartLayerClassName`) so OpenLayers renders it into its own canvas — layers
+ * sharing the default class are composited into one canvas and would all be
+ * filtered together.
+ * Returns a setter the caller invokes whenever the chart's adjustment changes;
+ * a subsequent `map.render()` repaints with the new values.
  */
 export function attachImageAdjustmentFilter(
   layer: TileLayer
 ): (adj?: ChartImageAdjustment) => void {
   let filter = '';
-  let applied = false;
-  layer.on('prerender', (evt: RenderEvent) => {
-    if (!filter) {
-      return;
+  let canvas: HTMLCanvasElement | null = null;
+  const apply = () => {
+    if (canvas && canvas.style.filter !== filter) {
+      canvas.style.filter = filter;
     }
-    const ctx = evt.context as CanvasRenderingContext2D;
-    ctx.save();
-    ctx.filter = filter;
-    applied = true;
-  });
+  };
   layer.on('postrender', (evt: RenderEvent) => {
-    if (!applied) {
-      return;
+    const cnv = (evt.context as CanvasRenderingContext2D)?.canvas;
+    if (cnv instanceof HTMLCanvasElement) {
+      canvas = cnv;
+      apply();
     }
-    const ctx = evt.context as CanvasRenderingContext2D;
-    ctx.restore();
-    applied = false;
   });
   return (adj?: ChartImageAdjustment) => {
     filter = imageAdjustmentToFilter(adj);
+    apply();
   };
+}
+
+/**
+ * Unique layer class name for a chart so OpenLayers renders the layer into its
+ * own canvas element (required for the per-chart CSS image-adjustment filter).
+ * Retains the default `ol-layer` class alongside the chart-specific one.
+ */
+export function chartLayerClassName(id: string): string {
+  return 'ol-layer chart-' + String(id).replace(/[^\w-]/g, '-');
 }
 
 export function resolveLayerMaxZoom(

--- a/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
@@ -17,6 +17,7 @@ import { osmLayer } from '../util';
 import { MapComponent } from '../map.component';
 import {
   attachImageAdjustmentFilter,
+  chartLayerClassName,
   extentFromBounds,
   resolveLayerMaxZoom
 } from './chart-utils';
@@ -75,7 +76,7 @@ export class RasterChartLayerComponent implements OnDestroy {
       );
 
       if (chart[0] === 'openstreetmap') {
-        this.layer = osmLayer();
+        this.layer = osmLayer(chartLayerClassName(chart[0]));
         this.layer.setZIndex(this.zIndex());
         this.layer.setMinZoom(chart[1].minZoom);
         this.layer.setMaxZoom(layerMaxZ);
@@ -87,7 +88,11 @@ export class RasterChartLayerComponent implements OnDestroy {
             : chart[1].minZoom;
 
         if (chart[1].url.indexOf('.pmtiles') !== -1) {
-          this.layer = initPMTilesXYZLayer(chart[1], this.zIndex());
+          this.layer = initPMTilesXYZLayer(
+            chart[1],
+            this.zIndex(),
+            chartLayerClassName(chart[0])
+          );
         } else {
           this.layer = new TileLayer({
             source: new XYZ({
@@ -99,7 +104,8 @@ export class RasterChartLayerComponent implements OnDestroy {
             zIndex: this.zIndex(),
             minZoom: minZ,
             maxZoom: layerMaxZ,
-            opacity: chart[1].defaultOpacity ?? 1
+            opacity: chart[1].defaultOpacity ?? 1,
+            className: chartLayerClassName(chart[0])
           });
         }
         if (this.layer) {

--- a/src/app/modules/map/ol/lib/charts/layer-tilejson-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-tilejson-chart.component.ts
@@ -16,6 +16,7 @@ import { MapComponent } from '../map.component';
 import { ChartImageAdjustment, FBChart } from 'src/app/types';
 import {
   attachImageAdjustmentFilter,
+  chartLayerClassName,
   extentFromBounds,
   resolveLayerMaxZoom
 } from './chart-utils';
@@ -85,7 +86,8 @@ export class TileJsonChartLayerComponent implements OnDestroy {
         minZoom: minZ,
         maxZoom: layerMaxZ,
         opacity: chart[1].defaultOpacity ?? 1,
-        extent: extentFromBounds(chart[1].bounds)
+        extent: extentFromBounds(chart[1].bounds),
+        className: chartLayerClassName(chart[0])
       });
 
       if (this.layer) {

--- a/src/app/modules/map/ol/lib/charts/layer-wms-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wms-chart.component.ts
@@ -18,6 +18,7 @@ import { Map } from 'ol';
 import { MapService } from '../map.service';
 import {
   attachImageAdjustmentFilter,
+  chartLayerClassName,
   extentFromBounds,
   resolveLayerMaxZoom
 } from './chart-utils';
@@ -124,7 +125,8 @@ export class WmsChartLayerComponent implements OnDestroy {
         minZoom: minZ,
         maxZoom: layerMaxZ,
         opacity: chart[1].defaultOpacity ?? 1,
-        extent: extentFromBounds(chart[1].bounds)
+        extent: extentFromBounds(chart[1].bounds),
+        className: chartLayerClassName(chart[0])
       });
 
       if (this.layer) {

--- a/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
@@ -18,6 +18,7 @@ import WMTS, { optionsFromCapabilities } from 'ol/source/WMTS';
 import WMTSCapabilities from 'ol/format/WMTSCapabilities';
 import {
   attachImageAdjustmentFilter,
+  chartLayerClassName,
   extentFromBounds,
   resolveLayerMaxZoom
 } from './chart-utils';
@@ -100,7 +101,8 @@ export class WmtsChartLayerComponent implements OnDestroy {
         minZoom: minZ,
         maxZoom: layerMaxZ,
         opacity: chart[1].defaultOpacity ?? 1,
-        extent: extentFromBounds(chart[1].bounds)
+        extent: extentFromBounds(chart[1].bounds),
+        className: chartLayerClassName(chart[0])
       });
 
       if (this.layer) {

--- a/src/app/modules/map/ol/lib/charts/pmtiles-utils.ts
+++ b/src/app/modules/map/ol/lib/charts/pmtiles-utils.ts
@@ -51,7 +51,8 @@ export function initPMTilesWebGLLayer(
 // create a PMTile XYZ source TileLayer
 export function initPMTilesXYZLayer(
   chart: SKChart,
-  zIndex: number
+  zIndex: number,
+  className?: string
 ): TileLayer<XYZ> {
   const tiles = new pmtiles.PMTiles(chart.url);
 
@@ -87,7 +88,8 @@ export function initPMTilesXYZLayer(
       minZoom: chart.minZoom
     }),
     zIndex: zIndex,
-    opacity: chart.defaultOpacity ?? 1
+    opacity: chart.defaultOpacity ?? 1,
+    className
   });
 }
 

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -14,8 +14,8 @@ export function defaultLayers() {
   return [osmLayer()];
 }
 
-export function osmLayer() {
-  return new TileLayer({ source: new OSM() });
+export function osmLayer(className?: string) {
+  return new TileLayer({ source: new OSM(), className });
 }
 
 export function osmSource() {


### PR DESCRIPTION
Fixes the Image Adjustment sliders having no effect on iOS (Safari and Chrome), reported on #457.

**Why:** the brightness/contrast was applied via `CanvasRenderingContext2D.filter`, which WebKit ships **disabled by default** (implemented behind a flag since Safari 18 — see [caniuse](https://caniuse.com/mdn-api_canvasrenderingcontext2d_filter) / [WebKit #198416](https://bugs.webkit.org/show_bug.cgi?id=198416)). Every iOS browser is WebKit, so the filter was a silent no-op there.

**How:** apply the adjustment as a **CSS filter on the layer's canvas element** instead — supported by all engines, and one code path for every browser (also composites on the GPU). Each raster chart layer now gets a unique `className`: OpenLayers renders consecutive same-class layers into a shared canvas, so without it the CSS filter would tint every chart; a distinct class gives the layer its own canvas.

Verified on iOS Safari/Chrome and desktop Chrome. Tests cover the CSS-filter apply/update/clear behaviour, the non-canvas (WebGL) context guard, and the per-chart class-name generation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart image adjustments by applying brightness and contrast filters reliably during map rendering.
  * Ensured neutral adjustments correctly remove visual filters.
  * Prevented errors when rendering contexts are not canvas elements.
* **Improvements**
  * Added unique styling identifiers for chart layers, supporting independent filtering across multiple charts.
  * Applied consistent chart-specific styling to raster, tile, WMS, WMTS, OpenStreetMap, and PMTiles layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->