### PR TITLE
fix(routes): hide Info for unsaved route drafts

### DIFF
--- a/src/app/modules/map/popovers/resource-popover.component.spec.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { ResourcePopoverComponent } from './resource-popover.component';
+
+// A minimal route stub — just the fields parseRoute() reads. Built inline
+// rather than importing SKRoute, to avoid pulling a second deep module path
+// into the test graph (which perturbs barrel-import evaluation order and can
+// break the AppComponent bootstrap spec).
+const routeStub = () => ({
+  name: '',
+  description: '',
+  distance: 0,
+  feature: { properties: {} }
+});
+
+/**
+ * Info button visibility for the route popover (#533). Clicking INFO on an
+ * unsaved route draft fetched the route from the server, which 404s (the draft
+ * is not stored yet), surfacing an error. An unsaved draft must therefore not
+ * offer INFO — the SAVE shortcut already opens the details dialog for editing
+ * its title/description.
+ *
+ * `computeControls()` (the constructor effect body) only reads plain instance
+ * fields and the signal inputs, so exercise it on a bare prototype instance
+ * with the inputs stubbed as plain getters (same approach as
+ * ais-base.component.spec).
+ */
+const appStub = {
+  formatValueForDisplay: (v: number) => `${v} m`,
+  useInfoPanel: () => false
+};
+
+function popover(canSave: boolean) {
+  const c = Object.create(
+    ResourcePopoverComponent.prototype
+  ) as ResourcePopoverComponent;
+  Object.assign(c, {
+    resource: () => ['route-1', routeStub()],
+    type: () => 'route',
+    active: () => undefined,
+    featureCount: () => 2,
+    canSave: () => canSave,
+    app: appStub,
+    _title: { set: () => undefined },
+    hasMarkdown: { set: () => undefined },
+    ctrl: {
+      showInfoButton: false,
+      showModifyButton: false,
+      showDeleteButton: false,
+      showAddNoteButton: false,
+      showRelatedButton: false,
+      showPointsButton: false,
+      showNotesButton: false,
+      showSaveButton: false,
+      canActivate: false,
+      isActive: false,
+      activeText: 'ACTIVE',
+      isReadOnly: false,
+      modifyLabel: 'MOVE'
+    }
+  });
+  (c as unknown as { computeControls: () => void }).computeControls();
+  return c as unknown as {
+    ctrl: { showInfoButton: boolean; showSaveButton: boolean };
+  };
+}
+
+describe('ResourcePopoverComponent — route Info visibility (#533)', () => {
+  it('shows INFO for a saved route', () => {
+    const c = popover(false);
+    expect(c.ctrl.showSaveButton).toBe(false);
+    expect(c.ctrl.showInfoButton).toBe(true);
+  });
+
+  it('hides INFO for an unsaved route draft (offers SAVE instead)', () => {
+    const c = popover(true);
+    expect(c.ctrl.showSaveButton).toBe(true);
+    expect(c.ctrl.showInfoButton).toBe(false);
+  });
+});

--- a/src/app/modules/map/popovers/resource-popover.component.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.ts
@@ -321,28 +321,34 @@ export class ResourcePopoverComponent {
   protected app = inject(AppFacade);
 
   constructor() {
-    effect(() => {
-      this.resource();
-      this.type();
-      this.active();
-      this.parse();
-      this.ctrl.showModifyButton =
-        this.type() !== 'destination' && this.featureCount() > 0 ? true : false;
-      // Routes/regions are shape-edited ("Modify"); points are moved ("Move").
-      this.ctrl.modifyLabel =
-        this.type() === 'route' || this.type() === 'region' ? 'MODIFY' : 'MOVE';
-      // Save shortcut: only for an unsaved route (host-decided via canSave).
-      this.ctrl.showSaveButton = this.type() === 'route' && this.canSave();
-      if (this.ctrl.showSaveButton) {
-        // Unsaved draft: also offer a quick Delete (discard) shortcut, and hide
-        // the actions that only work against a stored resource — Start
-        // (navigation), Route Points and Show Notes — which a draft has none of.
-        this.ctrl.showDeleteButton = true;
-        this.ctrl.canActivate = false;
-        this.ctrl.showPointsButton = false;
-        this.ctrl.showNotesButton = false;
-      }
-    });
+    effect(() => this.computeControls());
+  }
+
+  /** Derive button/state visibility from the current inputs (effect body). */
+  private computeControls() {
+    this.resource();
+    this.type();
+    this.active();
+    this.parse();
+    this.ctrl.showModifyButton =
+      this.type() !== 'destination' && this.featureCount() > 0;
+    // Routes/regions are shape-edited ("Modify"); points are moved ("Move").
+    this.ctrl.modifyLabel =
+      this.type() === 'route' || this.type() === 'region' ? 'MODIFY' : 'MOVE';
+    // Save shortcut: only for an unsaved route (host-decided via canSave).
+    this.ctrl.showSaveButton = this.type() === 'route' && this.canSave();
+    if (this.ctrl.showSaveButton) {
+      // Unsaved draft: also offer a quick Delete (discard) shortcut, and hide
+      // the actions that only work against a stored resource — Start
+      // (navigation), Route Points, Show Notes and Info — which a draft has
+      // none of. Info fetches the route from the server, which 404s for a
+      // draft; Save already opens the details dialog for title/description.
+      this.ctrl.showDeleteButton = true;
+      this.ctrl.canActivate = false;
+      this.ctrl.showPointsButton = false;
+      this.ctrl.showNotesButton = false;
+      this.ctrl.showInfoButton = false;
+    }
   }
 
   private parse() {


### PR DESCRIPTION
Clicking **Info** on an unsaved route draft fetched the route from the server, which 404s (the draft is not stored yet), surfacing an error to the user.

Hide Info for unsaved route drafts. The **Save** shortcut already opens the route details dialog for editing the title/description, so Info is redundant there anyway. The effect body is extracted into a small `computeControls()` method so the button-visibility logic can be unit-tested.

Closes #533


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated route draft popovers to show only actions available for unsaved routes.
  * The Save action is now offered for unsaved routes, while navigation, activation, route points, notes, and details actions are hidden.
  * Saved routes continue to display the appropriate information and editing controls.

* **Tests**
  * Added coverage to verify the correct controls appear for saved and unsaved routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->