### PR TITLE
fix(markdown): enable GFM so remark renders tables and strikethrough

### DIFF
--- a/features/custom-map-symbols.md
+++ b/features/custom-map-symbols.md
@@ -40,18 +40,17 @@ choice and won't swap your custom icon back in later.
 
 ## Where custom icons show up
 
-Custom icons work for:
-
-- Notes
-- Waypoints
-- Your own vessel
-- AIS vessels
-- Aids to navigation
-- Route start / turn / end points
-
-They don't apply to special waypoint markers (start pin, start boat,
-sightings, alarms), shaded chart areas, or the dots used for moored vessels
-— those always keep their built-in look.
+| Area | Custom icons? |
+|------|:---:|
+| Notes | Yes |
+| Waypoints | Yes |
+| Your own vessel | Yes |
+| AIS vessels | Yes |
+| Aids to navigation | Yes |
+| Route start / turn / end points | Yes |
+| Special waypoint markers (start pin, start boat, sightings, alarms) | No |
+| Shaded chart areas | No |
+| Dots for moored vessels | No |
 
 Icons that normally rotate to a heading or bearing — your vessel, AIS
 targets, aids to navigation, route turn points — keep rotating correctly even

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,11 @@
         "@signalk/server-api": "^2.24.0",
         "geolib": "^3.3.3",
         "google-protobuf": "^4.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
         "signalk-plotterext-bus": "^0.10.0",
         "tslib": "^2.0.0",
+        "unified": "^11.0.5",
         "uuid": "^14.0.1"
       },
       "devDependencies": {
@@ -4522,7 +4525,6 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -4600,7 +4602,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -4617,7 +4618,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4698,7 +4698,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/xml2js": {
@@ -5334,7 +5333,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5621,6 +5619,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5635,7 +5643,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6021,7 +6028,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6046,7 +6052,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -6087,7 +6092,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6108,7 +6112,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -6765,7 +6768,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -7510,7 +7512,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8052,7 +8053,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8143,6 +8143,16 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8153,11 +8163,38 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
       "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -8178,11 +8215,111 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
       "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -8197,7 +8334,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
       "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -8219,7 +8355,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -8270,7 +8405,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8306,7 +8440,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8337,11 +8470,131 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8363,7 +8616,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8386,7 +8638,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8407,7 +8658,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8430,7 +8680,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8453,7 +8702,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8474,7 +8722,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8494,7 +8741,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8516,7 +8762,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8537,7 +8782,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8557,7 +8801,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8580,7 +8823,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8597,7 +8839,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8614,7 +8855,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8634,7 +8874,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8654,7 +8893,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8676,7 +8914,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8699,7 +8936,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8716,7 +8952,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8956,7 +9191,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msgpackr": {
@@ -10193,11 +10427,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -10214,7 +10465,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -11145,7 +11395,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11311,7 +11560,6 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -11331,7 +11579,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -11345,7 +11592,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -11359,7 +11605,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -11375,7 +11620,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -11491,7 +11735,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -11506,7 +11749,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -12098,7 +12340,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,11 @@
     "@signalk/server-api": "^2.24.0",
     "geolib": "^3.3.3",
     "google-protobuf": "^4.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "signalk-plotterext-bus": "^0.10.0",
     "tslib": "^2.0.0",
+    "unified": "^11.0.5",
     "uuid": "^14.0.1"
   },
   "devDependencies": {

--- a/src/app/lib/markdown.spec.ts
+++ b/src/app/lib/markdown.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import type { Node, Parent } from 'unist';
+import { markdownProcessor } from './markdown';
+
+/** Parse + run markdown the same way ngx-remark's <remark> does, and collect
+ *  every node type present in the resulting MDAST tree. */
+function nodeTypes(markdown: string): Set<string> {
+  const tree = markdownProcessor.runSync(markdownProcessor.parse(markdown));
+  const types = new Set<string>();
+  const walk = (node: Node) => {
+    types.add(node.type);
+    for (const child of (node as Parent).children ?? []) walk(child);
+  };
+  walk(tree);
+  return types;
+}
+
+describe('markdownProcessor (GFM support)', () => {
+  it('parses a GFM pipe table into a table node, not literal text', () => {
+    const md = [
+      '| Area | Custom icons? |',
+      '| --- | --- |',
+      '| Waypoints | Yes |',
+      '| Routes | No |'
+    ].join('\n');
+
+    const types = nodeTypes(md);
+    // Without remark-gfm the whole block collapses to a single `paragraph`
+    // of literal pipe text; with it, a real `table` node is produced.
+    expect(types.has('table')).toBe(true);
+    expect(types.has('tableRow')).toBe(true);
+    expect(types.has('tableCell')).toBe(true);
+  });
+
+  it('parses strikethrough (~~) into a delete node', () => {
+    const types = nodeTypes('This is ~~struck~~ text.');
+    expect(types.has('delete')).toBe(true);
+  });
+});

--- a/src/app/lib/markdown.ts
+++ b/src/app/lib/markdown.ts
@@ -1,0 +1,22 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+
+/**
+ * Shared Markdown processor for `ngx-remark`'s `<remark [processor]>` input.
+ *
+ * `ngx-remark` defaults to `unified().use(remarkParse)`, which is *core*
+ * CommonMark only. GitHub-Flavored-Markdown constructs — pipe tables,
+ * strikethrough, autolinks, task lists, footnotes — are a GFM extension and
+ * would otherwise render as literal text (e.g. a `| a | b |` table shows its
+ * pipes). Adding `remark-gfm` makes the parser emit the corresponding MDAST
+ * nodes, which `<remark>` already has default templates for (`table`, `delete`,
+ * `footnotes`, …).
+ *
+ * A single frozen processor instance is safe to share across every `<remark>`
+ * in the app: parsing is stateless with respect to the processor.
+ */
+export const markdownProcessor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .freeze();

--- a/src/app/modules/features/feature-browser-dialog.html
+++ b/src/app/modules/features/feature-browser-dialog.html
@@ -61,7 +61,7 @@
         }
       </div>
       <div class="body">
-        <remark [markdown]="f.body">
+        <remark [processor]="mdProcessor" [markdown]="f.body">
           <ng-template remarkTemplate="image" let-node>
             <figure
               class="shot"

--- a/src/app/modules/features/feature-browser-dialog.ts
+++ b/src/app/modules/features/feature-browser-dialog.ts
@@ -18,6 +18,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { A11yModule } from '@angular/cdk/a11y';
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../lib/markdown';
 
 import { FeatureCorpusService } from './feature-corpus.service';
 import {
@@ -54,6 +55,7 @@ import {
   styleUrl: './feature-browser-dialog.css'
 })
 export class FeatureBrowserDialog implements OnInit {
+  protected readonly mdProcessor = markdownProcessor;
   private corpus = inject(FeatureCorpusService);
   protected dialogRef = inject(MatDialogRef<FeatureBrowserDialog>);
   private host = inject<ElementRef<HTMLElement>>(ElementRef);

--- a/src/app/modules/map/popovers/resource-popover.component.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.ts
@@ -17,6 +17,7 @@ import { PopoverComponent } from './popover.component';
 
 import { AppFacade } from 'src/app/app.facade';
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../lib/markdown';
 import { SKRoute, SKWaypoint, SKNote, SKRegion } from 'src/app/modules';
 import { AppIconDef, getResourceIcon } from 'src/app/modules/icons';
 
@@ -57,6 +58,7 @@ interface PopoverCtrl {
     >
       @if (hasMarkdown()) {
         <remark
+          [processor]="mdProcessor"
           style="flex: 1 1 auto;text-align:left;font-style: italic; overflow: hidden;
                                   display: -webkit-box;
                                   -webkit-box-orient: vertical;
@@ -277,6 +279,7 @@ interface PopoverCtrl {
   styleUrls: [`./popover.component.scss`]
 })
 export class ResourcePopoverComponent {
+  protected readonly mdProcessor = markdownProcessor;
   title = input<string>(); // popover title text
   resource = input<SKRoute | SKWaypoint | SKNote | SKRegion>();
   type = input<string>(); // resource type

--- a/src/app/modules/skresources/components/notes/note-dialog.html
+++ b/src/app/modules/skresources/components/notes/note-dialog.html
@@ -98,7 +98,10 @@
             </div>
             @if(data.note.mimeType.includes('markdown')) {
             <div class="note-description">
-              <remark [markdown]="data.note.description" />
+              <remark
+                [processor]="mdProcessor"
+                [markdown]="data.note.description"
+              />
             </div>
             } @else {
             <div

--- a/src/app/modules/skresources/components/notes/note-dialog.ts
+++ b/src/app/modules/skresources/components/notes/note-dialog.ts
@@ -21,6 +21,7 @@ import {
   AngularEditorConfig
 } from '@kolkov/angular-editor';
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 import { AddTargetPipe } from './safe.pipe';
 
 import { AppFacade } from 'src/app/app.facade';
@@ -64,6 +65,7 @@ interface DialogData {
   styleUrls: ['notes.css']
 })
 export class NoteDialog implements OnInit {
+  protected readonly mdProcessor = markdownProcessor;
   private editorHiddenButtons = [
     [
       //'undo',

--- a/src/app/modules/skresources/components/notes/note-panel.html
+++ b/src/app/modules/skresources/components/notes/note-panel.html
@@ -129,6 +129,7 @@
   </div>
   } @if(note().mimeType.includes('markdown')) {
   <remark
+    [processor]="mdProcessor"
     [markdown]="note().description"
     style="flex: 2 1 auto; overflow-y: auto; padding-left: 5px"
   >

--- a/src/app/modules/skresources/components/notes/note-panel.ts
+++ b/src/app/modules/skresources/components/notes/note-panel.ts
@@ -14,6 +14,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 import { AddTargetPipe } from './safe.pipe';
 
 import { AppFacade } from 'src/app/app.facade';
@@ -40,6 +41,7 @@ import { Position } from 'src/app/types';
   styleUrls: ['notes.css']
 })
 export class NotePanel {
+  protected readonly mdProcessor = markdownProcessor;
   note = input<SKNote>(new SKNote());
   id = input<string>(undefined);
   interacting = input<boolean>(false);

--- a/src/app/modules/skresources/components/notes/relatednotes-dialog.html
+++ b/src/app/modules/skresources/components/notes/relatednotes-dialog.html
@@ -74,6 +74,7 @@
               </div>
               @if(n[1].mimeType?.includes('markdown')) {
               <remark
+                [processor]="mdProcessor"
                 style="
                   flex: 1 1 auto;
                   text-align: left;

--- a/src/app/modules/skresources/components/notes/relatednotes-dialog.ts
+++ b/src/app/modules/skresources/components/notes/relatednotes-dialog.ts
@@ -14,6 +14,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 import { AddTargetPipe } from './safe.pipe';
 
 import { AppFacade } from 'src/app/app.facade';
@@ -46,6 +47,7 @@ interface DialogData {
   styleUrls: ['notes.css']
 })
 export class RelatedNotesDialog implements OnInit {
+  protected readonly mdProcessor = markdownProcessor;
   protected relatedBy: string;
 
   protected data = inject<DialogData>(MAT_DIALOG_DATA);

--- a/src/app/modules/skresources/components/regions/region-panel.html
+++ b/src/app/modules/skresources/components/regions/region-panel.html
@@ -75,6 +75,7 @@
   </div>
 
   <remark
+    [processor]="mdProcessor"
     [markdown]="_region().description"
     style="flex: 2 1 auto; overflow-y: auto; padding-left: 5px"
   >

--- a/src/app/modules/skresources/components/regions/region-panel.ts
+++ b/src/app/modules/skresources/components/regions/region-panel.ts
@@ -17,6 +17,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatExpansionModule } from '@angular/material/expansion';
 
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 
 import { AppFacade } from 'src/app/app.facade';
 import { AppIconDef, getResourceIcon } from 'src/app/modules/icons';
@@ -47,6 +48,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   styleUrls: []
 })
 export class RegionPanel {
+  protected readonly mdProcessor = markdownProcessor;
   region = input<SKRegion>(new SKRegion());
   id = input<string>(undefined);
   related = input<string>(undefined);

--- a/src/app/modules/skresources/components/regions/regionlist.html
+++ b/src/app/modules/skresources/components/regions/regionlist.html
@@ -79,6 +79,7 @@
                 <b>{{r[1].name}}</b>
               </div>
               <remark
+                [processor]="mdProcessor"
                 style="
                   flex: 1 1 auto;
                   text-align: left;

--- a/src/app/modules/skresources/components/regions/regionlist.ts
+++ b/src/app/modules/skresources/components/regions/regionlist.ts
@@ -29,6 +29,7 @@ import { SKRegion } from '../../resource-classes';
 import { SKResourceGroupService } from '../groups/groups.service';
 import { SingleSelectListDialog } from 'src/app/lib/components';
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
@@ -49,6 +50,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   ]
 })
 export class RegionListComponent extends ResourceListBase {
+  protected readonly mdProcessor = markdownProcessor;
   @Input() regions: FBRegions;
   select = output<FBResourceSelect>();
   refresh = output<void>();

--- a/src/app/modules/skresources/components/routes/route-panel.html
+++ b/src/app/modules/skresources/components/routes/route-panel.html
@@ -119,6 +119,7 @@
   </div>
 
   <remark
+    [processor]="mdProcessor"
     [markdown]="_route().description"
     style="flex: 2 1 auto; overflow-y: auto; padding-left: 5px"
   >

--- a/src/app/modules/skresources/components/routes/route-panel.ts
+++ b/src/app/modules/skresources/components/routes/route-panel.ts
@@ -20,6 +20,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatDialog } from '@angular/material/dialog';
 
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 
 import { AppFacade } from 'src/app/app.facade';
 import { InfoPanelFacade } from 'src/app/modules/info-panel/info-panel.facade';
@@ -57,6 +58,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   styleUrls: []
 })
 export class RoutePanel {
+  protected readonly mdProcessor = markdownProcessor;
   route = input<SKRoute>(new SKRoute());
   id = input<string>(undefined);
   related = input<string>(undefined);

--- a/src/app/modules/skresources/components/routes/routelist.html
+++ b/src/app/modules/skresources/components/routes/routelist.html
@@ -84,6 +84,7 @@
                 <b>{{r[1].name}}</b>
               </div>
               <remark
+                [processor]="mdProcessor"
                 style="
                   flex: 1 1 auto;
                   text-align: left;

--- a/src/app/modules/skresources/components/routes/routelist.ts
+++ b/src/app/modules/skresources/components/routes/routelist.ts
@@ -33,6 +33,7 @@ import { SKWorkerService } from 'src/app/modules/skstream/skstream.service';
 import { SKResourceGroupService } from '../groups/groups.service';
 import { SingleSelectListDialog } from 'src/app/lib/components';
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
@@ -54,6 +55,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   ]
 })
 export class RouteListComponent extends ResourceListBase {
+  protected readonly mdProcessor = markdownProcessor;
   activeRoute = input<string>();
   editingRouteId = input<string>();
   select = output<FBResourceSelect>();

--- a/src/app/modules/skresources/components/tracks/tracklist.html
+++ b/src/app/modules/skresources/components/tracks/tracklist.html
@@ -83,6 +83,7 @@
                 <b>{{r[1].feature.properties?.name || i}}</b>
               </div>
               <remark
+                [processor]="mdProcessor"
                 style="
                   flex: 1 1 auto;
                   text-align: left;

--- a/src/app/modules/skresources/components/tracks/tracklist.ts
+++ b/src/app/modules/skresources/components/tracks/tracklist.ts
@@ -23,6 +23,7 @@ import { FBTrack, FBTracks, Position } from 'src/app/types';
 import { SKWorkerService } from 'src/app/modules';
 import { ResourceListBase } from '../resource-list-baseclass';
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 
 @Component({
   selector: 'track-list',
@@ -43,6 +44,7 @@ import { RemarkModule } from 'ngx-remark';
   ]
 })
 export class TrackListComponent extends ResourceListBase {
+  protected readonly mdProcessor = markdownProcessor;
   closed = output<void>();
   center = output<Position>();
 

--- a/src/app/modules/skresources/components/waypoints/waypoint-panel.html
+++ b/src/app/modules/skresources/components/waypoints/waypoint-panel.html
@@ -109,6 +109,7 @@
   </div>
 
   <remark
+    [processor]="mdProcessor"
     [markdown]="_waypoint().description"
     style="flex: 2 1 auto; overflow-y: auto; padding-left: 5px"
   >

--- a/src/app/modules/skresources/components/waypoints/waypoint-panel.ts
+++ b/src/app/modules/skresources/components/waypoints/waypoint-panel.ts
@@ -19,6 +19,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatDialog } from '@angular/material/dialog';
 
 import { RemarkModule } from 'ngx-remark';
+import { markdownProcessor } from '../../../../lib/markdown';
 
 import { AppFacade } from 'src/app/app.facade';
 import { AppIconDef, getResourceIcon } from 'src/app/modules/icons';
@@ -50,6 +51,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   styleUrls: []
 })
 export class WaypointPanel {
+  protected readonly mdProcessor = markdownProcessor;
   waypoint = input<SKWaypoint>(new SKWaypoint());
   id = input<string>(undefined);
   related = input<string>(undefined);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -71,6 +71,28 @@ b { font-weight: 500; }
     color: inherit;
 }
 
+/* GFM tables rendered by <remark>. ngx-remark ships no CSS and emits a bare
+   <table>, which the browser draws without borders. Scoped to `remark` so it
+   cannot reach Angular Material's tables. Column alignment from the Markdown
+   (`:---:`) is applied inline by ngx-remark and so still wins over this. */
+remark table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.5em 0;
+}
+
+remark th,
+remark td {
+    border: 1px solid var(--mat-sys-outline-variant, #ccc);
+    padding: 4px 8px;
+    text-align: left;
+}
+
+remark th {
+    font-weight: 500;
+    background: var(--mat-sys-surface-container, rgba(127, 127, 127, 0.12));
+}
+
 /*xs*/
 @media only screen and (max-width: 599px) {
     .weather-data .mat-horizontal-content-container {


### PR DESCRIPTION
## What & why

Feature docs and resource descriptions are rendered with `ngx-remark`, which by
default runs a **core-CommonMark** processor (`unified().use(remarkParse)`).
GitHub-Flavored-Markdown constructs — pipe tables, strikethrough, autolinks, task
lists, footnotes — are a GFM extension, so they rendered as **literal text**
(e.g. `features/custom-map-symbols.md`'s "Where custom icons show up" table showed
its raw pipes in the Feature Browser).

## Fix

- Add a shared, frozen GFM processor in `src/app/lib/markdown.ts`
  (`unified().use(remarkParse).use(remarkGfm)` — the ngx-remark-documented pattern)
  and pass it to every `<remark>` in the app via the component's `[processor]`
  input. GFM now renders wherever markdown is shown: the Feature Browser, and
  note / route / waypoint / region / track descriptions (panels, lists, dialogs,
  and the resource popover). `ngx-remark` already ships default templates for the
  `table` / `delete` / `footnotes` nodes, so no template work was needed.
- Style the tables. `ngx-remark` ships no CSS and emits a bare `<table>`, which
  the browser draws with no borders. The rule has to be global — the table lives
  in ngx-remark's own view, so the dialog's component styles can't reach it — so
  it's scoped to `remark` to keep it away from Angular Material's tables, and uses
  the Material system tokens so it follows the theme. Markdown column alignment
  (`:---:`) is applied inline by ngx-remark and still wins over it.
- Restore the "Where custom icons show up" table in the `custom-map-symbols`
  feature doc, which had been flattened to a bullet list to work around the
  missing table support.

## Dependencies

Adds `unified`, `remark-parse`, and `remark-gfm` as runtime `dependencies`.
(`remark` was only a `devDependency`, so importing it into client code would pull
a dev dep — and `remark-stringify` — into the bundle; `unified` + `remark-parse`
mirror ngx-remark's own default and are lighter.)

## Tests

`src/app/lib/markdown.spec.ts` asserts the shared processor emits `table` /
`tableRow` / `tableCell` nodes for a GFM pipe table and a `delete` node for
strikethrough. Verified red before the fix, green after. Full suite: 253 passing.
Verified in a running Freeboard against a local Signal K server.

Closes #536


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Markdown content now supports GitHub-Flavored Markdown, including tables and strikethrough formatting, across feature, resource, note, region, route, track, and waypoint descriptions.
  - Markdown tables display with improved layout, borders, spacing, and themed headers.

- **Documentation**
  - Clarified which chart elements support custom icons with a structured comparison table.

- **Tests**
  - Added coverage confirming table and strikethrough Markdown are rendered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->