### PR TITLE
fix(features): reset details pane scroll when a new feature is selected

### DIFF
--- a/src/app/modules/features/feature-browser-dialog.spec.ts
+++ b/src/app/modules/features/feature-browser-dialog.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { EMPTY } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { CompiledFeature } from './feature-corpus';
+import { FeatureCorpusService } from './feature-corpus.service';
+import { FeatureBrowserDialog } from './feature-browser-dialog';
+
+function feature(id: string, title: string): CompiledFeature {
+  return {
+    id,
+    title,
+    category: 'General',
+    body: `# ${title}\n\nprose`,
+    since: '2.1.0',
+    latestKind: 'new',
+    events: [],
+    images: []
+  };
+}
+
+describe('FeatureBrowserDialog details scroll', () => {
+  let fixture: ComponentFixture<FeatureBrowserDialog>;
+
+  const corpus = [feature('alpha', 'Alpha'), feature('bravo', 'Bravo')];
+
+  const detailsPane = () =>
+    fixture.nativeElement.querySelector('.details') as HTMLElement;
+
+  const rows = () =>
+    Array.from(
+      fixture.nativeElement.querySelectorAll('tr[mat-row]')
+    ) as HTMLElement[];
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [FeatureBrowserDialog],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: FeatureCorpusService,
+          useValue: { load: async () => corpus, hueFor: () => 0 }
+        },
+        {
+          provide: MatDialogRef,
+          useValue: { keydownEvents: () => EMPTY, close: () => undefined }
+        }
+      ]
+    });
+
+    fixture = TestBed.createComponent(FeatureBrowserDialog);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('returns the details pane to the top when another feature is selected', () => {
+    const pane = detailsPane();
+    expect(pane).toBeTruthy();
+
+    // The user has read to the bottom of the first feature...
+    pane.scrollTop = 250;
+
+    // ...then picks a different row (whichever one isn't already shown).
+    const other = rows().find((r) => !r.classList.contains('active'));
+    expect(other).toBeTruthy();
+    other?.click();
+    fixture.detectChanges();
+
+    expect(detailsPane().scrollTop).toBe(0);
+  });
+});

--- a/src/app/modules/features/feature-browser-dialog.ts
+++ b/src/app/modules/features/feature-browser-dialog.ts
@@ -3,6 +3,7 @@ import {
   ElementRef,
   OnInit,
   computed,
+  effect,
   inject,
   signal
 } from '@angular/core';
@@ -101,6 +102,16 @@ export class FeatureBrowserDialog implements OnInit {
     () => (this.activeFeature()?.images.length ?? 0) > 1
   );
 
+  constructor() {
+    // A new feature starts at its first line: the details pane is its own
+    // scroll region, so without this it inherits the previous feature's
+    // scroll offset and opens part-way down (or past the end of shorter prose).
+    effect(() => {
+      this.activeFeature();
+      this.resetDetailsScroll();
+    });
+  }
+
   async ngOnInit() {
     // Bind via the dialog's keydown stream (not @HostListener) so arrow keys
     // work regardless of which element inside the dialog has focus.
@@ -162,6 +173,12 @@ export class FeatureBrowserDialog implements OnInit {
     // exist in `displayed()` order, so this doesn't depend on change detection
     // having re-applied the highlight class before this callback runs.
     requestAnimationFrame(() => this.revealRow(next));
+  }
+
+  /** Return the details pane to the top so the new feature reads from line one. */
+  private resetDetailsScroll() {
+    const pane = this.host.nativeElement.querySelector<HTMLElement>('.details');
+    if (pane) pane.scrollTop = 0;
   }
 
   /** Bring row `index` fully into view, keeping it clear of the sticky header. */


### PR DESCRIPTION
The details pane is its own scroll region, and nothing returned it to the top when
the shown feature changed — so picking a new row while scrolled down opened the new
feature part-way through its prose, or past the end of it entirely.

Resets `.details` scroll via an `effect()` keyed on `activeFeature()` rather than
patching each selection path. That covers mouse click, arrow-key navigation, and the
case where filtering or re-sorting changes which feature is active. Since
`activeFeature` is a `computed` compared by reference, it only fires when the feature
genuinely changes — re-sorting the table doesn't yank a pane you're reading.

Test drives a real row click and was verified red→green (fails with the previous
offset retained before the fix).

Closes #539
