### PR TITLE
fix(charts): apply constrain map zoom on startup

### DIFF
--- a/src/app/modules/skresources/resources-charts-zoom-extent.spec.ts
+++ b/src/app/modules/skresources/resources-charts-zoom-extent.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { signal } from '@angular/core';
+import { SKResourceService } from './resources.service';
+import { FBCharts } from 'src/app/types';
+
+/**
+ * Regression tests for "constrain map zoom" not being applied on startup (#552).
+ *
+ * `setMapZoomRange` derives the extent from the chart cache signal, so
+ * `refreshCharts` must populate that cache *before* calling it — otherwise the
+ * first refresh computes from an empty list and the constraint silently never
+ * takes effect, while the toolbar button still reports itself as active.
+ *
+ * `setMapZoomRange` / `refreshCharts` only touch `this.app`, the cache signal and
+ * a few list helpers, so exercise them on a bare prototype instance with a mock
+ * app — no Angular DI needed (same approach as the chart opacity specs). Class
+ * field initializers don't run under `Object.create`, so the cache signal is
+ * supplied explicitly.
+ */
+const DEFAULT_EXTENT = { min: 2, max: 28 };
+
+/** Minimal stand-in for a chart cache entry: [id, chart, selected]. */
+function chartEntry(id: string, minZoom: number, maxZoom: number) {
+  return [id, { minZoom, maxZoom }, true] as unknown as FBCharts[0];
+}
+
+function svcWithCharts(mapConstrainZoom: boolean, cache: FBCharts = []) {
+  const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+  (svc as unknown as { app: unknown }).app = {
+    uiConfig: () => ({ mapConstrainZoom }),
+    MAP_ZOOM_EXTENT: { ...DEFAULT_EXTENT },
+    debug: () => undefined
+  };
+  (svc as unknown as { chartCacheSignal: unknown }).chartCacheSignal =
+    signal<FBCharts>(cache);
+  return svc;
+}
+
+const extentOf = (svc: SKResourceService) =>
+  (svc as unknown as { app: { MAP_ZOOM_EXTENT: { min: number; max: number } } })
+    .app.MAP_ZOOM_EXTENT;
+
+describe('map zoom extent (#552)', () => {
+  it('derives the extent on the first refresh, when the cache starts empty', async () => {
+    const svc = svcWithCharts(true);
+    const served = [chartEntry('limited', 0, 16)] as FBCharts;
+    // identity list helpers keep the fixture deterministic — the built-in OSM
+    // charts would otherwise widen the union to their own 0..24 range.
+    Object.assign(svc as unknown as Record<string, unknown>, {
+      listFromServer: vi.fn(async () => served),
+      appendOSM: (l: FBCharts) => l,
+      sortByScaleDesc: (l: FBCharts) => l,
+      arrangeChartLayers: (l: FBCharts) => l
+    });
+
+    await svc.refreshCharts();
+
+    // pre-fix this stayed at the unconstrained default, because the extent was
+    // computed before the cache was populated
+    expect(extentOf(svc)).toEqual({ min: 0, max: 16 });
+  });
+
+  it('takes the widest range across selected charts', () => {
+    const svc = svcWithCharts(true, [
+      chartEntry('a', 4, 16),
+      chartEntry('b', 1, 12)
+    ] as FBCharts);
+
+    svc.setMapZoomRange();
+
+    expect(extentOf(svc)).toEqual({ min: 1, max: 16 });
+  });
+
+  it('falls back to the default extent when no chart supplies a bound', () => {
+    const svc = svcWithCharts(true);
+    extentOf(svc).min = 5;
+    extentOf(svc).max = 15;
+
+    svc.setMapZoomRange();
+
+    expect(extentOf(svc)).toEqual(DEFAULT_EXTENT);
+  });
+
+  it('uses the default extent when constrain is off', () => {
+    const svc = svcWithCharts(false, [
+      chartEntry('limited', 0, 16)
+    ] as FBCharts);
+
+    svc.setMapZoomRange();
+
+    expect(extentOf(svc)).toEqual(DEFAULT_EXTENT);
+  });
+
+  it('uses the default extent when explicitly asked to, despite constrain', () => {
+    const svc = svcWithCharts(true, [chartEntry('limited', 0, 16)] as FBCharts);
+
+    svc.setMapZoomRange(true);
+
+    expect(extentOf(svc)).toEqual(DEFAULT_EXTENT);
+  });
+});

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -599,14 +599,14 @@ export class SKResourceService {
       let flist = chts.filter((chart: FBChart) => chart[2]);
       flist = this.sortByScaleDesc(flist);
       flist = this.arrangeChartLayers(flist);
-      // set map zoom extent
-      this.setMapZoomRange();
       this.chartCacheSignal.set(flist);
+      // set map zoom extent (derived from the cache, so populate it first)
+      this.setMapZoomRange();
     } catch (err) {
       this.app.debug('** refreshCharts:', err);
       const flist = this.appendOSM([]);
-      this.setMapZoomRange();
       this.chartCacheSignal.set(flist);
+      this.setMapZoomRange();
     }
   }
 
@@ -672,11 +672,12 @@ export class SKResourceService {
             derivedExtent.max = c[1].maxZoom;
           }
         }
-        this.app.MAP_ZOOM_EXTENT.min =
-          derivedExtent.min === 1000 ? defaultExtent.min : derivedExtent.min;
-        this.app.MAP_ZOOM_EXTENT.max =
-          derivedExtent.max === -1 ? defaultExtent.max : derivedExtent.max;
       });
+      // fall back to the default when no selected chart supplied a bound
+      this.app.MAP_ZOOM_EXTENT = {
+        min: derivedExtent.min === 1000 ? defaultExtent.min : derivedExtent.min,
+        max: derivedExtent.max === -1 ? defaultExtent.max : derivedExtent.max
+      };
       this.app.debug('*** MAP_ZOOM_EXTENT', this.app.MAP_ZOOM_EXTENT);
     }
   }


### PR DESCRIPTION
`setMapZoomRange()` derives the zoom extent from the chart cache signal, but `refreshCharts()` called it *before* populating that cache. On startup the cache is still empty, so the extent was computed from an empty chart list and the constraint silently never took effect — while the toolbar button still rendered as active and the config still read `mapConstrainZoom: true`. Toggling the button off and on recomputed the extent against a now-populated cache, which is why that worked around it.

Separately, the two `MAP_ZOOM_EXTENT` assignments sat *inside* the `forEach` body, so an empty selection skipped them entirely and left whatever extent was there before rather than falling back to the default. Both defects had to line up to produce the reported symptom, and the second is independently reachable by deselecting every chart.

Reproduced on `3.0.0-rc.1` against a local server before fixing: with constrain persisted on, a fresh load allowed zooming to 28 (the unconstrained default) instead of the selected charts' 24; toggling off/on snapped it back to 24.

Regression test added — it fails on both counts before the change (`{2,28}` instead of `{0,16}`; a stale extent instead of the default) and passes after.

Closes #552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map zoom range updates when chart selections change.
  * Ensured zoom limits correctly reflect the widest available range across selected charts.
  * Restored the default zoom extent when no chart bounds are available or constraints are disabled.
  * Fixed zoom extent updates after chart loading errors and during initial chart refreshes.

* **Tests**
  * Added regression coverage for map zoom extent behavior across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->