### PR TITLE
docs(features): document chart zoom limits

### DIFF
--- a/features/changelog.json
+++ b/features/changelog.json
@@ -17,5 +17,6 @@
   { "feature": "notes", "pr": 485, "kind": "enhanced", "since": "v3.0.0-beta.2", "date": "2026-07-07", "title": "feat(notes): size Note Details dialog to fit its content" },
   { "feature": "notes", "pr": 512, "kind": "enhanced", "since": "v3.0.0-beta.4", "date": "2026-07-12", "title": "feat(notes): add option to open note details on single click" },
   { "feature": "feature-browser", "pr": 528, "kind": "new", "since": "v3.0.0-rc.1", "date": "2026-07-16", "title": "feat(features): add a searchable \"What's New\" feature browser" },
-  { "feature": "feature-browser", "pr": 530, "kind": "enhanced", "since": "v3.0.0-rc.1", "date": "2026-07-17", "title": "feat(features): replace forced onboarding modals with a passive What's New indicator" }
+  { "feature": "feature-browser", "pr": 530, "kind": "enhanced", "since": "v3.0.0-rc.1", "date": "2026-07-17", "title": "feat(features): replace forced onboarding modals with a passive What's New indicator" },
+  { "feature": "chart-zoom-limits", "kind": "new", "since": "v2.1.0", "date": "2023-07-06", "title": "limit zoom to selected maps" }
 ]

--- a/features/chart-zoom-limits.md
+++ b/features/chart-zoom-limits.md
@@ -1,0 +1,44 @@
+---
+id: chart-zoom-limits
+title: Chart Zoom Limits
+category: Charts
+---
+
+Every chart holds detail down to a certain resolution and no further. Zoom in past that
+point and you aren't shown more information — you're shown the last real chart data
+magnified, which looks sharper than it is. Freeboard gives you two controls over what
+happens at that boundary.
+
+## Constrain map zoom
+
+The **Constrain map zoom** button (the `zoom_in_map` icon on the right-hand toolbar) stops
+the map at the edge of your chart data. Turn it on and you simply cannot zoom in — or out —
+beyond the range your selected charts actually cover. The button highlights while active,
+and the zoom **+** / **−** buttons grey out once you reach a limit.
+
+The limits are taken from the **widest** range across all currently selected charts: the
+lowest minimum zoom and the highest maximum zoom of any of them. Selecting or deselecting
+charts recalculates it, so the constraint always reflects what you have switched on. Charts
+that don't declare their own zoom range fall back to a 0–24 range. With the setting off,
+the map is free to move between zoom 2 and 28 regardless of what your charts hold.
+
+This is off by default. It matters most when you're working from downloaded or offline
+chart sets — a cached raster or MBTiles collection on a boat with no internet — where
+zooming past the data can't be rescued by fetching better tiles, and where a magnified
+tile can read as detail that was never surveyed.
+
+## Keep tiles visible on max zoom
+
+The companion setting, **Keep tiles visible on max zoom** (Settings → Map), decides what a
+chart layer does once you pass *its* maximum zoom. Leave it on — it is on by default — and
+the chart keeps drawing, stretched, instead of disappearing. Turn it off and each layer
+stops rendering beyond the resolution it genuinely has, leaving the chart blank there.
+
+It also matters when charts of different resolutions are stacked. In a selection mixing a
+wide-area chart with a detailed harbour chart, the lower-resolution one keeps rendering
+(stretched) up to the map's maximum rather than dropping out as you zoom in.
+
+The two settings answer different questions: *Constrain map zoom* decides **whether you can
+get there at all**, while *Keep tiles visible on max zoom* decides **what you see if you
+do**. With the defaults — constrain off, keep-tiles on — you can zoom freely and charts
+stay visible but progressively blurrier past their real detail.

--- a/src/app/modules/features/feature-browser-dialog.html
+++ b/src/app/modules/features/feature-browser-dialog.html
@@ -90,9 +90,9 @@
               {{ e.date ? (e.date | date: 'mediumDate') : '' }}
             </td>
             <td class="pr-num">
-              <a [href]="prUrl(e.pr)" target="_blank" rel="noopener"
-                >#{{ e.pr }}</a
-              >
+              @if (e.pr; as pr) {
+              <a [href]="prUrl(pr)" target="_blank" rel="noopener">#{{ pr }}</a>
+              }
             </td>
             <td class="pr-title">{{ e.title }}</td>
           </tr>

--- a/src/app/modules/features/feature-corpus.spec.ts
+++ b/src/app/modules/features/feature-corpus.spec.ts
@@ -167,6 +167,26 @@ describe('compileCorpus', () => {
   it('handles an empty corpus', () => {
     expect(compileCorpus({ docs: [], ledger: [] })).toEqual([]);
   });
+
+  it('supports a row with no PR (a change predating the PR workflow)', () => {
+    const old = compileCorpus({
+      docs: [doc('old', { title: 'Old', category: 'Charts' }, 'b')],
+      ledger: [
+        {
+          feature: 'old',
+          kind: 'new',
+          since: 'v2.1.0',
+          date: '2023-07-06',
+          title: 'limit zoom to selected maps'
+        }
+      ]
+    })[0];
+    expect(old.since).toBe('v2.1.0');
+    expect(old.latestKind).toBe('new');
+    // null (not undefined) so the template can guard the PR link on it
+    expect(old.events[0].pr).toBeNull();
+    expect(old.events[0].title).toBe('limit zoom to selected maps');
+  });
 });
 
 describe('sortFeatures', () => {

--- a/src/app/modules/features/feature-corpus.ts
+++ b/src/app/modules/features/feature-corpus.ts
@@ -21,7 +21,8 @@ export type FeatureChangeKind = 'new' | 'enhanced' | 'skip';
 /** One append-only change event from `features/changelog.json`. */
 export interface FeatureLedgerRow {
   feature: string | null;
-  pr: number;
+  /** Absent for changes that predate the PR workflow (direct commits). */
+  pr?: number | null;
   kind: FeatureChangeKind;
   since?: string | null;
   /** ISO date (e.g. "2026-05-08") the change landed. */
@@ -46,7 +47,8 @@ export interface FeatureCorpusPayload {
 
 /** One PR that changed a feature — a row in the details pane's history table. */
 export interface FeatureEvent {
-  pr: number;
+  /** Null when the change predates the PR workflow — rendered without a link. */
+  pr: number | null;
   date: string | null;
   /** PR title with any `type(scope):` prefix stripped. */
   title: string;
@@ -203,7 +205,7 @@ export function compileCorpus(
           ? latest.kind
           : null,
       events: rows.map((r) => ({
-        pr: r.pr,
+        pr: r.pr ?? null,
         date: r.date ?? null,
         title: stripTypePrefix(r.title ?? '')
       })),
@@ -217,7 +219,7 @@ function compareEvent(a: FeatureLedgerRow, b: FeatureLedgerRow): number {
   const da = a.date ?? '';
   const db = b.date ?? '';
   if (da !== db) return da < db ? -1 : 1;
-  return a.pr - b.pr;
+  return (a.pr ?? 0) - (b.pr ?? 0);
 }
 
 const TYPE_PREFIX_RE =


### PR DESCRIPTION
Documents the **Constrain map zoom** toolbar button and its companion **Keep tiles visible on max zoom** setting as one feature — they're two halves of the same user question ("why is my chart blurry / why won't it zoom further"), so splitting them across two docs would make neither answer it.

The feature has shipped since **v2.1.0** but was never in the corpus, so it appears with a `new` row at that release rather than as something introduced now. It won't surface in the 3.0.0 release notes' New Features section, which is correct — it isn't new here.

That row exposed a gap: it predates the PR workflow (a direct commit, no PR), and the history table rendered a missing `pr` as a `#` linking to `/pull/undefined`. The PR cell is now guarded, `FeatureLedgerRow.pr` is optional, `FeatureEvent.pr` is nullable, and `compareEvent` no longer yields `NaN` when sorting a row without one. Any future catch-up doc for a pre-2024 feature needs this.

Deliberately **not** recorded here: the recent startup fix (#553). It restored behaviour the feature already promised — neither `new` nor `enhanced` — so it stays out of the ledger and keeps its place in the release notes' Bug Fixes section, which is driven by commits *absent* from the ledger.

@coderabbitai ignore
