### PR TITLE
fix(map): treat sub-knot SOG noise as stopped for cursor ETA

### DIFF
--- a/src/app/modules/map/cursor-eta.spec.ts
+++ b/src/app/modules/map/cursor-eta.spec.ts
@@ -27,6 +27,13 @@ describe('computeCursorEta', () => {
     expect(info.timeToGo).toBeCloseTo(info.distance / 3, 5);
   });
 
+  it('treats sub-knot SOG noise while moored as stopped (#555)', () => {
+    // A GPS SOG spike of ~0.5 kn (0.257 m/s) at anchor must not be used directly
+    // (it would yield an absurd multi-day ETA); fall back to the reference speed.
+    const info = computeCursorEta(FROM, TO, 0.257, 3);
+    expect(info.timeToGo).toBeCloseTo(info.distance / 3, 5);
+  });
+
   it('returns a null ETA when stopped with no reference speed', () => {
     const info = computeCursorEta(FROM, TO, 0, 0);
     expect(info.timeToGo).toBeNull();

--- a/src/app/modules/map/cursor-eta.ts
+++ b/src/app/modules/map/cursor-eta.ts
@@ -9,9 +9,13 @@ export interface CursorEtaInfo {
   timeToGo: number | null; // seconds; null when no usable speed
 }
 
-// Below this speed (m/s, ~0.1 kn) the vessel is treated as stopped and the
-// configured reference speed is used for the ETA instead of live SOG.
-const STOPPED_SOG_THRESHOLD = 0.05;
+// At or below this speed the vessel is treated as stopped and the configured reference
+// speed is used for the ETA instead of live SOG. Set at ~1 kn: at anchor or moored,
+// GPS SOG noise routinely spikes to several tenths of a knot — still not making way,
+// but a lower threshold lets those spikes through and produces absurd multi-day ETAs
+// (#555). One knot is the point below which the vessel isn't making meaningful way,
+// so the reference speed gives a more useful estimate.
+const STOPPED_SOG_THRESHOLD = 1 / 1.94384; // ~0.514 m/s (1 kn)
 
 /**
  * Compute the cursor bearing, distance and ETA relative to the vessel position.


### PR DESCRIPTION
The "Live ETA at cursor" readout uses live SOG when the vessel is under way and
falls back to the configured reference speed when stopped. The stopped threshold
was ~0.1 kn, which is far below the SOG noise a receiver produces while moored or
at anchor — spikes of several tenths of a knot pass the threshold and get used
directly, so the ETA flips between "minutes" (reference speed) and "days/hours"
(the tiny noisy SOG) as the reading jitters.

Raise the threshold to 1 kn — the point below which the vessel isn't making
meaningful way — so that sub-knot noise falls back to the reference speed and the
ETA stays stable.

Adds a regression test covering a ~0.5 kn moored noise spike.

Closes #555

@coderabbitai ignore
