### PR TITLE
chore(recommends): update recommended plugins for v3.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     ],
     "recommends": [
       "signalk-charts-provider-simple",
-      "signalk-flags",
-      "signalk-buddylist-plugin",
+      "signalk-instrument-widgets",
+      "signalk-symbol-manager",
+      "@signalk/open-meteo-provider",
+      "signalk-basic-tide-widgets",
       "signalk-restricted-areas"
     ]
   },


### PR DESCRIPTION
Refresh the App Store "recommended plugins" list for the v3.0 release, replacing plugins that no longer reflect the recommended companion set with the current ones (instrument widgets, symbol manager, Open-Meteo provider, basic tide widgets).

Closes #558

@coderabbitai ignore
