### PR TITLE
fix(map): draw lines crossing the dateline without jumping across the map

### DIFF
--- a/src/app/modules/map/ol/lib/charts/layer-chart-bounds.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-chart-bounds.component.ts
@@ -144,16 +144,13 @@ export class ChartBoundsLayerComponent extends FBFeatureLayerComponent {
         bounds[3] === 90)
     )
       return [];
-    const rect = mapifyCoords(
-      [
-        [bounds[0], bounds[1]],
-        [bounds[2], bounds[1]],
-        [bounds[2], bounds[3]],
-        [bounds[0], bounds[3]],
-        [bounds[0], bounds[1]]
-      ],
-      0
-    );
+    const rect = mapifyCoords([
+      [bounds[0], bounds[1]],
+      [bounds[2], bounds[1]],
+      [bounds[2], bounds[3]],
+      [bounds[0], bounds[3]],
+      [bounds[0], bounds[1]]
+    ]);
     return [fromLonLatArray(rect)];
   }
 }

--- a/src/app/modules/map/ol/lib/util.spec.ts
+++ b/src/app/modules/map/ol/lib/util.spec.ts
@@ -66,9 +66,9 @@ describe('mapifyCoords', () => {
   });
 
   it('unwraps relative to the preceding point, not the first point', () => {
-    // Regression: the previous implementation compared every point against
-    // coords[0], so a line approaching the antimeridian from far away was
-    // shifted a whole world backwards partway along.
+    // Each point is resolved against its immediate predecessor, so a line
+    // approaching the antimeridian from far away is carried across it rather
+    // than shifted a whole world backwards partway along.
     const coords: Array<Coordinate> = [
       [-50, 0],
       [0, 0],
@@ -100,8 +100,8 @@ describe('mapifyCoords', () => {
   });
 
   it('unwraps a crossing regardless of distance from the antimeridian', () => {
-    // Previously only points within 10 degrees of the antimeridian were
-    // considered, so a sparsely sampled track stepped straight over it.
+    // A crossing is unwrapped on the size of the step alone, so a sparsely
+    // sampled track is carried across however far its samples land from 180.
     expect(
       lons(
         mapifyCoords([
@@ -125,6 +125,25 @@ describe('mapifyCoords', () => {
     ).toEqual([-175, -170]);
   });
 
+  it('preserves an optional third ordinate', () => {
+    // A GeoJSON position may carry altitude; only longitude is ever adjusted.
+    const result = mapifyCoords([
+      [170, 10, 5],
+      [-170, 20, 7]
+    ]);
+    expect(result).toEqual([
+      [170, 10, 5],
+      [190, 20, 7]
+    ]);
+  });
+
+  it('shifts a far out-of-range longitude in a single step', () => {
+    // Whole turns are removed arithmetically, so an implausible longitude
+    // resolves immediately rather than by repeated 360 degree subtraction.
+    expect(lons(mapifyCoords([[1e6, 0]]))[0]).toBeGreaterThanOrEqual(-180);
+    expect(lons(mapifyCoords([[1e6, 0]]))[0]).toBeLessThanOrEqual(180);
+  });
+
   it('preserves vertex count, order and latitudes', () => {
     // Route editing maps the rendered coordinates 1:1 back onto waypoints, so
     // unwrapping must never add, drop or reorder a vertex.
@@ -140,9 +159,8 @@ describe('mapifyCoords', () => {
   });
 
   it('does not mutate the input coordinates', () => {
-    // Regression: the previous implementation wrote longitudes back through the
-    // caller's tuples, corrupting the cached Signal K resource coordinates that
-    // callers pass in directly.
+    // The caller retains ownership of its tuples: callers pass cached Signal K
+    // resource coordinates in directly, and those must survive rendering.
     const coords: Array<Coordinate> = [
       [170, 0],
       [-170, 0]

--- a/src/app/modules/map/ol/lib/util.spec.ts
+++ b/src/app/modules/map/ol/lib/util.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { mapifyCoords } from './util';
+import { Coordinate } from './models';
+
+/** Longitudes of a coordinate list, for concise assertions. */
+const lons = (coords: Array<Coordinate>) => coords.map((c) => c[0]);
+
+/** Largest longitude step between consecutive points. */
+const maxStep = (coords: Array<Coordinate>) =>
+  coords
+    .slice(1)
+    .reduce((max, c, i) => Math.max(max, Math.abs(c[0] - coords[i][0])), 0);
+
+describe('mapifyCoords', () => {
+  it('returns an empty array for empty input', () => {
+    expect(mapifyCoords([])).toEqual([]);
+  });
+
+  it('returns a single point unchanged', () => {
+    expect(mapifyCoords([[90, 45]])).toEqual([[90, 45]]);
+  });
+
+  it('leaves a line that does not cross the antimeridian unchanged', () => {
+    const coords: Array<Coordinate> = [
+      [0, 0],
+      [10, 5],
+      [20, 10]
+    ];
+    expect(mapifyCoords(coords)).toEqual(coords);
+  });
+
+  it('unwraps an eastbound crossing to continuous longitudes past +180', () => {
+    // 170E -> 170W travelling east is 20 degrees, not 340.
+    expect(
+      lons(
+        mapifyCoords([
+          [170, 0],
+          [-170, 0]
+        ])
+      )
+    ).toEqual([170, 190]);
+  });
+
+  it('unwraps a westbound crossing to continuous longitudes past -180', () => {
+    expect(
+      lons(
+        mapifyCoords([
+          [-170, 0],
+          [170, 0]
+        ])
+      )
+    ).toEqual([-170, -190]);
+  });
+
+  it('unwraps repeated crossings back and forth', () => {
+    expect(
+      lons(
+        mapifyCoords([
+          [170, 0],
+          [-170, 0],
+          [170, 0],
+          [-170, 0]
+        ])
+      )
+    ).toEqual([170, 190, 170, 190]);
+  });
+
+  it('unwraps relative to the preceding point, not the first point', () => {
+    // Regression: the previous implementation compared every point against
+    // coords[0], so a line approaching the antimeridian from far away was
+    // shifted a whole world backwards partway along.
+    const coords: Array<Coordinate> = [
+      [-50, 0],
+      [0, 0],
+      [50, 0],
+      [100, 0],
+      [150, 0],
+      [170, 0],
+      [179, 0],
+      [-179, 0]
+    ];
+    expect(lons(mapifyCoords(coords))).toEqual([
+      -50, 0, 50, 100, 150, 170, 179, 181
+    ]);
+  });
+
+  it('never leaves a step wider than half a world', () => {
+    // The invariant the renderer relies on: no segment may span more than 180
+    // degrees, or it draws the long way around the globe.
+    const coords: Array<Coordinate> = [
+      [-50, 10],
+      [60, 12],
+      [150, 14],
+      [179, 16],
+      [-179, 18],
+      [-100, 20],
+      [-20, 22]
+    ];
+    expect(maxStep(mapifyCoords(coords))).toBeLessThanOrEqual(180);
+  });
+
+  it('unwraps a crossing regardless of distance from the antimeridian', () => {
+    // Previously only points within 10 degrees of the antimeridian were
+    // considered, so a sparsely sampled track stepped straight over it.
+    expect(
+      lons(
+        mapifyCoords([
+          [160, 0],
+          [-160, 0]
+        ])
+      )
+    ).toEqual([160, 200]);
+  });
+
+  it('normalises a first point outside [-180, 180]', () => {
+    // Anchors the line in the primary world so it stays inside the range
+    // OpenLayers replicates into adjacent world copies.
+    expect(
+      lons(
+        mapifyCoords([
+          [185, 0],
+          [190, 0]
+        ])
+      )
+    ).toEqual([-175, -170]);
+  });
+
+  it('preserves vertex count, order and latitudes', () => {
+    // Route editing maps the rendered coordinates 1:1 back onto waypoints, so
+    // unwrapping must never add, drop or reorder a vertex.
+    const coords: Array<Coordinate> = [
+      [175, 10],
+      [179, 20],
+      [-178, 30],
+      [-170, 40]
+    ];
+    const result = mapifyCoords(coords);
+    expect(result).toHaveLength(coords.length);
+    expect(result.map((c) => c[1])).toEqual([10, 20, 30, 40]);
+  });
+
+  it('does not mutate the input coordinates', () => {
+    // Regression: the previous implementation wrote longitudes back through the
+    // caller's tuples, corrupting the cached Signal K resource coordinates that
+    // callers pass in directly.
+    const coords: Array<Coordinate> = [
+      [170, 0],
+      [-170, 0]
+    ];
+    const snapshot = coords.map((c) => [c[0], c[1]]);
+    mapifyCoords(coords);
+    expect(coords).toEqual(snapshot);
+  });
+});

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -40,44 +40,46 @@ export function fromLonLatArray(
   }
 }
 
-/** DateLine Crossing:
- * returns true if point is in the zone for dateline transition
- * zoneValue: lower end of 180 to xx range within which Longitude must fall for retun value to be true
- **/
-export function inDLCrossingZone(coord: Coordinate, zoneValue = 170) {
-  return Math.abs(coord[0]) >= zoneValue ? true : false;
-}
-
-// update linestring coords for map display (including dateline crossing)
-export function mapifyCoords(
-  coords: Array<Coordinate>,
-  zoneValue?: number
-): Array<Coordinate> {
-  if (coords.length === 0) {
-    return coords;
+/**
+ * Unwrap longitudes for map display so consecutive points never jump more than
+ * half a world.
+ *
+ * A line stored in [-180, 180] is ambiguous at the antimeridian: successive
+ * points at 179 and -179 are 2 degrees apart on the water but 358 apart
+ * numerically, so the line renders the long way around the globe. Shifting each
+ * point by a multiple of 360 relative to its predecessor makes the sequence
+ * continuous and the rendered segment short.
+ *
+ * Each longitude only ever gains a multiple of 360, so vertex count, order and
+ * latitudes are preserved and the result maps 1:1 back onto the input — which is
+ * what lets an unwrapped geometry stay editable. The first point is normalised
+ * into [-180, 180] so the geometry starts in the primary world; OpenLayers
+ * replicates geometry into adjacent world copies out to +/-540 degrees, and
+ * anchoring the start keeps a line within that range.
+ *
+ * The input is left untouched — callers pass cached Signal K resource
+ * coordinates straight in.
+ */
+export function mapifyCoords(coords: Array<Coordinate>): Array<Coordinate> {
+  const out: Array<Coordinate> = coords.map((c) => [c[0], c[1]] as Coordinate);
+  if (out.length === 0) {
+    return out;
   }
-  let dlCrossing = 0;
-  const last = coords[0];
-  for (let i = 0; i < coords.length; i++) {
-    if (
-      inDLCrossingZone(coords[i], zoneValue) ||
-      inDLCrossingZone(last, zoneValue)
-    ) {
-      dlCrossing =
-        last[0] > 0 && coords[i][0] < 0
-          ? 1
-          : last[0] < 0 && coords[i][0] > 0
-            ? -1
-            : 0;
-      if (dlCrossing === 1) {
-        coords[i][0] = coords[i][0] + 360;
-      }
-      if (dlCrossing === -1) {
-        coords[i][0] = Math.abs(coords[i][0]) - 360;
-      }
+  while (out[0][0] > 180) {
+    out[0][0] -= 360;
+  }
+  while (out[0][0] < -180) {
+    out[0][0] += 360;
+  }
+  for (let i = 1; i < out.length; i++) {
+    while (out[i][0] - out[i - 1][0] > 180) {
+      out[i][0] -= 360;
+    }
+    while (out[i - 1][0] - out[i][0] > 180) {
+      out[i][0] += 360;
     }
   }
-  return coords;
+  return out;
 }
 
 // ** return adjusted radius to correctly render circle on ground at given position.

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -61,22 +61,24 @@ export function fromLonLatArray(
  * coordinates straight in.
  */
 export function mapifyCoords(coords: Array<Coordinate>): Array<Coordinate> {
-  const out: Array<Coordinate> = coords.map((c) => [c[0], c[1]] as Coordinate);
+  // Spread rather than [c[0], c[1]] so an optional third ordinate survives.
+  const out: Array<Coordinate> = coords.map((c) => [...c] as Coordinate);
   if (out.length === 0) {
     return out;
   }
-  while (out[0][0] > 180) {
-    out[0][0] -= 360;
-  }
-  while (out[0][0] < -180) {
-    out[0][0] += 360;
+  // Shift by whole turns in one step. Repeated -= 360 would spin for an
+  // impractical number of iterations on a wildly out-of-range longitude.
+  if (out[0][0] > 180) {
+    out[0][0] -= 360 * Math.ceil((out[0][0] - 180) / 360);
+  } else if (out[0][0] < -180) {
+    out[0][0] += 360 * Math.ceil((-180 - out[0][0]) / 360);
   }
   for (let i = 1; i < out.length; i++) {
-    while (out[i][0] - out[i - 1][0] > 180) {
-      out[i][0] -= 360;
-    }
-    while (out[i - 1][0] - out[i][0] > 180) {
-      out[i][0] += 360;
+    const delta = out[i][0] - out[i - 1][0];
+    if (delta > 180) {
+      out[i][0] -= 360 * Math.ceil((delta - 180) / 360);
+    } else if (delta < -180) {
+      out[i][0] += 360 * Math.ceil((-180 - delta) / 360);
     }
   }
   return out;


### PR DESCRIPTION
A track, trail or route that crosses the dateline could render as a line whipping right across the map instead of the short hop it actually is.

> **Origin:** the `mapifyCoords` rewrite here — predecessor-relative unwrapping, non-mutating, zone heuristic removed — originated in @daniel-freiermuth's #364 (commits 80b48baf6 / e0ad2a2a0). This PR extracts it and adapts the tests from that branch so it can land independently of the antimeridian route work. Credit for the fix is his.

OpenLayers already handles the wrapping world for us. Its vector renderer replicates geometry into every visible world copy, and it accepts coordinates that run continuously past ±180° — out to ±540°. All Freeboard has to do is hand it a line whose longitudes are continuous, which is the entire job of `mapifyCoords`. The bug was that Freeboard often handed over a *discontinuous* line, so the support OpenLayers already provides never got the chance to engage.

Three things caused that:

- Every point was compared against `coords[0]` rather than its predecessor, so a line approaching the dateline from far away was shifted a whole world backwards partway along — a track running from -50 to -179 came back as `… 150, -190, -181, -179` and drew straight across the map.
- Unwrapping only applied within 10° of the dateline, so a sparsely sampled track that stepped over 180 without landing near it was never unwrapped at all.
- Longitudes were written back through the caller's tuples. Callers pass cached Signal K resource coordinates directly, so rendering a route mutated the stored route.

Unwrapping now works off the preceding point, copies before writing, and drops the proximity heuristic along with the now-unused `inDLCrossingZone`. Vertex count and order are preserved — each longitude only ever gains a multiple of 360 — so unwrapped geometry maps 1:1 back onto its source and stays editable.

This is the shared helper behind 13 map layers, so the fix also covers laylines, XTE path, bearing line, target angle, regions, anchor/CPA alarms, the racing start line and chart bounds. The 2-point layers are provably unaffected (no consecutive pair can exceed 180°), and `layer-chart-bounds` was passing `zoneValue: 0` to force what is now the default.

Groundwork for SignalK/freeboard-sk#364, which needs correct unwrapping before it can drop its route-splitting machinery.

### Test plan

- [x] New `util.spec.ts` — 12 cases; the 5 covering the fixed behaviour fail against the previous implementation and pass against this one
- [x] `npm run test:ci` — 273 tests across 36 files pass
- [x] `npm run build:web` — clean
- [x] Prettier check — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map line rendering across the international date line, preventing unexpected jumps and preserving continuous paths.
  * Ensured coordinate data remains unchanged during map processing.
  * Improved handling of coordinates that begin outside the standard longitude range.

* **Tests**
  * Added comprehensive coverage for date-line crossings, repeated crossings, coordinate preservation, and longitude continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
