### PR TITLE
feat(radar): Support Radar API 3.4.0 in the radar overlay (with pre-3.4.0 fallback)

### DIFF
--- a/src/app/modules/map/ol/lib/radar/radar-render.service.ts
+++ b/src/app/modules/map/ol/lib/radar/radar-render.service.ts
@@ -63,11 +63,17 @@ export class RadarRenderService {
     return {
       id: this.radarApi.radar().device.id,
       name: this.radarApi.radar().device.name,
-      spokesPerRevolution: this.radarApi.radar().device.spokesPerRevolution,
-      maxSpokeLen: this.radarApi.radar().device.maxSpokeLen,
+      // Spoke geometry comes from /capabilities (present on both old and new
+      // servers). Radar API 3.4.0 streams binary spokes from …/{id}/spokes;
+      // pre-3.4.0 servers (no version in the discovery envelope) use …/{id}/stream.
+      spokesPerRevolution:
+        this.radarApi.radar().capabilities.spokesPerRevolution,
+      maxSpokeLen: this.radarApi.radar().capabilities.maxSpokeLength,
       streamUrl: `${this.app.hostDef.ssl ? 'wss' : 'ws'}://${this.app.hostDef.name}:${
         this.app.hostDef.port
-      }/signalk/v2/api/vessels/self/radars/${this.radarApi.radarId()}/stream`,
+      }/signalk/v2/api/vessels/self/radars/${this.radarApi.radarId()}/${
+        this.radarApi.apiVersion() ? 'spokes' : 'stream'
+      }`,
       legend: legend
     };
   }

--- a/src/app/modules/radar/radar-api.service.ts
+++ b/src/app/modules/radar/radar-api.service.ts
@@ -248,13 +248,20 @@ export class RadarAPIService {
             // Legacy (pre-3.4.0) servers return a bare array (no version).
             this._apiVersion.set('');
             resolve(val);
-          } else if (val && typeof val.radars === 'object') {
+          } else if (
+            val &&
+            val.radars !== null &&
+            typeof val.radars === 'object' &&
+            !Array.isArray(val.radars)
+          ) {
             // Radar API 3.4.0: { version, radars } keyed by radar id.
             this._apiVersion.set(val.version ?? '');
             resolve(
               Object.entries(val.radars).map(([id, info]) => ({ ...info, id }))
             );
           } else {
+            // Malformed / unexpected response — fall back to no radars.
+            this._apiVersion.set('');
             resolve([]);
           }
         },

--- a/src/app/modules/radar/radar-api.service.ts
+++ b/src/app/modules/radar/radar-api.service.ts
@@ -12,15 +12,21 @@ export interface SKRadarLegendEntry {
   color: string;
 }
 
+// Radar discovery entry (Radar API 3.4.0: lean RadarInfo). `id` is the map key
+// in the /radars envelope, folded back into the entry. Static parameters
+// (spokesPerRevolution, maxSpokeLength, legend) live on /capabilities.
 export interface SKRadar {
   id: string;
   name: string;
   brand: string;
-  status: string;
-  spokesPerRevolution: number;
-  maxSpokeLen: number;
-  range: number;
-  controls: Record<string, Record<string, any>>;
+  model?: string;
+  radarIpAddress?: string;
+}
+
+// GET /radars response envelope (Radar API 3.4.0)
+export interface RadarsResponse {
+  version: string;
+  radars: Record<string, Omit<SKRadar, 'id'>>;
 }
 
 export interface CapabilityManifest {
@@ -28,7 +34,7 @@ export interface CapabilityManifest {
   minRange: number;
   supportedRanges: Array<number>;
   spokesPerRevolution: number;
-  maxSpokeLen: number;
+  maxSpokeLength: number;
   pixelValues: number;
   legend: {
     dopplerApproaching: [number, number];
@@ -98,6 +104,10 @@ export class RadarAPIService {
   readonly radarId = this._selectedRadar.asReadonly();
   private _radar = signal<ActiveRadar>(undefined);
   readonly radar = this._radar.asReadonly();
+  // Radar API version reported by GET /radars. Empty for pre-3.4.0 servers,
+  // which return a bare array with no version envelope.
+  private _apiVersion = signal<string>('');
+  readonly apiVersion = this._apiVersion.asReadonly();
 
   private app = inject(AppFacade);
   private signalk = inject(SignalKClient);
@@ -192,6 +202,9 @@ export class RadarAPIService {
       this._radar.set(undefined);
       return;
     }
+    // Radar API 3.4.0: the discovery object is lean and carries no id; fold in
+    // the selected id so consumers (info panel, render, panel) can read it.
+    rd['device'].id = this._selectedRadar();
     // filter controls
     const baseControls = new Map<string, any>();
     const cdef = rd['capabilities']['controls'];
@@ -228,10 +241,22 @@ export class RadarAPIService {
 
   /** Return list of available radars */
   public async listRadars(): Promise<SKRadar[]> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this.signalk.api.get(this.app.skApiVersion, this.basePath).subscribe({
-        next: (val: SKRadar[]) => {
-          resolve(Array.isArray(val) ? val : []);
+        next: (val: SKRadar[] | RadarsResponse) => {
+          if (Array.isArray(val)) {
+            // Legacy (pre-3.4.0) servers return a bare array (no version).
+            this._apiVersion.set('');
+            resolve(val);
+          } else if (val && typeof val.radars === 'object') {
+            // Radar API 3.4.0: { version, radars } keyed by radar id.
+            this._apiVersion.set(val.version ?? '');
+            resolve(
+              Object.entries(val.radars).map(([id, info]) => ({ ...info, id }))
+            );
+          } else {
+            resolve([]);
+          }
         },
         error: () => resolve([])
       });


### PR DESCRIPTION
The Radar API is moving to **3.4.0**, which changes the discovery response to a `{ version, radars }` envelope keyed by radar id, and renames the binary spoke stream endpoint from `/stream` to `/spokes`. This updates the radar overlay client to the 3.4.0 shape while keeping it working against pre-3.4.0 servers, so a single build supports both.

**How**
- `GET /radars`: parse the `{ version, radars }` envelope (id comes from the map key) and still accept the legacy bare array. The reported version is exposed via `apiVersion()`.
- Spoke geometry (`spokesPerRevolution`, `maxSpokeLength`) is sourced from `/capabilities`, which both old and new servers provide; the selected id is folded into the (now lean) discovery object.
- The binary spoke stream endpoint is chosen by the reported version: `…/{id}/spokes` for 3.4.0, `…/{id}/stream` for pre-3.4.0.
- `CapabilityManifest`: `maxSpokeLen` → `maxSpokeLength` (matches the server).

**Testing**
Verified end-to-end with the same production build against both a 3.4.0 server (mayara-server 3.4.0 + signalk-server) and a pre-3.4.0 server: radars are discovered and live spokes render via the appropriate endpoint. Typecheck and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Radar API 3.4.0 discovery responses.
  - Radar streaming now automatically uses the correct endpoint for the detected API version.
  - Radar rendering uses advertised capabilities for spoke count and maximum spoke length.

- **Bug Fixes**
  - Improved compatibility with both current and legacy radar servers.
  - Preserved radar selection and display details when using the updated discovery format.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->