### PR TITLE
fix(map): keep popups and route editing aligned when the map is scrolled a full world sideways

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,29 @@ live.)
   values omit it. Don't call `Convert` directly for display — `Convert` is the pure
   primitive for geometry and numeric math only. See
   [`docs/signalk/unit-preferences.md`](docs/signalk/unit-preferences.md).
+- **Map coordinates → keep render space and data space separate.** The map deals
+  with two coordinate spaces and must not confuse them:
+  - **Data space** — canonical WGS84 in `[-180, 180]`. Everything persisted to the
+    Signal K server, streamed, displayed, or read by another app. GeoJSON requires
+    it (RFC 7946 §3.1.9); a stored longitude of `197` is malformed and other
+    consumers may reject it. **Normalise at every data boundary** (`toLonLat`
+    already does this on the way in; the save path re-normalises on the way out).
+  - **Render space** — EPSG:3857 Mercator, world-copy-aware. OpenLayers pans
+    horizontally without limit and replicates geometry into every visible world
+    copy out to ±540° (see the *reading / exploring* lesson on the wrapping world),
+    so a click east/west of the primary world carries an x outside one world width.
+    This offset is what lets a popover or an edited vertex land in the copy the user
+    is actually looking at.
+  - **The rule.** When you convert a pointer event to a coordinate, place an
+    overlay, or hit-test/​edit a feature, carry the **world offset** in render space
+    and apply it in Mercator — never bake it into a lon/lat (that would leak an
+    out-of-range value toward storage). The shared machinery: `worldCopyOffset()`
+    (`ol/lib/util.ts`) computes the offset; map click events carry it as
+    `worldOffset`; `ol-overlay`'s `worldOffset` input places an overlay in that copy
+    while its `position` stays canonical; `Modify` edits shift the feature by a
+    whole-world offset (visually transparent under wrapX, normalised on save). Route
+    them through these rather than re-deriving with ad-hoc `toLonLat`/`fromLonLat`
+    or `±360` shifts — that fragmentation is exactly what #572 consolidated.
 - **Tests.** New behaviour needs tests where the test infrastructure supports it
   (`*.spec.ts`, run via `npm run test:ci`). Test behaviour, not implementation.
 

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -511,7 +511,11 @@
 
   <!-- Distance & Bearing to -->
   @if (overlay().show && overlay().type === 'bearing_dist') {
-    <ol-overlay [position]="overlay().position" [positioning]="'top-center'">
+    <ol-overlay
+      [position]="overlay().position"
+      [worldOffset]="overlay().worldOffset ?? 0"
+      [positioning]="'top-center'"
+    >
       <ap-popover
         [title]="overlay().title"
         [canClose]="false"
@@ -539,7 +543,11 @@
 
   <!-- Popovers -->
   @if (overlay().show && !mapInteract.isModifying()) {
-    <ol-overlay [position]="overlay().position" [positioning]="'top-center'">
+    <ol-overlay
+      [position]="overlay().position"
+      [worldOffset]="overlay().worldOffset ?? 0"
+      [positioning]="'top-center'"
+    >
       @if (mapInteract.isMeasuring()) {
         <ap-popover
           [title]="overlay().title"

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -42,7 +42,7 @@ import { FreeboardOpenlayersModule } from 'src/app/modules/map/ol';
 import { CoordsPipe } from 'src/app/lib/pipes';
 
 import { computeDestinationPoint, getGreatCircleBearing } from 'geolib';
-import { toLonLat } from 'ol/proj';
+import { fromLonLat, toLonLat } from 'ol/proj';
 import { Style, Stroke, Fill } from 'ol/style';
 import { Collection, Feature } from 'ol';
 import { Feature as GeoJsonFeature } from 'geojson';
@@ -122,6 +122,7 @@ import { ScaleLine } from 'ol/control';
 import { Units } from 'ol/control/ScaleLine';
 import { DragBoxEvent } from 'ol/interaction/DragBox';
 import { MapService } from './ol/lib/map.service';
+import { worldCopyOffset } from './ol/lib/util';
 import { AppIconDef } from '../icons';
 import { LayerWindWeatherComponent } from './ol/lib/resources/layer-wind-weather.component';
 import { LayerCurrentsWeatherComponent } from './ol/lib/resources/layer-currents-weather.component';
@@ -285,6 +286,19 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   private saveTimer;
   private isDirty = false;
+  /**
+   * EPSG:3857-metre offset of the world copy the most recent click landed in.
+   * Passed to overlays so a popover is drawn in the copy the user clicked, not
+   * the primary world. Render-space only — never written to stored data (#572).
+   */
+  private clickWorldOffset = 0;
+  /**
+   * Raw EPSG:3857 x of the most recent click, world-copy-aware. Used to align an
+   * edited feature with the copy the user is looking at before Modify hit-tests
+   * it (a route's own coordinates may be unwrapped past ±180, so the click's
+   * world alone isn't enough — align by the feature's extent). See #572.
+   */
+  private clickMercX = 0;
 
   // Cursor position readout. A signal so the readout (and measure overlay)
   // refresh when pointer-move runs OUTSIDE the Angular zone (see MapComponent).
@@ -530,20 +544,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
           }
         }
       }
-      if (this.app.mapExtent()[0] < 180 && this.app.mapExtent()[2] > 180) {
-        // if dateline is in view adjust overlay position to stay with vessel
-
-        if (
-          this.overlay().position[0] < 0 &&
-          this.overlay().position[0] > -180
-        ) {
-          this.overlay.update((current) => {
-            return Object.assign({}, current, {
-              position: [current.position[0] + 360, current.position[1]]
-            });
-          });
-        }
-      }
+      // The popover follows the vessel in whichever world copy it was opened in:
+      // position stays canonical and the overlay's worldOffset (preserved across
+      // these updates) draws it in the right copy (#572).
     }
     this.drawVesselLines(this.app.data.vessels.self.positionReceived);
     this.rotateMap();
@@ -676,6 +679,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
         this.overlay.update((current) => {
           return Object.assign({}, current, {
             position: c,
+            // Keep the live measure label in the pointer's world copy (#572).
+            worldOffset: e.worldOffset ?? 0,
             title: `${this.app.formatValueForDisplay(
               lm,
               'm'
@@ -692,6 +697,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
         this.overlay.update((current) => {
           return Object.assign({}, current, {
             position: c,
+            // Keep the live measure label in the pointer's world copy (#572).
+            worldOffset: e.worldOffset ?? 0,
             title: `${this.app.formatValueForDisplay(
               lm,
               'm'
@@ -744,6 +751,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   protected onMapSingleClick(e) {
+    // Remember which world copy this click landed in so any popover it opens is
+    // drawn there, and the raw world-aware x so a route edit aligns with it (#572).
+    this.clickWorldOffset = e.worldOffset ?? 0;
+    this.clickMercX = fromLonLat(e.lonlat)[0] + this.clickWorldOffset;
     this.app.data.map.atClick = {
       features: e.features,
       lonlat: e.lonlat
@@ -774,7 +785,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   /** Handle right click / touch hold */
-  protected onMapRightClick(e: { features: FeatureLike[]; lonlat: Position }) {
+  protected onMapRightClick(e: {
+    features: FeatureLike[];
+    lonlat: Position;
+    worldOffset?: number;
+  }) {
+    this.clickWorldOffset = e.worldOffset ?? 0;
+    this.clickMercX = fromLonLat(e.lonlat)[0] + this.clickWorldOffset;
     this.app.data.map.atClick = e;
     this.app.debug(`onRightClick()`, this.app.data.map.atClick);
     if (this.mapInteract.isMeasuring()) {
@@ -1020,6 +1037,29 @@ export class FBMapComponent implements OnInit, OnDestroy {
   protected modifyFeature(featureType?: string) {
     if (this.mapInteract.draw.features.getLength() === 0) {
       return;
+    }
+    // Align the edit feature with the world copy the user is looking at, so OL
+    // Modify (which hit-tests raw geometry in view-space, ignoring wrapX) matches
+    // where they click. A route's own coordinates may be unwrapped past ±180, so
+    // the click's world alone is wrong — align by the feature's extent centre:
+    // the whole-world shift that puts the feature centre in the clicked world.
+    // It's a whole-world translation, so wrapX still draws the feature in the same
+    // place (visually transparent), no vertices are added, and the edited
+    // coordinates normalise back to [-180,180] on save (#572).
+    const editGeom = (
+      this.mapInteract.draw.features.getArray()[0] as Feature
+    )?.getGeometry();
+    if (editGeom) {
+      // EPSG:3857 world width in metres (the map's Mercator projection).
+      const worldWidth = 2 * 20037508.342789244;
+      const ext = editGeom.getExtent();
+      const centreX = (ext[0] + ext[2]) / 2;
+      const shift = worldCopyOffset(this.clickMercX - centreX, worldWidth);
+      if (shift) {
+        this.mapInteract.draw.features.forEach((f: Feature) =>
+          f.getGeometry()?.translate(shift, 0)
+        );
+      }
     }
     this.mapInteract.startModifying(this.overlay());
     if (this.overlay().type === 'route') {
@@ -1393,6 +1433,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
       title: null,
       featureCount: this.mapInteract.draw.features?.getLength(),
       position: coord,
+      // Draw the popover in the world copy the opening click landed in. position
+      // stays canonical; this only shifts where it renders (#572).
+      worldOffset: this.clickWorldOffset,
       readOnly: false,
       isSelf: false
     };

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -26,6 +26,12 @@ export interface IPopover {
   type: string;
   icon?: string;
   position: Position;
+  /**
+   * Render-space offset (EPSG:3857 metres) of the world copy the user clicked
+   * in, relative to the primary world. `position` stays canonical (`[-180,180]`);
+   * this only shifts where the overlay is *drawn*, so it never leaks into data.
+   */
+  worldOffset?: number;
   show: boolean;
   title: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -24,7 +24,8 @@ import { AsyncSubject } from 'rxjs';
 import { toLonLat, transformExtent } from 'ol/proj';
 import { Coordinate } from 'ol/coordinate';
 import { FeatureLike } from 'ol/Feature';
-import { Extent } from 'ol/extent';
+import { Extent, getWidth } from 'ol/extent';
+import { worldCopyOffset } from './util';
 
 export interface FBMapEvent extends MapEvent {
   lonlat: Coordinate;
@@ -43,10 +44,14 @@ export interface FBMapEvent extends MapEvent {
 export interface FBClickEvent extends MapBrowserEvent<PointerEvent> {
   features: Array<FeatureLike>;
   lonlat: Coordinate;
+  /** EPSG:3857-metre offset of the clicked world copy from the primary world. */
+  worldOffset: number;
 }
 
 export interface FBPointerEvent extends MapBrowserEvent<PointerEvent> {
   lonlat: Coordinate;
+  /** EPSG:3857-metre offset of the pointer's world copy from the primary world. */
+  worldOffset: number;
 }
 
 // used for wind vector scaling
@@ -90,7 +95,12 @@ export class MapComponent implements OnInit, OnDestroy {
   @Output() mapRightClick: EventEmitter<{
     features: FeatureLike[];
     lonlat: Coordinate;
-  }> = new EventEmitter<{ features: FeatureLike[]; lonlat: Coordinate }>();
+    worldOffset: number;
+  }> = new EventEmitter<{
+    features: FeatureLike[];
+    lonlat: Coordinate;
+    worldOffset: number;
+  }>();
   @Output() mapContextMenu: EventEmitter<FBPointerEvent> =
     new EventEmitter<FBPointerEvent>();
   @Output() mapSingleClick: EventEmitter<FBClickEvent> =
@@ -336,8 +346,12 @@ export class MapComponent implements OnInit, OnDestroy {
         .getArray()
         .some((i) => i instanceof Modify && i.getActive());
       this.touchTimer = setTimeout(this.touchHold, modifying ? 1500 : 500);
-      const c = toLonLat(this.map.getEventCoordinate(event));
-      const e = Object.assign(event, { lonlat: c });
+      const rawCoord = this.map.getEventCoordinate(event);
+      const c = toLonLat(rawCoord);
+      const e = Object.assign(event, {
+        lonlat: c,
+        worldOffset: this.worldOffsetOf(rawCoord)
+      });
       this.mapService.clearFeatureUrls();
       this.mapPointerDown.emit(e);
       this._pointerDown.update(() => e);
@@ -368,7 +382,8 @@ export class MapComponent implements OnInit, OnDestroy {
             hitTolerance: this.hitTolerance
           }
         ),
-        lonlat: toLonLat(c)
+        lonlat: toLonLat(c),
+        worldOffset: this.worldOffsetOf(c)
       });
     });
   };
@@ -381,13 +396,24 @@ export class MapComponent implements OnInit, OnDestroy {
     this.ngZone.run(() => this.mapDblClick.emit(this.augmentClickEvent(event)));
   };
 
-  // ** add {lonlat, features}fields to event
+  // Render-space offset (EPSG:3857 metres) of the world copy a click landed in,
+  // relative to the primary world. `toLonLat` normalises a click to [-180,180]
+  // and so discards which copy the user was looking at; consumers that place an
+  // overlay or hit-test a feature need this offset to work in that copy. It stays
+  // in Mercator and never becomes a lon/lat, so it cannot leak into stored data.
+  private worldOffsetOf(coordinate: Coordinate): number {
+    const worldWidth = getWidth(this.map.getView().getProjection().getExtent());
+    return worldCopyOffset(coordinate[0], worldWidth);
+  }
+
+  // ** add {lonlat, worldOffset, features} fields to event
   private augmentClickEvent(event: MapBrowserEvent<PointerEvent>) {
     return Object.assign(event, {
       features: this.map.getFeaturesAtPixel(event.pixel, {
         hitTolerance: this.hitTolerance
       }),
-      lonlat: toLonLat(event.coordinate)
+      lonlat: toLonLat(event.coordinate),
+      worldOffset: this.worldOffsetOf(event.coordinate)
     });
   }
 
@@ -428,9 +454,12 @@ export class MapComponent implements OnInit, OnDestroy {
     this.mapPointerMove.emit(this.augmentPointerEvent(event));
   };
 
-  // ** add {lonlat} field to event
+  // ** add {lonlat, worldOffset} fields to event
   private augmentPointerEvent(event: MapBrowserEvent<PointerEvent>) {
-    return Object.assign(event, { lonlat: toLonLat(event.coordinate) });
+    return Object.assign(event, {
+      lonlat: toLonLat(event.coordinate),
+      worldOffset: this.worldOffsetOf(event.coordinate)
+    });
   }
 
   private emitPostComposeEvent = (event: RenderEvent) =>

--- a/src/app/modules/map/ol/lib/overlay.component.ts
+++ b/src/app/modules/map/ol/lib/overlay.component.ts
@@ -28,6 +28,13 @@ export class OverlayComponent implements OnInit, OnChanges, OnDestroy {
   @Input() className: string;
   @Input() offset: number[];
   @Input() position: Coordinate;
+  /**
+   * Render-space offset (EPSG:3857 metres) of the world copy to draw this
+   * overlay in. `position` is canonical lon/lat; this shifts only the drawn
+   * Mercator position so the overlay appears in the world copy the user is
+   * looking at. Defaults to the primary world.
+   */
+  @Input() worldOffset = 0;
   @Input() positioning: string;
   @Input() stopEvent: boolean;
   @Input() insertFirst: boolean;
@@ -40,13 +47,19 @@ export class OverlayComponent implements OnInit, OnChanges, OnDestroy {
     this.changeDetectorRef.detach();
   }
 
+  // Project a canonical lon/lat to its Mercator position in the target world copy.
+  private toWorldPosition(position: Coordinate): number[] {
+    const merc = fromLonLat(position);
+    return this.worldOffset ? [merc[0] + this.worldOffset, merc[1]] : merc;
+  }
+
   ngOnInit() {
     if (this.elementRef.nativeElement) {
       this.element = this.elementRef.nativeElement;
       this.overlay = new Overlay(this as Options);
       this.mapComponent.getMap().addOverlay(this.overlay);
       if (this.position) {
-        this.overlay.setPosition(fromLonLat(this.position));
+        this.overlay.setPosition(this.toWorldPosition(this.position));
       }
     }
   }
@@ -59,8 +72,11 @@ export class OverlayComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.overlay && changes.position) {
-      this.overlay.setPosition(fromLonLat(changes.position.currentValue));
+    // Re-place on a change to either the canonical position or the target world.
+    if (this.overlay && (changes.position || changes.worldOffset)) {
+      if (this.position) {
+        this.overlay.setPosition(this.toWorldPosition(this.position));
+      }
     }
   }
 

--- a/src/app/modules/map/ol/lib/util.spec.ts
+++ b/src/app/modules/map/ol/lib/util.spec.ts
@@ -1,6 +1,49 @@
 import { describe, it, expect } from 'vitest';
-import { mapifyCoords } from './util';
+import { mapifyCoords, worldCopyOffset } from './util';
 import { Coordinate } from './models';
+
+// EPSG:3857 world width (metres), as OL derives it from the projection extent.
+const W = 2 * 20037508.342789244;
+
+describe('worldCopyOffset', () => {
+  it('is zero inside the primary world', () => {
+    expect(worldCopyOffset(0, W)).toBeCloseTo(0, 3);
+    expect(worldCopyOffset(W / 2 - 1, W)).toBeCloseTo(0, 3);
+    expect(worldCopyOffset(-(W / 2) + 1, W)).toBeCloseTo(0, 3);
+  });
+
+  it('returns +one world width for a click in the copy to the east', () => {
+    // 197°E rendered in world +1 sits ~0.55 worlds east of centre.
+    const mercX = (197 / 180) * (W / 2);
+    expect(worldCopyOffset(mercX, W)).toBeCloseTo(W, 3);
+  });
+
+  it('returns -one world width for a click in the copy to the west', () => {
+    const mercX = (-197 / 180) * (W / 2);
+    expect(worldCopyOffset(mercX, W)).toBeCloseTo(-W, 3);
+  });
+
+  it('scales to further copies', () => {
+    expect(worldCopyOffset(2.4 * W, W)).toBeCloseTo(2 * W, 3);
+    expect(worldCopyOffset(-3.1 * W, W)).toBeCloseTo(-3 * W, 3);
+  });
+
+  it('adding the offset to a primary-world point is a whole-world shift', () => {
+    // The transparency invariant: the shift is always n·worldWidth, so it moves
+    // a point by an exact number of worlds and never leaves the [-180,180] copy
+    // once re-normalised.
+    for (const x of [0.3 * W, 1.9 * W, -0.7 * W, 5.5 * W]) {
+      const n = worldCopyOffset(x, W) / W;
+      expect(n).toBeCloseTo(Math.round(n), 6);
+    }
+  });
+
+  it('returns 0 for non-finite input or a bad world width (never throws)', () => {
+    expect(worldCopyOffset(Infinity, W)).toBe(0);
+    expect(worldCopyOffset(NaN, W)).toBe(0);
+    expect(worldCopyOffset(1000, 0)).toBe(0);
+  });
+});
 
 /** Longitudes of a coordinate list, for concise assertions. */
 const lons = (coords: Array<Coordinate>) => coords.map((c) => c[0]);

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -84,6 +84,23 @@ export function mapifyCoords(coords: Array<Coordinate>): Array<Coordinate> {
   return out;
 }
 
+/**
+ * Render-space offset (EPSG:3857 metres) of the world copy a Mercator x lands
+ * in, relative to the primary world. OpenLayers pans horizontally without limit,
+ * so a click east/west of the primary world carries an x outside
+ * `[-worldWidth/2, worldWidth/2]`; this returns the whole-world shift that maps
+ * the primary world onto that copy. The result is always a whole multiple of
+ * `worldWidth`, so adding it to a primary-world position is visually transparent
+ * under wrapX and never produces an out-of-range longitude. Returns 0 for the
+ * primary world. See #572.
+ */
+export function worldCopyOffset(mercX: number, worldWidth: number): number {
+  if (!Number.isFinite(mercX) || !(worldWidth > 0)) {
+    return 0;
+  }
+  return Math.round(mercX / worldWidth) * worldWidth;
+}
+
 // ** return adjusted radius to correctly render circle on ground at given position.
 export function mapifyRadius(radius: number, position: Coordinate): number {
   if (typeof radius === 'undefined' || typeof position === 'undefined') {


### PR DESCRIPTION
OpenLayers pans horizontally without limit and replicates features into every visible world copy, but Freeboard resolved every *interaction* to the primary world. `toLonLat()` normalises a click to `[-180,180]`, discarding which copy the user was looking at, so a popover opened a world away from the feature clicked, and route vertices could only be grabbed in the primary world. It had nothing to do with the antimeridian — a route in the Florida Keys reproduced it by panning one world over.

The fix introduces an explicit split between **render space** (EPSG:3857, world-copy-aware — placement and hit-testing) and **data space** (canonical WGS84 in `[-180,180]` — everything stored/streamed). A click carries a render-space **world offset** that is applied only in Mercator and never becomes a lon/lat, so nothing out-of-range can reach the server.

- `worldCopyOffset()` (util) derives the whole-world offset; map click events carry it as `worldOffset` while `lonlat` stays canonical.
- `ol-overlay` gains a `worldOffset` input and draws its (still canonical) `position` in that copy; a tracked vessel popover and the live measure label follow in the same copy. The dateline-only `+360` overlay hack this supersedes is removed.
- Route editing aligns the edit feature to the copy the user clicked **by its extent centre** — a route's own coordinates may be unwrapped past ±180, so the click's world alone is wrong — then shifts by a whole world so OL `Modify` (which hit-tests raw geometry in view space; its `wrapX` option only wraps the sketch overlay) matches where the user clicks. The shift is visually transparent under wrapX, adds no vertices, and normalises back to `[-180,180]` on save.

The render-space vs data-space rule and the shared helpers are documented in `AGENTS.md` so the pattern isn't re-fragmented.

Out of scope: WMS `GetFeatureInfo` (`layer-wms-chart`) has the same coordinate on a server bbox request; niche (WMS charts are rare) and a separate mechanism, noted as a follow-up.

### Test plan

- [x] `worldCopyOffset` unit tests (primary world, east/west copies, further copies, whole-world invariant, non-finite guards)
- [x] `npm run test:ci` — 281 tests pass; `npm run build:all` clean; prettier clean
- [x] Manual, against a live server with an antimeridian-crossing route: popups open on the icon one world east and west; route vertices editable in the primary world, one world east, one world west, and in the straddling (zoomed-out) case each half edits in its own copy; Florida Keys route edits normally
- [x] Invariant: a route created while panned **two worlds west** (and crossing the antimeridian) saved with every coordinate in `[-180,180]` — verified on disk

Closes #572


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map interactions near the international date line and across duplicated world views.
  * Kept popovers, measurement labels, and feature editing aligned with the world copy where the interaction occurred.
  * Preserved canonical geographic positions while displaying overlays in the correct rendered location.

* **Tests**
  * Added coverage for world-copy positioning, including adjacent and multiple wrapped worlds and invalid coordinate values.

* **Documentation**
  * Added guidance for separating geographic data coordinates from rendered map coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->