### PR TITLE
fix(map): stop right-click from deleting the wrong route vertex

### DIFF
--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.spec.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.spec.ts
@@ -1,0 +1,55 @@
+import { expect, describe, it } from 'vitest';
+import { vertexDeleteCondition } from './interaction-modify.component';
+
+// Minimal stand-in for the OL map: only get/set of the delete-on-release flag
+// are read by the condition.
+function fakeMap(vertexDeleteOnRelease = false) {
+  const store: Record<string, unknown> = { vertexDeleteOnRelease };
+  return {
+    get: (k: string) => store[k],
+    set: (k: string, v: unknown) => {
+      store[k] = v;
+    }
+  };
+}
+
+// Build a MapBrowserEvent-shaped object with only the fields the condition reads.
+function ev(
+  type: string,
+  opts: { ctrlKey?: boolean; map?: ReturnType<typeof fakeMap> } = {}
+) {
+  return {
+    type,
+    originalEvent: { ctrlKey: opts.ctrlKey ?? false },
+    map: opts.map ?? fakeMap()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('vertexDeleteCondition', () => {
+  it('does NOT delete on a right-click (contextmenu) — regression for #575', () => {
+    // A right-click never re-snaps the grabbed vertex, so treating it as a delete
+    // removed the last-touched vertex instead of the clicked one.
+    expect(vertexDeleteCondition(ev('contextmenu'))).toBe(false);
+  });
+
+  it('deletes on Ctrl-Click (mouse gesture)', () => {
+    expect(vertexDeleteCondition(ev('click', { ctrlKey: true }))).toBe(true);
+  });
+
+  it('does not delete on a plain left click', () => {
+    expect(vertexDeleteCondition(ev('click', { ctrlKey: false }))).toBe(false);
+  });
+
+  it('deletes on release when tap-hold flagged vertexDeleteOnRelease, and clears the flag', () => {
+    const map = fakeMap(true);
+    expect(vertexDeleteCondition(ev('pointerup', { map }))).toBe(true);
+    expect(map.get('vertexDeleteOnRelease')).toBe(false);
+  });
+
+  it('does not delete on release when the tap-hold flag is not set', () => {
+    expect(
+      vertexDeleteCondition(ev('pointerup', { map: fakeMap(false) }))
+    ).toBe(false);
+  });
+});

--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
@@ -12,6 +12,37 @@ import { Modify } from 'ol/interaction';
 import { ModifyEvent } from 'ol/interaction/Modify';
 import { MapComponent } from '../map.component';
 
+/**
+ * Decides whether a map event should delete the grabbed route vertex.
+ *
+ * Two delete gestures are supported, matching the on-screen instructions
+ * ("Ctrl-Click or Tap-hold to remove point from a line"):
+ * - **Ctrl-Click** (mouse) — a primary-button click, so OpenLayers re-snaps the
+ *   grabbed vertex to the point under the cursor before this runs.
+ * - **Tap-hold** (touch/pen) — map.component flags `vertexDeleteOnRelease`, which
+ *   we consume on the following release. OL 10 emits no `contextmenu` for touch,
+ *   so this is the only touch delete path.
+ *
+ * A mouse right-click (`contextmenu`) is deliberately **not** a delete gesture: it
+ * never re-snaps the grabbed vertex (its pointerdown is not a primary action), so
+ * it would delete whatever vertex was last touched rather than the one clicked
+ * (#575); and Freeboard already uses right-click for the map context menu.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const vertexDeleteCondition = (e: MapBrowserEvent<any>): boolean => {
+  if (
+    (e.type === 'pointerup' ||
+      e.type === 'singleclick' ||
+      e.type === 'click') &&
+    e.map.get('vertexDeleteOnRelease')
+  ) {
+    e.map.set('vertexDeleteOnRelease', false);
+    return true;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return e.type === 'click' && (e.originalEvent as any).ctrlKey;
+};
+
 @Component({
   selector: 'ol-map > ol-modify',
   template: '<ng-content></ng-content>',
@@ -52,26 +83,7 @@ export class InteractionModifyComponent {
     if (undefined !== this.map) {
       this.interaction = new Modify({
         features: this.features,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        deleteCondition: (e: MapBrowserEvent<any>) => {
-          // A long-press (touch or mouse) flagged a delete-on-release in
-          // map.component; consume it on the click/release. OL 10 emits no
-          // contextmenu event for touch, so this is the only delete path there.
-          if (
-            (e.type === 'pointerup' ||
-              e.type === 'singleclick' ||
-              e.type === 'click') &&
-            e.map.get('vertexDeleteOnRelease')
-          ) {
-            e.map.set('vertexDeleteOnRelease', false);
-            return true;
-          }
-          return (
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (e.type === 'click' && (e.originalEvent as any).ctrlKey) ||
-            e.type === 'contextmenu'
-          );
-        }
+        deleteCondition: vertexDeleteCondition
       });
       this.interaction.on('change', this.emitChangeEvent);
       this.interaction.on('modifystart', this.emitModifyStartEvent);


### PR DESCRIPTION
During route editing, right-clicking a waypoint deleted the **last-touched**
vertex rather than the one under the cursor (#575).

OpenLayers' `Modify` only re-snaps the grabbed vertex on `pointermove` or on a
**primary-button** `pointerdown`. A Ctrl-Click is a left-button down, so it
re-snaps to the vertex under the cursor before deleting (correct). A right-click's
`pointerdown` is button 2 and fails that condition, so nothing re-snaps and
`deleteCondition` removes whatever vertex was last grabbed.

The `contextmenu` delete branch was also vestigial: it dates from when touch
long-press emitted `contextmenu`, which OL 10 no longer does (touch now deletes via
the `vertexDeleteOnRelease` long-press path). Today it's reachable only by a mouse
right-click — which is undocumented (the on-screen hint says "Ctrl-Click or Tap-hold
to remove point from a line") and also fires Freeboard's own right-click map context
menu.

Removing `contextmenu` from `deleteCondition` leaves the two documented gestures —
Ctrl-Click (mouse) and Tap-hold (touch/pen) — and lets right-click revert to just
opening the context menu. The condition is extracted to a pure `vertexDeleteCondition`
function with a co-located spec covering each gesture.

Closes #575

@coderabbitai ignore
