### PR TITLE
feat(map): delete a route vertex with a long left-click, matching touch

### DIFF
--- a/src/app/lib/components/interact-help.component.ts
+++ b/src/app/lib/components/interact-help.component.ts
@@ -192,7 +192,7 @@ export class InteractionHelpComponent {
             this.mapInteract.draw.forSave.id !== 'anchor'
               ? [
                   'Click and drag to move point.',
-                  'Ctrl-Click or Tap-hold to remove point from a line.'
+                  'Ctrl-Click or press-and-hold to remove point from a line.'
                 ]
               : []
         };

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -26,6 +26,7 @@ import { Coordinate } from 'ol/coordinate';
 import { FeatureLike } from 'ol/Feature';
 import { Extent, getWidth } from 'ol/extent';
 import { worldCopyOffset } from './util';
+import { tryDeleteHeldVertexOnHold } from './vertex-delete';
 
 export interface FBMapEvent extends MapEvent {
   lonlat: Coordinate;
@@ -287,42 +288,9 @@ export class MapComponent implements OnInit, OnDestroy {
       return;
     }
     const src = Object.values(this.evCache)[0];
-    // Tap-hold to remove a route vertex (touch/tablet parity with Ctrl-Click;
-    // OL 10 emits no contextmenu for touch). Flag a delete-on-release as the
-    // reliable fallback, then try to remove the grabbed vertex immediately
-    // (mid-hold, the way touch plotters work). removePoint() refuses if the last
-    // event was a drag, so replay a pointermove at the press point to clear that
-    // state first.
-    const modify = this.map
-      .getInteractions()
-      .getArray()
-      .find((i) => i instanceof Modify && i.getActive()) as Modify | undefined;
-    if (modify) {
-      // Touch/pen only — a mouse user deletes a vertex with Ctrl-Click, so a
-      // long mouse hold (e.g. pausing to decide where to drag a point) must not
-      // delete it.
-      const pointerType = (src as PointerEvent).pointerType;
-      if (pointerType !== 'touch' && pointerType !== 'pen') {
-        return;
-      }
-      this.map.set('vertexDeleteOnRelease', true);
-      try {
-        this.map.getViewport().dispatchEvent(
-          new PointerEvent('pointermove', {
-            clientX: src.clientX,
-            clientY: src.clientY,
-            bubbles: true,
-            cancelable: true,
-            pointerId: (src as PointerEvent).pointerId ?? 1,
-            pointerType: (src as PointerEvent).pointerType ?? 'touch'
-          })
-        );
-        if (modify.removePoint()) {
-          this.map.set('vertexDeleteOnRelease', false);
-        }
-      } catch {
-        // Fall back to delete-on-release via the deleteCondition flag.
-      }
+    // During route editing a long hold removes the grabbed vertex; otherwise it
+    // opens the chart context menu.
+    if (tryDeleteHeldVertexOnHold(this.map, src)) {
       return;
     }
     this.mapContextMenu.emit(src as any);

--- a/src/app/modules/map/ol/lib/vertex-delete.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.spec.ts
@@ -1,0 +1,72 @@
+import { expect, describe, it, vi } from 'vitest';
+import { Map } from 'ol';
+import { Collection } from 'ol';
+import { Modify } from 'ol/interaction';
+import { tryDeleteHeldVertexOnHold } from './vertex-delete';
+
+// Minimal stand-in for the OL map: only the members the helper touches.
+function fakeMap(interactions: unknown[]) {
+  const props: Record<string, unknown> = {};
+  return {
+    getInteractions: () => ({ getArray: () => interactions }),
+    getViewport: () => document.createElement('div'),
+    get: (k: string) => props[k],
+    set: (k: string, v: unknown) => {
+      props[k] = v;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function activeModify(removePointResult = true): Modify {
+  const modify = new Modify({ features: new Collection() });
+  vi.spyOn(modify, 'getActive').mockReturnValue(true);
+  vi.spyOn(modify, 'removePoint').mockReturnValue(removePointResult);
+  return modify;
+}
+
+function src(pointerType: string): MouseEvent {
+  return {
+    clientX: 10,
+    clientY: 20,
+    pointerType,
+    pointerId: 1
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('tryDeleteHeldVertexOnHold', () => {
+  it('deletes the grabbed vertex on a long MOUSE hold — #578 parity with touch', () => {
+    const modify = activeModify();
+    const map = fakeMap([modify]);
+
+    expect(tryDeleteHeldVertexOnHold(map as Map, src('mouse'))).toBe(true);
+    expect(modify.removePoint).toHaveBeenCalled();
+  });
+
+  it('still deletes on a long touch hold', () => {
+    const modify = activeModify();
+    const map = fakeMap([modify]);
+
+    expect(tryDeleteHeldVertexOnHold(map as Map, src('touch'))).toBe(true);
+    expect(modify.removePoint).toHaveBeenCalled();
+  });
+
+  it('clears vertexDeleteOnRelease once the vertex is removed', () => {
+    const map = fakeMap([activeModify(true)]);
+    tryDeleteHeldVertexOnHold(map as Map, src('mouse'));
+    expect(map.get('vertexDeleteOnRelease')).toBe(false);
+  });
+
+  it('leaves vertexDeleteOnRelease set as a fallback when the immediate remove is refused', () => {
+    const map = fakeMap([activeModify(false)]);
+    tryDeleteHeldVertexOnHold(map as Map, src('mouse'));
+    expect(map.get('vertexDeleteOnRelease')).toBe(true);
+  });
+
+  it('does nothing (opens context menu instead) when no Modify is active', () => {
+    const map = fakeMap([]);
+    expect(tryDeleteHeldVertexOnHold(map as Map, src('mouse'))).toBe(false);
+    expect(map.get('vertexDeleteOnRelease')).toBeUndefined();
+  });
+});

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -1,0 +1,46 @@
+import { Map } from 'ol';
+import { Modify } from 'ol/interaction';
+
+/**
+ * On a long press during route editing, remove the grabbed vertex.
+ *
+ * Runs for **any** pointer — a long left-click gives mouse users parity with the
+ * touch/pen tap-hold (alongside Ctrl-Click). A press that is really the start of a
+ * drag cannot reach here: the Modify hold timer is 1500 ms and `clearTimerIfMoved`
+ * disarms it once the pointer moves past its tolerance.
+ *
+ * Returns `true` when a Modify interaction was active (delete attempted, so the
+ * caller should not also open the context menu), `false` when there was none.
+ */
+export function tryDeleteHeldVertexOnHold(map: Map, src: MouseEvent): boolean {
+  const modify = map
+    .getInteractions()
+    .getArray()
+    .find((i) => i instanceof Modify && i.getActive()) as Modify | undefined;
+  if (!modify) {
+    return false;
+  }
+  // Flag a delete-on-release as the reliable fallback, then try to remove the
+  // grabbed vertex immediately (mid-hold, the way touch plotters work).
+  // removePoint() refuses if the last event was a drag, so replay a pointermove at
+  // the press point to clear that state first.
+  map.set('vertexDeleteOnRelease', true);
+  try {
+    map.getViewport().dispatchEvent(
+      new PointerEvent('pointermove', {
+        clientX: src.clientX,
+        clientY: src.clientY,
+        bubbles: true,
+        cancelable: true,
+        pointerId: (src as PointerEvent).pointerId ?? 1,
+        pointerType: (src as PointerEvent).pointerType ?? 'touch'
+      })
+    );
+    if (modify.removePoint()) {
+      map.set('vertexDeleteOnRelease', false);
+    }
+  } catch {
+    // Fall back to delete-on-release via the deleteCondition flag.
+  }
+  return true;
+}


### PR DESCRIPTION
Mouse users could only delete a route vertex with Ctrl-Click, while touch/pen
users had the more discoverable press-and-hold. This adds a **long left-click**
(mouse press-and-hold on a vertex) as an equivalent delete gesture, giving the two
input styles parity (#578).

The long-hold delete already existed for touch/pen in `touchHold`; it was gated to
those pointer types by an explicit early-return. Removing that restriction lets any
pointer use it. A press that's really the start of a drag can't trigger it: the
Modify hold is 1500 ms and `clearTimerIfMoved` disarms the timer once the pointer
moves beyond the existing tolerance — so *press → move → pause* never deletes.

The delete logic is extracted from the component into a pure `tryDeleteHeldVertexOnHold`
helper with a co-located spec (mouse parity, touch unchanged, fallback flag, no-op
when not editing). The on-screen hint now reads "Ctrl-Click or press-and-hold".

Closes #578

@coderabbitai ignore
