### PR TITLE
feat(routes): unify the route draw and modify helper panels

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1044,6 +1044,7 @@
           >
             <!-- MAP -->
             <fb-map
+              #fbMap
               [scaleUnits]="app.config.units.distance"
               [setFocus]="mapSetFocus()"
               [mapCenter]="mapCenter()"
@@ -1124,7 +1125,11 @@
 
           <!-- Interaction Help Container Panel -->
           @if (isInteracting()) {
-            <fb-interact-help (cancel)="closeInteraction()"> </fb-interact-help>
+            <fb-interact-help
+              (finish)="handleInteractionFinish()"
+              (cancel)="closeInteraction()"
+            >
+            </fb-interact-help>
           }
 
           <!-- *** Nav data panel ***-->

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -181,6 +181,7 @@ interface DrawEndEvent {
 })
 export class AppComponent {
   @ViewChild('sideright', { static: false }) sideright;
+  @ViewChild('fbMap', { static: false }) fbMap: FBMapComponent;
 
   protected navDataPanel = signal<{
     show: boolean;
@@ -1902,8 +1903,25 @@ export class AppComponent {
     }
   }
 
-  /** End interaction mode */
-  protected closeInteraction() {
+  /**
+   * "Finish" from the route draw/modify helper. Drawing completes the sketch
+   * (which flows through onDrawEnd → handleDrawEnded); modifying saves the edit
+   * directly (no save-changes prompt — the ✕/Cancel path discards it instead).
+   */
+  protected handleInteractionFinish() {
+    if (this.mapInteract.isDrawing()) {
+      this.fbMap.finishDrawing();
+    } else {
+      this.closeInteraction(true);
+    }
+  }
+
+  /**
+   * End interaction mode. `routeModifySave` decides a pending route edit: the
+   * helper's Finish passes `true` (save), its ✕/Cancel passes `false` (discard);
+   * non-route modifies still confirm before saving.
+   */
+  protected closeInteraction(routeModifySave = false) {
     // No feature is being edited once an interaction ends — clear the marker
     // (it is set on every modify drag and otherwise never reset), so dependent
     // UI such as the route-list visibility checkboxes re-enables.
@@ -1929,113 +1947,113 @@ export class AppComponent {
           return;
         }
 
-        // save changes. Editing an unsaved live buffer just applies the change
-        // to the draft (it is not persisted here — that is an explicit Save),
-        // so word the prompt to match rather than implying a named save.
         const fsParts = this.mapInteract.draw.forSave.id.split('.');
-        // A draft edit (unsaved live buffer) just stages the change; a saved
-        // route — or a saved buffer — persists on confirm, so word to match.
-        const draftBuf =
-          fsParts[0] === 'route'
-            ? this.routeBuffers.get(fsParts[1])
-            : undefined;
-        const isDraftEdit = !!draftBuf && !draftBuf.saved;
+        if (fsParts[0] === 'route') {
+          // The route helper commits directly (issue #545): Finish saves,
+          // ✕/Cancel discards — no save-changes prompt.
+          this.applyModifyResult(routeModifySave);
+          return;
+        }
+
+        // Other resource types still confirm before saving a modify.
         this.app
           .showConfirm(
-            isDraftEdit
-              ? 'Keep the changes to this unsaved route?'
-              : `Do you want to save the changes made to ${fsParts[0]}?`,
-            isDraftEdit ? 'Keep Changes' : 'Save Changes'
+            `Do you want to save the changes made to ${fsParts[0]}?`,
+            'Save Changes'
           )
-          .subscribe((result) => {
-            const r = this.mapInteract.draw.forSave.id.split('.');
-            if (result) {
-              // save changes
-              if (r[0] === 'route') {
-                const buf = this.routeBuffers.get(r[1]);
-                if (buf && !buf.saved) {
-                  // Unsaved draft: stage the modified geometry to the buffer
-                  // (emits route.dirty). Persisted only via an explicit Save.
-                  // Carry the per-point name/description so the metadata is not
-                  // dropped on a later Save.
-                  const meta = this.mapInteract.draw.forSave.coordsMetadata as
-                    Array<{ name?: string; description?: string }> | undefined;
-                  this.routeBuffers.replace(
-                    r[1],
-                    this.mapInteract.draw.forSave.coords.map((position, i) => ({
-                      position,
-                      ...(meta?.[i]?.name ? { name: meta[i].name } : {}),
-                      ...(meta?.[i]?.description
-                        ? { description: meta[i].description }
-                        : {})
-                    }))
-                  );
-                } else {
-                  // Saved route (plain resource or a saved buffer): persist the
-                  // edit, mirrored through the registry so extensions observe it
-                  // (route.visible/dirty → route.saved).
-                  this.plotterExt.saveNativeRouteEdit(
-                    r[1],
-                    this.mapInteract.draw.forSave.coords,
-                    this.mapInteract.draw.forSave.coordsMetadata
-                  );
-                }
-              }
-              if (r[0] === 'waypoint') {
-                this.skres.updateWaypointPosition(
-                  r[1],
-                  this.mapInteract.draw.forSave.coords
-                );
-                // if waypoint the target destination update nextPoint
-                if (r[1] === this.app.data.activeWaypoint) {
-                  this.course.setDestination({
-                    latitude: this.mapInteract.draw.forSave.coords[1],
-                    longitude: this.mapInteract.draw.forSave.coords[0]
-                  });
-                }
-              }
-              if (r[0] === 'note') {
-                this.skres.updateNotePosition(
-                  r[1],
-                  this.mapInteract.draw.forSave.coords
-                );
-              }
-              if (r[0] === 'region') {
-                this.skres.updateRegionCoords(
-                  r[1],
-                  this.mapInteract.draw.forSave.coords
-                );
-              }
-            } else {
-              // do not save
-              if (r[0] === 'route') {
-                const buf = this.routeBuffers.get(r[1]);
-                if (buf && (!buf.saved || buf.dirty)) {
-                  // Restore the draft (or dirty saved buffer): the Modify
-                  // interaction moved the map feature, but the buffer itself
-                  // was never changed.
-                  this.routeBuffers.refresh();
-                } else {
-                  // Clean saved route — re-render from the resource to revert
-                  // the unsaved geometry move.
-                  this.skres.refreshRoutes();
-                }
-              }
-              if (r[0] === 'waypoint') {
-                this.skres.refreshWaypoints();
-              }
-              if (r[0] === 'note') {
-                this.skres.refreshNotes();
-              }
-              if (r[0] === 'region') {
-                this.skres.refreshRegions();
-              }
-            }
-            this.mapInteract.draw.forSave = null;
-            this.focusMap();
-          });
+          .subscribe((result) => this.applyModifyResult(result));
       }
     }
+  }
+
+  /**
+   * Apply (`save`) or revert the pending modify edit described by
+   * `draw.forSave`, then clear it. Shared by the route helper's direct
+   * Finish/Cancel and the confirm prompt used for other resource types.
+   */
+  private applyModifyResult(save: boolean) {
+    const r = this.mapInteract.draw.forSave.id.split('.');
+    if (save) {
+      if (r[0] === 'route') {
+        const buf = this.routeBuffers.get(r[1]);
+        if (buf && !buf.saved) {
+          // Unsaved draft: stage the modified geometry to the buffer (emits
+          // route.dirty). Persisted only via an explicit Save. Carry the
+          // per-point name/description so metadata is not dropped on a later
+          // Save.
+          const meta = this.mapInteract.draw.forSave.coordsMetadata as
+            Array<{ name?: string; description?: string }> | undefined;
+          this.routeBuffers.replace(
+            r[1],
+            this.mapInteract.draw.forSave.coords.map((position, i) => ({
+              position,
+              ...(meta?.[i]?.name ? { name: meta[i].name } : {}),
+              ...(meta?.[i]?.description
+                ? { description: meta[i].description }
+                : {})
+            }))
+          );
+        } else {
+          // Saved route (plain resource or a saved buffer): persist the edit,
+          // mirrored through the registry so extensions observe it
+          // (route.visible/dirty → route.saved).
+          this.plotterExt.saveNativeRouteEdit(
+            r[1],
+            this.mapInteract.draw.forSave.coords,
+            this.mapInteract.draw.forSave.coordsMetadata
+          );
+        }
+      }
+      if (r[0] === 'waypoint') {
+        this.skres.updateWaypointPosition(
+          r[1],
+          this.mapInteract.draw.forSave.coords
+        );
+        // if waypoint the target destination update nextPoint
+        if (r[1] === this.app.data.activeWaypoint) {
+          this.course.setDestination({
+            latitude: this.mapInteract.draw.forSave.coords[1],
+            longitude: this.mapInteract.draw.forSave.coords[0]
+          });
+        }
+      }
+      if (r[0] === 'note') {
+        this.skres.updateNotePosition(
+          r[1],
+          this.mapInteract.draw.forSave.coords
+        );
+      }
+      if (r[0] === 'region') {
+        this.skres.updateRegionCoords(
+          r[1],
+          this.mapInteract.draw.forSave.coords
+        );
+      }
+    } else {
+      if (r[0] === 'route') {
+        const buf = this.routeBuffers.get(r[1]);
+        if (buf && (!buf.saved || buf.dirty)) {
+          // Restore the draft (or dirty saved buffer): the Modify interaction
+          // moved the map feature, but the buffer itself was never changed.
+          this.routeBuffers.refresh();
+        } else {
+          // Clean saved route — re-render from the resource to revert the
+          // unsaved geometry move.
+          this.skres.refreshRoutes();
+        }
+      }
+      if (r[0] === 'waypoint') {
+        this.skres.refreshWaypoints();
+      }
+      if (r[0] === 'note') {
+        this.skres.refreshNotes();
+      }
+      if (r[0] === 'region') {
+        this.skres.refreshRegions();
+      }
+    }
+    this.mapInteract.draw.forSave = null;
+    this.focusMap();
   }
 
   // ******** SIGNAL K STREAM *************

--- a/src/app/lib/components/interact-help.component.spec.ts
+++ b/src/app/lib/components/interact-help.component.spec.ts
@@ -1,0 +1,93 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { InteractionHelpComponent } from './interact-help.component';
+import { FBMapInteractService } from '../../modules/map/fbmap-interact.service';
+import { AppFacade } from '../../app.facade';
+
+/**
+ * Route drawing and modifying share one docked popover card (issue #545). These
+ * exercise the constructor decision logic that selects that card, its title, and
+ * when Finish is allowed — without rendering the template (keeps the test off the
+ * barrel-cycle path that flakes full-render component specs).
+ */
+describe('InteractionHelpComponent — unified route helper', () => {
+  let svc: FBMapInteractService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: AppFacade,
+          useValue: { debug: () => undefined, formatValueForDisplay: () => '' }
+        }
+      ]
+    });
+    svc = TestBed.inject(FBMapInteractService);
+  });
+
+  const create = () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TestBed.runInInjectionContext(() => new InteractionHelpComponent()) as any;
+
+  it('renders the "Draw New Route" card while drawing a route', () => {
+    svc.draw.resourceType = 'route';
+    svc.isDrawing.set(true);
+    const c = create();
+    expect(c.isRouteEditing()).toBe(true);
+    expect(c.mode.iconText).toBe('Draw New Route');
+  });
+
+  it('gates Finish on ≥2 drawn points while drawing', () => {
+    svc.draw.resourceType = 'route';
+    svc.isDrawing.set(true);
+    svc.measurementCoords = [[0, 0]];
+    const c = create();
+    expect(c.canFinish()).toBe(false);
+
+    svc.measurementCoords = [
+      [0, 0],
+      [1, 1]
+    ];
+    expect(c.canFinish()).toBe(true);
+  });
+
+  it('renders the "Modify Route" card with Finish always enabled', () => {
+    svc.draw.resourceType = 'route';
+    svc.isModifying.set(true);
+    const c = create();
+    expect(c.isRouteEditing()).toBe(true);
+    expect(c.mode.iconText).toBe('Modify Route');
+    expect(c.canFinish()).toBe(true);
+  });
+
+  it('titles the modify card with the route name when known', () => {
+    svc.draw.resourceType = 'route';
+    svc.draw.name = 'Passage to Marathon';
+    svc.isModifying.set(true);
+    const c = create();
+    expect(c.mode.iconText).toBe('Modify Passage to Marathon');
+  });
+
+  it('leaves non-route interactions on the legacy panel', () => {
+    svc.draw.resourceType = 'waypoint';
+    svc.draw.forSave = { id: null, coords: null };
+    svc.isModifying.set(true);
+    const c = create();
+    expect(c.isRouteEditing()).toBe(false);
+  });
+
+  it('emits finish and cancel from the card actions', () => {
+    svc.draw.resourceType = 'route';
+    svc.isDrawing.set(true);
+    const c = create();
+    let finished = false;
+    let cancelled = false;
+    c.finish.subscribe(() => (finished = true));
+    c.cancel.subscribe(() => (cancelled = true));
+    c.finishEditing();
+    c.close();
+    expect(finished).toBe(true);
+    expect(cancelled).toBe(true);
+  });
+});

--- a/src/app/lib/components/interact-help.component.ts
+++ b/src/app/lib/components/interact-help.component.ts
@@ -14,6 +14,7 @@ import { AppFacade } from 'src/app/app.facade';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { FBMapInteractService } from 'src/app/modules/map/fbmap-interact.service';
 import { Measurements } from './measurements.component';
+import { PopoverComponent } from 'src/app/modules/map/popovers/popover.component';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,70 +24,128 @@ import { Measurements } from './measurements.component';
     MatButtonModule,
     MatTooltip,
     MatToolbarModule,
-    Measurements
+    Measurements,
+    PopoverComponent
   ],
   template: `
-    <div class="mat-app-background _ap_interact_help">
-      @if (showHelpPanel()) {
-        <div class="mat-app-background measurePanel">
-          <div>
-            <span style="font-weight: bold; padding: 5px">
-              <mat-icon>{{ mode.iconName }}</mat-icon> {{ mode.iconText }}
-            </span>
-            @if (mode.description.length !== 0) {
-              <div style="padding: 5px">
-                {{ mode.description }}
-              </div>
-            }
-            @if (mode.steps.length !== 0) {
-              <div style="padding: 5px">
-                <ol
-                  style="
-                margin-block-start: 0.2em;
-                margin-block-end: 0.2em;
-                padding-inline-start: 15px;
-              "
-                >
-                  @for (step of mode.steps; track step) {
-                    <li>{{ step }}</li>
-                  }
-                </ol>
-              </div>
-            }
-          </div>
-
-          <div style="text-align: center; padding: 6px 0 8px">
-            <!-- cancel Draw button -->
-            <a
-              class="icon-warn"
-              mat-raised-button
-              (click)="close()"
-              [matTooltip]="
-                mapInteract.isModifying()
-                  ? 'Finish Editing'
-                  : 'Cancel Operation'
-              "
-              matTooltipPosition="left"
-            >
-              <mat-icon class="icon-warn">close</mat-icon>
-              {{ mapInteract.isModifying() ? 'FINISH' : 'CANCEL' }}
-            </a>
-          </div>
-        </div>
-      }
-      @if (showMeasurePanel()) {
-        <fb-measurements
-          matTooltip="Click on the Map to start. Click cancel or the last point to end."
-          [coords]="mapInteract.measurement().coords"
-          [index]="mapInteract.measurement().index"
-          [totalOnly]="
-            mapInteract.isDrawing() && mapInteract.draw.resourceType === 'route'
-          "
-          (cancel)="close()"
+    @if (isRouteEditing()) {
+      <!-- Unified route draw/modify helper: same ap-popover card as the
+           feature popover (#2), docked in place. Finish = keep, ✕ = cancel. -->
+      <div class="_ap_interact_dock">
+        <ap-popover
+          [docked]="true"
+          [canClose]="true"
+          [title]="mode.iconText"
+          [icon]="{ class: '', name: mode.iconName }"
+          (closed)="close()"
         >
-        </fb-measurements>
-      }
-    </div>
+          <fb-measurements
+            [coords]="mapInteract.measurement().coords"
+            [index]="mapInteract.measurement().index"
+            [totalOnly]="mapInteract.isDrawing()"
+            [card]="true"
+          >
+          </fb-measurements>
+          @if (mode.steps.length !== 0) {
+            <ol class="_ap_steps">
+              @for (step of mode.steps; track step) {
+                <li>{{ step }}</li>
+              }
+            </ol>
+          }
+          <div class="_ap_action_row">
+            <div class="_ap_action_button">
+              <button
+                mat-button
+                color="primary"
+                [disabled]="!canFinish()"
+                (click)="finishEditing()"
+                [matTooltip]="
+                  mapInteract.isModifying()
+                    ? 'Save changes'
+                    : 'Finish — keep changes'
+                "
+                matTooltipPosition="after"
+              >
+                <mat-icon>check</mat-icon>
+                {{ mapInteract.isModifying() ? 'SAVE' : 'FINISH' }}
+              </button>
+            </div>
+            <div class="_ap_action_button">
+              <button
+                mat-button
+                class="icon-warn"
+                (click)="close()"
+                matTooltip="Cancel — discard changes"
+                matTooltipPosition="after"
+              >
+                <mat-icon class="icon-warn">close</mat-icon>
+                CANCEL
+              </button>
+            </div>
+          </div>
+        </ap-popover>
+      </div>
+    } @else {
+      <div class="mat-app-background _ap_interact_help">
+        @if (showHelpPanel()) {
+          <div class="mat-app-background measurePanel">
+            <div>
+              <span style="font-weight: bold; padding: 5px">
+                <mat-icon>{{ mode.iconName }}</mat-icon> {{ mode.iconText }}
+              </span>
+              @if (mode.description.length !== 0) {
+                <div style="padding: 5px">
+                  {{ mode.description }}
+                </div>
+              }
+              @if (mode.steps.length !== 0) {
+                <div style="padding: 5px">
+                  <ol
+                    style="
+                  margin-block-start: 0.2em;
+                  margin-block-end: 0.2em;
+                  padding-inline-start: 15px;
+                "
+                  >
+                    @for (step of mode.steps; track step) {
+                      <li>{{ step }}</li>
+                    }
+                  </ol>
+                </div>
+              }
+            </div>
+
+            <div style="text-align: center; padding: 6px 0 8px">
+              <!-- cancel Draw button -->
+              <a
+                class="icon-warn"
+                mat-raised-button
+                (click)="close()"
+                [matTooltip]="
+                  mapInteract.isModifying()
+                    ? 'Finish Editing'
+                    : 'Cancel Operation'
+                "
+                matTooltipPosition="left"
+              >
+                <mat-icon class="icon-warn">close</mat-icon>
+                {{ mapInteract.isModifying() ? 'FINISH' : 'CANCEL' }}
+              </a>
+            </div>
+          </div>
+        }
+        @if (showMeasurePanel()) {
+          <fb-measurements
+            matTooltip="Click on the Map to start. Click cancel or the last point to end."
+            [coords]="mapInteract.measurement().coords"
+            [index]="mapInteract.measurement().index"
+            (cancel)="close()"
+          >
+          </fb-measurements>
+        }
+      </div>
+    }
   `,
   styles: [
     `
@@ -99,6 +158,28 @@ import { Measurements } from './measurements.component';
         border: black 1px solid;
         font-family: roboto;
         font-size: 10pt;
+      }
+
+      ._ap_interact_dock {
+        position: fixed;
+        top: 60px;
+        left: 50px;
+        font-family: roboto;
+        font-size: 10pt;
+      }
+
+      ._ap_steps {
+        margin-block-start: 0.2em;
+        margin-block-end: 0.4em;
+        padding-inline-start: 18px;
+      }
+
+      ._ap_action_row {
+        display: flex;
+        flex-wrap: wrap;
+      }
+      ._ap_action_button {
+        flex: 1 1 45%;
       }
 
       ._ap_row {
@@ -127,10 +208,16 @@ import { Measurements } from './measurements.component';
   ]
 })
 export class InteractionHelpComponent {
+  finish = output<void>();
   cancel = output<void>();
 
   protected showHelpPanel: Signal<boolean>;
   protected showMeasurePanel: Signal<boolean>;
+  /** Route draw or modify → render the unified docked popover card. */
+  protected isRouteEditing: Signal<boolean>;
+  /** Enough drawn points for Finish to complete a route (always true once
+   *  modifying). */
+  protected canFinish: Signal<boolean>;
 
   protected mode = {
     iconName: '',
@@ -156,14 +243,48 @@ export class InteractionHelpComponent {
 
     this.showMeasurePanel = computed(() => {
       return (
-        (this.mapInteract.isMeasuring() &&
-          this.mapInteract.measureGeometryType === 'LineString') ||
-        (this.mapInteract.draw.resourceType === 'route' &&
-          (this.mapInteract.isDrawing() || this.mapInteract.isModifying()))
+        this.mapInteract.isMeasuring() &&
+        this.mapInteract.measureGeometryType === 'LineString'
       );
     });
 
-    if (this.showHelpPanel()) {
+    this.isRouteEditing = computed(() => {
+      return (
+        this.mapInteract.draw.resourceType === 'route' &&
+        (this.mapInteract.isDrawing() || this.mapInteract.isModifying())
+      );
+    });
+
+    this.canFinish = computed(() => {
+      return (
+        this.mapInteract.isModifying() ||
+        this.mapInteract.measurement().coords.length >= 2
+      );
+    });
+
+    if (this.isRouteEditing()) {
+      this.mode = this.mapInteract.isDrawing()
+        ? {
+            iconName: 'edit',
+            iconText: 'Draw New Route',
+            description: '',
+            steps: [
+              'Click / tap the map to add each point.',
+              'Double-click, or press Finish, to end.'
+            ]
+          }
+        : {
+            iconName: 'edit',
+            iconText: this.mapInteract.draw.name
+              ? `Modify ${this.mapInteract.draw.name}`
+              : 'Modify Route',
+            description: '',
+            steps: [
+              'Click and drag to move a point.',
+              'Ctrl-Click or press-and-hold to remove a point.'
+            ]
+          };
+    } else if (this.showHelpPanel()) {
       if (this.mapInteract.isDrawing()) {
         this.mode = {
           iconName: 'edit',
@@ -223,7 +344,14 @@ export class InteractionHelpComponent {
     }
   }
 
+  /** ✕ / cancel — discard the draw or the route modify directly (non-route
+   *  modifies are still confirmed by the host). */
   close() {
     this.cancel.emit();
+  }
+
+  /** Finish — complete & keep (drawing finishes the sketch; modify exits). */
+  finishEditing() {
+    this.finish.emit();
   }
 }

--- a/src/app/lib/components/measurements.component.ts
+++ b/src/app/lib/components/measurements.component.ts
@@ -22,48 +22,68 @@ import { MatToolbarModule } from '@angular/material/toolbar';
   selector: 'fb-measurements',
   imports: [MatIconModule, MatButtonModule, MatTooltip, MatToolbarModule],
   template: `
-    <div class="_ap_measurements">
-      <mat-toolbar>
-        <div class="_ap_row">
-          <div class="_ap_row">
-            <div class="icon-label">
-              <mat-icon>straighten</mat-icon>
+    @if (card()) {
+      <div class="_ap_measurements_card">
+        <div class="_ap_prop">
+          <div class="_ap_prop_key">Distance:</div>
+          <div class="_ap_prop_val">{{ totalDistance }}</div>
+        </div>
+        @if (!totalOnly()) {
+          <div class="_ap_prop">
+            <div class="_ap_prop_key">Leg:</div>
+            <div class="_ap_prop_val">
+              {{ coords().length < 2 ? '--' : legDistance }}
+              @if (coords().length >= 2 && legBearing !== '--') {
+                · {{ legBearing }}
+              }
             </div>
-            <div class="value">{{ totalDistance }}<br /></div>
           </div>
-          @if (!totalOnly()) {
+        }
+      </div>
+    } @else {
+      <div class="_ap_measurements">
+        <mat-toolbar>
+          <div class="_ap_row">
             <div class="_ap_row">
+              <div class="icon-label">
+                <mat-icon>straighten</mat-icon>
+              </div>
+              <div class="value">{{ totalDistance }}<br /></div>
+            </div>
+            @if (!totalOnly()) {
               <div class="_ap_row">
-                <div style="font-size: 12pt;">
-                  <mat-icon>square_foot</mat-icon><br />
-                  {{
-                    this.coords().length < 2
-                      ? '-'
-                      : this._index() === -1
-                        ? this.coords().length - 1
-                        : this._index() + 1
-                  }}
-                </div>
-                <div class="value">
-                  {{ legDistance }}<br />
-                  {{ legBearing }}
+                <div class="_ap_row">
+                  <div style="font-size: 12pt;">
+                    <mat-icon>square_foot</mat-icon><br />
+                    {{
+                      this.coords().length < 2
+                        ? '-'
+                        : this._index() === -1
+                          ? this.coords().length - 1
+                          : this._index() + 1
+                    }}
+                  </div>
+                  <div class="value">
+                    {{ legDistance }}<br />
+                    {{ legBearing }}
+                  </div>
                 </div>
               </div>
+            }
+            <div>
+              <button
+                matTooltip="Cancel"
+                matTooltipPosition="below"
+                mat-icon-button
+                (click)="close()"
+              >
+                <mat-icon>close</mat-icon>
+              </button>
             </div>
-          }
-          <div>
-            <button
-              matTooltip="Cancel"
-              matTooltipPosition="below"
-              mat-icon-button
-              (click)="close()"
-            >
-              <mat-icon>close</mat-icon>
-            </button>
           </div>
-        </div>
-      </mat-toolbar>
-    </div>
+        </mat-toolbar>
+      </div>
+    }
   `,
   styles: [
     `
@@ -71,6 +91,19 @@ import { MatToolbarModule } from '@angular/material/toolbar';
         position: relative;
         top: 0;
         min-width: 200px;
+      }
+
+      ._ap_prop {
+        display: flex;
+        margin: 2px 0;
+      }
+      ._ap_prop_key {
+        font-weight: bold;
+      }
+      ._ap_prop_val {
+        flex: 1 1 auto;
+        text-align: right;
+        white-space: nowrap;
       }
 
       ._ap_row {
@@ -103,6 +136,9 @@ export class Measurements {
   index = input<number>(-1);
   _index = linkedSignal(() => this.index());
   totalOnly = input<boolean>(false);
+  /** Render as plain property rows (for embedding in a popover card) rather
+   *  than the standalone measuring toolbar. */
+  card = input<boolean>(false);
   cancel = output<void>();
 
   protected totalDistance: string;

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -48,6 +48,7 @@
   }
   @if (mapInteract.isDrawing()) {
     <ol-draw
+      #routeDraw
       [type]="mapInteract.draw.featureType"
       [stopClick]="mapInteract.draw.resourceType === 'route' ? false : true"
       [style]="mapInteract.draw.style"

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -122,6 +122,7 @@ import { ScaleLine } from 'ol/control';
 import { Units } from 'ol/control/ScaleLine';
 import { DragBoxEvent } from 'ol/interaction/DragBox';
 import { MapService } from './ol/lib/map.service';
+import { InteractionDrawComponent } from './ol/lib/interactions/interaction-draw.component';
 import { worldCopyOffset } from './ol/lib/util';
 import { AppIconDef } from '../icons';
 import { LayerWindWeatherComponent } from './ol/lib/resources/layer-wind-weather.component';
@@ -207,6 +208,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   @ViewChild(MatMenuTrigger, { static: true }) contextMenu: MatMenuTrigger;
   @ViewChild('olMap', { static: false }) olMap: MapComponent;
+  @ViewChild('routeDraw', { static: false })
+  routeDraw: InteractionDrawComponent;
 
   scaleUnits = input<string>('');
 
@@ -967,6 +970,15 @@ export class FBMapComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Complete the in-progress draw sketch (as a double-click would), so a
+   * "Finish" button can end a route draw. A no-op until the sketch has enough
+   * points; OL then dispatches drawend → onDrawEnd through the normal path.
+   */
+  finishDrawing() {
+    this.routeDraw?.finishDrawing();
+  }
+
   /** Handle OL interaction end event */
   protected onDrawEnd(e: { feature: Feature }) {
     // OL dispatches drawend synchronously from the map's viewport pointer
@@ -1064,6 +1076,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
     this.mapInteract.startModifying(this.overlay());
     if (this.overlay().type === 'route') {
       const rid = this.overlay().id;
+      // Route name for the helper title ("Modify <name>"). An unnamed draft
+      // resolves to the "(unsaved)" placeholder from formatPopover(), which we
+      // keep on purpose so the title reads "Modify (unsaved)" — a deliberate
+      // signal that the route has not been saved.
+      const res = this.overlay().resource;
+      this.mapInteract.draw.name = Array.isArray(res)
+        ? ((res[1] as SKRoute)?.name ?? '')
+        : '';
       this.mapInteract.measurementCoords = this.routeBuffers.has(rid)
         ? (this.routeBuffers
             .get(rid)!

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -75,6 +75,7 @@ export interface DrawFeatureInfo {
   forSave: any;
   properties: { [key: string]: any };
   style?: any; // feature draw style
+  name?: string; // display name of the feature being modified (helper title)
 }
 
 @Injectable({ providedIn: 'root' })
@@ -214,6 +215,7 @@ export class FBMapInteractService {
   startDrawing(resType: DrawFeatureType) {
     this.app.debug(`startDrawing()...`);
     this.isDrawing.set(true);
+    this.draw.name = undefined;
     this.draw.resourceType = resType;
     this.draw.featureType =
       resType === 'route'
@@ -262,6 +264,7 @@ export class FBMapInteractService {
       return;
     }
     this.isModifying.set(true);
+    this.draw.name = undefined;
     this.draw.resourceType = overlay.type as DrawFeatureType;
     this.draw.featureType = null;
     this.draw.forSave = { id: null, coords: null };

--- a/src/app/modules/map/ol/lib/interactions/interaction-draw.component.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-draw.component.ts
@@ -72,6 +72,16 @@ export class InteractionDrawComponent {
     }
   }
 
+  /**
+   * Complete the current sketch, as a double-click does — dispatches `drawend`
+   * and adds the sketch to the layer, letting a "Finish" button end a route
+   * draw without the double-click gesture. Whether the sketch has enough points
+   * is enforced by the caller's Finish gating, not here.
+   */
+  finishDrawing() {
+    this.interaction?.finishDrawing();
+  }
+
   // ** emit events
   private emitChangeEvent = (event: DrawEvent) => this.change.emit(event);
   private emitDrawStartEvent = (event: DrawEvent) => this.drawStart.emit(event);

--- a/src/app/modules/map/popovers/popover.component.scss
+++ b/src/app/modules/map/popovers/popover.component.scss
@@ -120,6 +120,16 @@
     flex:1 1 45%;
 }
 
+.popover.docked {
+    position: static;
+    transform: none;
+    margin: 0;
+}
+
+.popover.docked > .arrow {
+    display: none;
+}
+
 .popover.compact {
     min-width: 0;
     max-width: 170px;

--- a/src/app/modules/map/popovers/popover.component.ts
+++ b/src/app/modules/map/popovers/popover.component.ts
@@ -35,7 +35,7 @@ measure: boolean= measure mode;
   template: `
     <div
       class="popover top in mat-app-background"
-      [ngClass]="{ measure: measure, compact: compact }"
+      [ngClass]="{ measure: measure, compact: compact, docked: docked }"
     >
       @if (title || icon || mmsi || canClose || navTo) {
         <div class="popover-title">
@@ -106,6 +106,9 @@ export class PopoverComponent {
   @Input() canClose = true;
   @Input() measure = false;
   @Input() compact = false;
+  /** Render in place (no anchor arrow, static position) for use as a docked
+   *  panel rather than a feature-anchored popover. */
+  @Input() docked = false;
   @Input() navTo = false;
   @Output() closed: EventEmitter<void> = new EventEmitter();
   @Output() navigateTo: EventEmitter<void> = new EventEmitter();


### PR DESCRIPTION
Unifies the route creation/editing helpers into one consistent card (#545).

**Why.** Drawing a route, clicking a route, and modifying one each presented a
different helper. Draw and Modify in particular looked unrelated despite being
the same kind of operation.

**What.** Route Draw and Modify now share one docked popover card — the same
chrome as the feature popover — with distance at the top, the modify leg
read-out preserved, and `Finish` + `Cancel` actions in a fixed place. Drawing's
`Finish` completes the sketch via the OpenLayers draw interaction, so it matches
Modify's rather than relying on a double-click.

Before:
<img width="371" height="196" alt="Screenshot 2026-07-24 at 10 06 58 PM" src="https://github.com/user-attachments/assets/66568d54-4398-476a-b650-13cb99fbbcea" />

<img width="222" height="77" alt="Screenshot 2026-07-25 at 12 57 54 PM" src="https://github.com/user-attachments/assets/13df88d0-937f-4db0-bf41-6164ecae8209" />


After:
<img width="303" height="233" alt="Screenshot 2026-07-25 at 12 42 09 PM" src="https://github.com/user-attachments/assets/f4aa8fa7-2d3d-4c7a-a0f7-4f6fab0066f8" />

<img width="290" height="209" alt="Screenshot 2026-07-25 at 12 42 21 PM" src="https://github.com/user-attachments/assets/7bb25900-b459-4706-9fef-e13e46ec2c1f" />


**Behaviour change.** A route edit now commits directly from the card — `Finish`
saves, `Cancel` / the title-bar `✕` discards — replacing the old "Save route
changes?" confirm prompt. Non-route modifies (waypoint/note/region) keep their
confirm. Measure/box-select and other draws are unchanged.

Deferred to separate issues: the Undo↔Modify swap (depends on #542) and enabling
the Points reorder dialog on unsaved routes (needs the Points dialog to work
against the route buffer).

Closes #545
