### PR TITLE
feat(routes): add undo for route drawing and editing

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1128,6 +1128,7 @@
             <fb-interact-help
               (finish)="handleInteractionFinish()"
               (cancel)="closeInteraction()"
+              (undo)="handleInteractionUndo()"
             >
             </fb-interact-help>
           }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  HostListener,
   ViewChild,
   computed,
   effect,
@@ -1914,6 +1915,39 @@ export class AppComponent {
     } else {
       this.closeInteraction(true);
     }
+  }
+
+  /**
+   * "Undo" from the route draw/modify helper (button or Ctrl/Cmd-Z): step a
+   * draw back one point, or revert the last modify operation (#542).
+   */
+  protected handleInteractionUndo() {
+    this.fbMap.undoInteraction();
+  }
+
+  /**
+   * Ctrl-Z / Cmd-Z undoes the last route edit while drawing or modifying.
+   * Ignored when the undo would be ambiguous — a text field has focus (native
+   * text undo) or nothing is undoable.
+   */
+  @HostListener('document:keydown', ['$event'])
+  protected onDocumentKeydown(e: KeyboardEvent) {
+    const isUndo = (e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z';
+    if (!isUndo || !this.mapInteract.canUndo()) {
+      return;
+    }
+    const el = e.target as HTMLElement | null;
+    const tag = el?.tagName;
+    if (
+      tag === 'INPUT' ||
+      tag === 'TEXTAREA' ||
+      tag === 'SELECT' ||
+      el?.isContentEditable
+    ) {
+      return;
+    }
+    e.preventDefault();
+    this.handleInteractionUndo();
   }
 
   /**

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -86,6 +86,7 @@ import {
 
 import { Convert } from 'src/app/lib/convert';
 import { GeoUtils } from 'src/app/lib/geoutils';
+import { isUndoKeyEvent } from 'src/app/lib/undo-keys';
 
 import * as semver from 'semver';
 
@@ -1927,23 +1928,12 @@ export class AppComponent {
 
   /**
    * Ctrl-Z / Cmd-Z undoes the last route edit while drawing or modifying.
-   * Ignored when the undo would be ambiguous — a text field has focus (native
-   * text undo) or nothing is undoable.
+   * Ignored when there is nothing to undo (`isUndoKeyEvent` already excludes
+   * text-editing targets, where the browser's own undo should win).
    */
   @HostListener('document:keydown', ['$event'])
   protected onDocumentKeydown(e: KeyboardEvent) {
-    const isUndo = (e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z';
-    if (!isUndo || !this.mapInteract.canUndo()) {
-      return;
-    }
-    const el = e.target as HTMLElement | null;
-    const tag = el?.tagName;
-    if (
-      tag === 'INPUT' ||
-      tag === 'TEXTAREA' ||
-      tag === 'SELECT' ||
-      el?.isContentEditable
-    ) {
+    if (!isUndoKeyEvent(e) || !this.mapInteract.canUndo()) {
       return;
     }
     e.preventDefault();

--- a/src/app/lib/components/interact-help.component.spec.ts
+++ b/src/app/lib/components/interact-help.component.spec.ts
@@ -90,4 +90,68 @@ describe('InteractionHelpComponent — unified route helper', () => {
     expect(finished).toBe(true);
     expect(cancelled).toBe(true);
   });
+
+  it('emits undo from the card Undo action (#542)', () => {
+    svc.draw.resourceType = 'route';
+    svc.isModifying.set(true);
+    const c = create();
+    let undone = false;
+    c.undo.subscribe(() => (undone = true));
+    c.undoLast();
+    expect(undone).toBe(true);
+  });
+});
+
+/**
+ * The route-editing undo stack lives on the interaction service (issue #542) so
+ * the docked card's Undo button and Ctrl/Cmd-Z share one source of truth. These
+ * cover the `canUndo` signal across draw and modify, and that starting an
+ * interaction clears any prior history.
+ */
+describe('FBMapInteractService — route editing undo', () => {
+  let svc: FBMapInteractService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: AppFacade,
+          useValue: {
+            debug: () => undefined,
+            uiCtrl: { update: () => undefined }
+          }
+        }
+      ]
+    });
+    svc = TestBed.inject(FBMapInteractService);
+  });
+
+  it('offers undo while drawing once a point is placed', () => {
+    svc.isDrawing.set(true);
+    expect(svc.canUndo()).toBe(false);
+    svc.measurementCoords = [[0, 0]];
+    expect(svc.canUndo()).toBe(true);
+    svc.measurementCoords = [];
+    expect(svc.canUndo()).toBe(false);
+  });
+
+  it('offers undo while modifying once an operation is stacked', () => {
+    svc.isModifying.set(true);
+    expect(svc.canUndo()).toBe(false);
+    svc.pushModifyUndo({ coordinates: [[0, 0]] });
+    expect(svc.canUndo()).toBe(true);
+    const snap = svc.popModifyUndo();
+    expect(snap?.coordinates).toEqual([[0, 0]]);
+    expect(svc.canUndo()).toBe(false);
+  });
+
+  it('clears the modify undo history when a new interaction starts', () => {
+    svc.isModifying.set(true);
+    svc.pushModifyUndo({ coordinates: [[0, 0]] });
+    expect(svc.canUndo()).toBe(true);
+
+    svc.startDrawing('route');
+    expect(svc.popModifyUndo()).toBeUndefined();
+    expect(svc.canUndo()).toBe(false);
+  });
 });

--- a/src/app/lib/components/interact-help.component.ts
+++ b/src/app/lib/components/interact-help.component.ts
@@ -57,6 +57,18 @@ import { PopoverComponent } from 'src/app/modules/map/popovers/popover.component
             <div class="_ap_action_button">
               <button
                 mat-button
+                [disabled]="!mapInteract.canUndo()"
+                (click)="undoLast()"
+                matTooltip="Undo last change (Ctrl/Cmd-Z)"
+                matTooltipPosition="after"
+              >
+                <mat-icon>undo</mat-icon>
+                UNDO
+              </button>
+            </div>
+            <div class="_ap_action_button">
+              <button
+                mat-button
                 color="primary"
                 [disabled]="!canFinish()"
                 (click)="finishEditing()"
@@ -210,6 +222,7 @@ import { PopoverComponent } from 'src/app/modules/map/popovers/popover.component
 export class InteractionHelpComponent {
   finish = output<void>();
   cancel = output<void>();
+  undo = output<void>();
 
   protected showHelpPanel: Signal<boolean>;
   protected showMeasurePanel: Signal<boolean>;
@@ -353,5 +366,10 @@ export class InteractionHelpComponent {
   /** Finish — complete & keep (drawing finishes the sketch; modify exits). */
   finishEditing() {
     this.finish.emit();
+  }
+
+  /** Undo — step the draw back a point or revert the last modify operation. */
+  undoLast() {
+    this.undo.emit();
   }
 }

--- a/src/app/lib/undo-keys.spec.ts
+++ b/src/app/lib/undo-keys.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { isUndoKeyEvent } from './undo-keys';
+
+/**
+ * The Ctrl-Z / Cmd-Z guard for route-editing undo (#542): fires only for the
+ * undo chord, and never when a text-editing element has focus (the browser's
+ * own undo should win there).
+ */
+describe('isUndoKeyEvent', () => {
+  const ev = (o: Partial<Record<string, unknown>>): KeyboardEvent =>
+    ({
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      key: 'z',
+      target: null,
+      ...o
+    }) as unknown as KeyboardEvent;
+
+  it('matches Ctrl-Z and Cmd-Z', () => {
+    expect(isUndoKeyEvent(ev({ ctrlKey: true }))).toBe(true);
+    expect(isUndoKeyEvent(ev({ metaKey: true }))).toBe(true);
+  });
+
+  it('still matches with CapsLock on (uppercase key)', () => {
+    expect(isUndoKeyEvent(ev({ ctrlKey: true, key: 'Z' }))).toBe(true);
+  });
+
+  it('ignores the redo chord (Shift) and plain z', () => {
+    expect(isUndoKeyEvent(ev({ ctrlKey: true, shiftKey: true }))).toBe(false);
+    expect(isUndoKeyEvent(ev({ key: 'z' }))).toBe(false);
+    expect(isUndoKeyEvent(ev({ ctrlKey: true, key: 'a' }))).toBe(false);
+  });
+
+  it('is ignored while a text-editing target has focus', () => {
+    for (const tagName of ['INPUT', 'TEXTAREA', 'SELECT']) {
+      expect(isUndoKeyEvent(ev({ ctrlKey: true, target: { tagName } }))).toBe(
+        false
+      );
+    }
+    expect(
+      isUndoKeyEvent(ev({ ctrlKey: true, target: { isContentEditable: true } }))
+    ).toBe(false);
+  });
+});

--- a/src/app/lib/undo-keys.ts
+++ b/src/app/lib/undo-keys.ts
@@ -1,0 +1,22 @@
+/**
+ * True when a keydown is the "undo" shortcut — Ctrl-Z / Cmd-Z, without Shift so
+ * it doesn't collide with the common redo chord — and is not aimed at a
+ * text-editing target, where the browser's own undo should win. The key match
+ * is case-insensitive so the shortcut still fires with CapsLock on (`e.key`
+ * would otherwise be `'Z'`).
+ */
+export function isUndoKeyEvent(e: KeyboardEvent): boolean {
+  const isUndo =
+    (e.ctrlKey || e.metaKey) && !e.shiftKey && e.key.toLowerCase() === 'z';
+  if (!isUndo) {
+    return false;
+  }
+  const el = e.target as HTMLElement | null;
+  const tag = el?.tagName;
+  return !(
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    !!el?.isContentEditable
+  );
+}

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -979,6 +979,62 @@ export class FBMapComponent implements OnInit, OnDestroy {
     this.routeDraw?.finishDrawing();
   }
 
+  /**
+   * Undo the last action in the active route interaction (#542): while drawing,
+   * remove the last placed point (repeatable back to the first); while
+   * modifying, revert the last vertex operation from the session undo stack.
+   */
+  undoInteraction() {
+    if (this.mapInteract.isDrawing()) {
+      this.undoDrawPoint();
+    } else if (this.mapInteract.isModifying()) {
+      this.undoModify();
+    }
+  }
+
+  /** Remove the last point placed in the current route draw sketch. */
+  private undoDrawPoint() {
+    this.routeDraw?.removeLastPoint();
+    // Keep the distance read-out in step: the sketch just lost its last placed
+    // point (the floating cursor point is excluded from measurement coords).
+    const coords = this.mapInteract.measurement().coords;
+    this.mapInteract.measurementCoords = coords.slice(
+      0,
+      Math.max(0, coords.length - 1)
+    );
+  }
+
+  /** Revert the last vertex operation of the current route Modify session. */
+  private undoModify() {
+    const snap = this.mapInteract.popModifyUndo();
+    if (!snap) {
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const f: any = this.mapInteract.draw.features?.getArray()[0];
+    if (!f) {
+      return;
+    }
+    // setCoordinates fires the feature's 'change' event; the active OL Modify
+    // interaction listens for it (handleFeatureChange_) and rebuilds its
+    // segment/vertex index whenever the geometry changes outside its own drag
+    // (changingFeature_ is false here), so the next drag targets the restored
+    // vertices — no manual re-sync of the interaction is needed.
+    f.getGeometry().setCoordinates(snap.coordinates);
+    // Restore per-point metadata on the feature too: updateCoordsMeta mutates
+    // pointMetadata in place, and the next modifystart re-reads it from the
+    // feature — so without this a later edit would splice a stale, wrong-length
+    // metadata array.
+    f.set('pointMetadata', snap.coordsMetadata ?? null);
+    // Re-baseline session state to the restored geometry so the next op (and a
+    // subsequent Finish/Cancel) sees the reverted route.
+    this.mapInteract.draw.coordinates = snap.coordinates;
+    this.mapInteract.draw.forSave.coordsMetadata = snap.coordsMetadata;
+    const pc = this.transformCoordsArray(snap.coordinates) as LineString;
+    this.mapInteract.draw.forSave['coords'] = pc;
+    this.mapInteract.measurementCoords = pc;
+  }
+
   /** Handle OL interaction end event */
   protected onDrawEnd(e: { feature: Feature }) {
     // OL dispatches drawend synchronously from the map's viewport pointer
@@ -1128,6 +1184,21 @@ export class FBMapComponent implements OnInit, OnDestroy {
     const f: any = e.features.getArray()[0];
     const fid = f.getId();
     const c = f.getGeometry().getCoordinates();
+    // Snapshot the pre-operation route geometry so this vertex op (move / add /
+    // delete) can be undone within the current Modify session (#542).
+    // draw.coordinates holds the geometry as it was at modifystart;
+    // coordsMetadata is mutated in place by updateCoordsMeta below, so clone it
+    // now.
+    if (fid.split('.')[0] === 'route') {
+      const meta = this.mapInteract.draw.forSave.coordsMetadata as
+        Array<{ name?: string; description?: string }> | undefined;
+      this.mapInteract.pushModifyUndo({
+        coordinates: (this.mapInteract.draw.coordinates as Position[]).map(
+          (co) => [...co] as Position
+        ),
+        coordsMetadata: meta ? meta.map((m) => ({ ...m })) : undefined
+      });
+    }
     if (f.getGeometry().getType() === 'LineString') {
       this.updateCoordsMeta(
         this.mapInteract.draw.coordinates,

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -1,6 +1,6 @@
 /** Map interactions Service
  * ************************************/
-import { inject, Injectable, signal } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 import { Feature } from 'ol';
 import { Coordinate } from 'ol/coordinate';
 import { toLonLat } from 'ol/proj';
@@ -78,6 +78,17 @@ export interface DrawFeatureInfo {
   name?: string; // display name of the feature being modified (helper title)
 }
 
+/**
+ * A pre-operation snapshot of a route being modified, used to undo the last
+ * vertex operation (move / add / delete) within the current Modify session.
+ * Coordinates are in render space (EPSG:3857) — the raw feature geometry — so
+ * restoring is a straight `setCoordinates`, world-copy offset and all.
+ */
+export interface ModifyUndoSnapshot {
+  coordinates: Position[];
+  coordsMetadata?: Array<{ name?: string; description?: string }>;
+}
+
 @Injectable({ providedIn: 'root' })
 export class FBMapInteractService {
   // signals
@@ -110,9 +121,52 @@ export class FBMapInteractService {
     properties: {}
   };
 
+  /**
+   * Undo history for the current route Modify session: pre-operation geometry
+   * snapshots, most-recent last. Session-scoped — reset when a draw or modify
+   * starts or ends. Route draw uses OpenLayers' own sketch history
+   * (`removeLastPoint`) instead, so it is not stacked here.
+   */
+  private modifyUndoStack: ModifyUndoSnapshot[] = [];
+  private readonly undoDepth = signal<number>(0);
+
+  /**
+   * Whether an Undo is available in the current interaction: during a route
+   * draw once at least one point is placed (OL sketch history), during a modify
+   * once at least one vertex operation has been made.
+   */
+  readonly canUndo = computed<boolean>(() => {
+    if (this.isDrawing()) {
+      return this.measurement().coords.length >= 1;
+    }
+    if (this.isModifying()) {
+      return this.undoDepth() > 0;
+    }
+    return false;
+  });
+
   private app = inject(AppFacade);
 
   constructor() {}
+
+  /** Push a pre-operation snapshot onto the modify undo stack. */
+  pushModifyUndo(snapshot: ModifyUndoSnapshot) {
+    this.modifyUndoStack.push(snapshot);
+    this.undoDepth.set(this.modifyUndoStack.length);
+  }
+
+  /** Pop the most recent modify snapshot, or undefined when the stack is empty. */
+  popModifyUndo(): ModifyUndoSnapshot | undefined {
+    const snap = this.modifyUndoStack.pop();
+    this.undoDepth.set(this.modifyUndoStack.length);
+    return snap;
+  }
+
+  /** Discard all undo history (called when an interaction starts or ends). */
+  private clearUndo() {
+    this.modifyUndoStack = [];
+    this.undoDepth.set(0);
+  }
 
   /** add start coordinate to box select */
   initBoxCoord(coord: Position) {
@@ -329,6 +383,7 @@ export class FBMapInteractService {
   /** Common interaction start tasks */
   private interactionStarted() {
     this.app.debug(`interactionStarted()...`);
+    this.clearUndo();
     this.measurement.set({
       coords: [],
       index: -1,
@@ -343,6 +398,7 @@ export class FBMapInteractService {
   /** Interaction cleanup tasks */
   private interactionEnded() {
     this.app.debug(`interactionEnded()...`);
+    this.clearUndo();
     this.app.uiCtrl.update((current) => {
       return Object.assign({}, current, { suppressContextMenu: false });
     });

--- a/src/app/modules/map/ol/lib/interactions/interaction-draw.component.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-draw.component.ts
@@ -82,6 +82,15 @@ export class InteractionDrawComponent {
     this.interaction?.finishDrawing();
   }
 
+  /**
+   * Remove the last point placed in the current sketch, letting an "Undo"
+   * button step a route draw back one point at a time. Successive calls peel
+   * off successive points; a no-op once the sketch is empty.
+   */
+  removeLastPoint() {
+    this.interaction?.removeLastPoint();
+  }
+
   // ** emit events
   private emitChangeEvent = (event: DrawEvent) => this.change.emit(event);
   private emitDrawStartEvent = (event: DrawEvent) => this.drawStart.emit(event);


### PR DESCRIPTION
Adds Undo to route creation and editing (closes #542).

**Why.** Placing a wrong point mid-draw, or nudging the wrong vertex while
editing, previously meant starting over or fixing it by hand. Undo makes route
work forgiving.

**What.**
- **Draw:** Undo removes the last placed point — repeatable back to the first —
  via OpenLayers' sketch history.
- **Modify:** each vertex operation (move / add / delete) is snapshotted, so Undo
  reverts it one step at a time within the current Modify session; geometry and
  per-point metadata are restored together.
- Surfaced as an UNDO button on the route draw/modify card and via Ctrl-Z /
  Cmd-Z (ignored while a text field has focus).

**Scope.** Session-scoped — the history resets when an interaction starts or ends
— and the Finish/Cancel commit flow is unchanged. The button sits leftmost in the
action row for now; the Undo/Modify layout swap noted in #582 is a separate
follow-up.

Unit tests cover the `canUndo` state machine (draw and modify) and the card's
Undo action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Undo support while drawing and editing routes.
  * Use the Undo button in the interaction help panel or press Ctrl+Z/Cmd+Z.
  * Undo is disabled when no reversible changes are available.
  * Undo restores route geometry and associated point details during editing.

* **Bug Fixes**
  * Preserved route metadata when undoing vertex modifications.
  * Undo history is cleared when a new interaction begins or ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->