### PR TITLE
fix(map): rename navigation-stop controls to "Stop Navigating"

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -102,11 +102,7 @@
       @if (course.courseData().position) {
         <a mat-menu-item (click)="clearDestination()">
           <mat-icon>clear_all</mat-icon>
-          @if (app.data.activeRoute) {
-            <span>Clear Active Route</span>
-          } @else {
-            <span>Clear Destination</span>
-          }
+          <span>Stop Navigating</span>
         </a>
         <a mat-menu-item (click)="clearCourseData()">
           <mat-icon>clear_all</mat-icon>

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -933,11 +933,7 @@
         (click)="onContextMenuAction('cleardestination', item)"
       >
         <mat-icon>clear_all</mat-icon>
-        @if (app.data.activeRoute) {
-          <span>Clear Active Route</span>
-        } @else {
-          <span>Clear Destination</span>
-        }
+        <span>Stop Navigating</span>
       </button>
     }
     @if (app.data.vessels.showSelf || course.courseData().position) {

--- a/src/app/modules/map/popovers/resource-popover.component.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.ts
@@ -187,11 +187,11 @@ interface PopoverCtrl {
             <button
               mat-button
               (click)="emitActive(false)"
-              matTooltip="Clear Destination"
+              matTooltip="Stop Navigating"
               matTooltipPosition="after"
             >
               <mat-icon>clear_all</mat-icon>
-              CLEAR
+              STOP
             </button>
           </div>
         }

--- a/src/app/modules/skresources/components/routes/route-panel.html
+++ b/src/app/modules/skresources/components/routes/route-panel.html
@@ -62,10 +62,10 @@
           mat-button
           [disabled]="interacting()"
           (click)="onGoto(-1)"
-          matTooltip="Clear Destination"
+          matTooltip="Stop Navigating"
         >
           <mat-icon>clear_all</mat-icon>
-          CLEAR
+          STOP
         </button>
         } &nbsp;
         <button

--- a/src/app/modules/skresources/components/routes/routelist.html
+++ b/src/app/modules/skresources/components/routes/routelist.html
@@ -162,7 +162,7 @@
                 mat-icon-button
                 [disabled]="disableRefresh()"
                 (click)="itemClearActive(r[0])"
-                matTooltip="Clear Active Route"
+                matTooltip="Stop Navigating"
                 matTooltipPosition="above"
               >
                 <mat-icon>clear_all</mat-icon>

--- a/src/app/modules/skresources/components/waypoints/waypoint-panel.html
+++ b/src/app/modules/skresources/components/waypoints/waypoint-panel.html
@@ -64,10 +64,10 @@
           mat-button
           [disabled]="interacting()"
           (click)="onGoto(true)"
-          matTooltip="Clear Destination"
+          matTooltip="Stop Navigating"
         >
           <mat-icon>clear_all</mat-icon>
-          CLEAR
+          STOP
         </button>
         } &nbsp;
         <button

--- a/src/app/modules/skresources/components/waypoints/waypointlist.html
+++ b/src/app/modules/skresources/components/waypoints/waypointlist.html
@@ -135,7 +135,7 @@
                 mat-icon-button
                 [disabled]="disableRefresh"
                 (click)="itemClearActive()"
-                matTooltip="Clear Destination"
+                matTooltip="Stop Navigating"
                 matTooltipPosition="above"
               >
                 <mat-icon>clear_all</mat-icon>


### PR DESCRIPTION
The "Clear Active Route" / "Clear Destination" labels read as destructive —
they sound like they delete the route or waypoint. They don't: they stop
navigating and leave the resource untouched.

Use one consistent label, **"Stop Navigating"**, for the stop-navigation
action wherever it appears, covering both an active route and a single
waypoint destination. Button text becomes `STOP`; behaviour is unchanged.

Surfaces updated:
- map menu + map context menu (`app.component`, `fb-map.component`)
- route list tooltip + route panel button (`routelist`, `route-panel`)
- waypoint list tooltip + waypoint panel button (`waypointlist`, `waypoint-panel`)
- map feature popover button (`resource-popover`)

The now-redundant route-vs-destination conditionals in the two menus collapse
to a single label. Unrelated "Clear" actions (Clear Trail, Clear Course Data)
are untouched.

Closes #547

@coderabbitai ignore
