### PR TITLE
fix(map): use a larger hit tolerance for touch pointers

### DIFF
--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -25,7 +25,7 @@ import { toLonLat, transformExtent } from 'ol/proj';
 import { Coordinate } from 'ol/coordinate';
 import { FeatureLike } from 'ol/Feature';
 import { Extent, getWidth } from 'ol/extent';
-import { worldCopyOffset } from './util';
+import { hitToleranceForPointer, worldCopyOffset } from './util';
 import { tryDeleteHeldVertexOnHold } from './vertex-delete';
 
 export interface FBMapEvent extends MapEvent {
@@ -133,6 +133,9 @@ export class MapComponent implements OnInit, OnDestroy {
   @Input() properties: { [index: string]: any };
   @Input() setFocus = '';
   @Input() hitTolerance = 5;
+  // Touch pointers get a larger radius than the mouse so a deliberate tap on a
+  // thin route line lands in the common case (#548).
+  @Input() touchHitTolerance = 15;
 
   private _pointerDown = signal<MouseEvent>(undefined);
   public pointerDownSignal = this._pointerDown.asReadonly();
@@ -347,7 +350,11 @@ export class MapComponent implements OnInit, OnDestroy {
         features: this.map.getFeaturesAtPixel(
           this.map.getPixelFromCoordinateInternal(c),
           {
-            hitTolerance: this.hitTolerance
+            hitTolerance: hitToleranceForPointer(
+              (event as PointerEvent).pointerType,
+              this.hitTolerance,
+              this.touchHitTolerance
+            )
           }
         ),
         lonlat: toLonLat(c),
@@ -378,7 +385,11 @@ export class MapComponent implements OnInit, OnDestroy {
   private augmentClickEvent(event: MapBrowserEvent<PointerEvent>) {
     return Object.assign(event, {
       features: this.map.getFeaturesAtPixel(event.pixel, {
-        hitTolerance: this.hitTolerance
+        hitTolerance: hitToleranceForPointer(
+          event.originalEvent?.pointerType,
+          this.hitTolerance,
+          this.touchHitTolerance
+        )
       }),
       lonlat: toLonLat(event.coordinate),
       worldOffset: this.worldOffsetOf(event.coordinate)

--- a/src/app/modules/map/ol/lib/util.spec.ts
+++ b/src/app/modules/map/ol/lib/util.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mapifyCoords, worldCopyOffset } from './util';
+import { hitToleranceForPointer, mapifyCoords, worldCopyOffset } from './util';
 import { Coordinate } from './models';
 
 // EPSG:3857 world width (metres), as OL derives it from the projection extent.
@@ -42,6 +42,25 @@ describe('worldCopyOffset', () => {
     expect(worldCopyOffset(Infinity, W)).toBe(0);
     expect(worldCopyOffset(NaN, W)).toBe(0);
     expect(worldCopyOffset(1000, 0)).toBe(0);
+  });
+});
+
+describe('hitToleranceForPointer', () => {
+  it('uses the larger touch radius for a touch pointer', () => {
+    expect(hitToleranceForPointer('touch', 5, 15)).toBe(15);
+  });
+
+  it('uses the mouse radius for a mouse pointer', () => {
+    expect(hitToleranceForPointer('mouse', 5, 15)).toBe(5);
+  });
+
+  it('uses the mouse radius for a pen pointer (precise stylus)', () => {
+    expect(hitToleranceForPointer('pen', 5, 15)).toBe(5);
+  });
+
+  it('falls back to the mouse radius when pointer type is unknown', () => {
+    // e.g. a synthetic contextmenu MouseEvent has no pointerType.
+    expect(hitToleranceForPointer(undefined, 5, 15)).toBe(5);
   });
 });
 

--- a/src/app/modules/map/ol/lib/util.spec.ts
+++ b/src/app/modules/map/ol/lib/util.spec.ts
@@ -58,9 +58,13 @@ describe('hitToleranceForPointer', () => {
     expect(hitToleranceForPointer('pen', 5, 15)).toBe(5);
   });
 
-  it('falls back to the mouse radius when pointer type is unknown', () => {
-    // e.g. a synthetic contextmenu MouseEvent has no pointerType.
+  it('falls back to the mouse radius for any non-touch pointer type', () => {
+    // A synthetic contextmenu MouseEvent has no pointerType, and the Pointer
+    // Events spec permits an empty string when the device can't be determined —
+    // everything that isn't 'touch' keeps the mouse radius.
     expect(hitToleranceForPointer(undefined, 5, 15)).toBe(5);
+    expect(hitToleranceForPointer('', 5, 15)).toBe(5);
+    expect(hitToleranceForPointer('unknown', 5, 15)).toBe(5);
   });
 });
 

--- a/src/app/modules/map/ol/lib/util.ts
+++ b/src/app/modules/map/ol/lib/util.ts
@@ -101,6 +101,23 @@ export function worldCopyOffset(mercX: number, worldWidth: number): number {
   return Math.round(mercX / worldWidth) * worldWidth;
 }
 
+/**
+ * Hit-test tolerance (px radius) appropriate for the pointer that generated an
+ * event. A fingertip covers far more area than a mouse cursor, so a thin feature
+ * such as a route line is easy to miss at the mouse-sized tolerance — return the
+ * larger touch radius for a coarse (touch) pointer, the mouse radius otherwise.
+ * `pointerType` is the `PointerEvent.pointerType` field ('mouse' | 'touch' |
+ * 'pen'); `undefined` (e.g. a synthetic contextmenu `MouseEvent`) falls back to
+ * the mouse radius, so mouse behaviour is unchanged.
+ */
+export function hitToleranceForPointer(
+  pointerType: string | undefined,
+  mouseTolerance: number,
+  touchTolerance: number
+): number {
+  return pointerType === 'touch' ? touchTolerance : mouseTolerance;
+}
+
 // ** return adjusted radius to correctly render circle on ground at given position.
 export function mapifyRadius(radius: number, position: Coordinate): number {
   if (typeof radius === 'undefined' || typeof position === 'undefined') {


### PR DESCRIPTION
## Why

Routes are core, and on a touchscreen selecting a route drawn on the chart often
took several taps — and a long-press that missed the thin line fell through to the
generic map context menu instead of offering route actions. The cause: a single
`hitTolerance = 5` px was shared by mouse and touch, but a fingertip covers far
more area than a mouse cursor.

## How

Make the hit tolerance input-aware. A pure helper picks the tolerance from the
event's `pointerType`: a larger radius (`touchHitTolerance = 15`) for touch
pointers, the unchanged `hitTolerance = 5` for mouse — and pen (precise stylus) and
any unrecognized/empty pointer type (e.g. a synthetic contextmenu `MouseEvent`) also
keep the mouse radius. Both `getFeaturesAtPixel` call sites (single-click and
long-press/right-click) route through it, so mouse behaviour is unchanged.

Covered by a co-located vitest regression test on the helper.

Closes #548

@coderabbitai ignore
