### PR TITLE
feat(routes): add a Hide action to the route popover

### DIFF
--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -637,6 +637,7 @@
           (delete)="
             deleteFeature(overlay().id, overlay().type); popoverClosed()
           "
+          (hide)="hideFeature(overlay().id, overlay().type); popoverClosed()"
           (addNote)="
             skres.showNoteEditor({
               type: overlay().type,

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -2126,6 +2126,15 @@ export class FBMapComponent implements OnInit, OnDestroy {
     }
   }
 
+  // ** hide a displayed feature (non-destructive; resource is untouched)
+  protected hideFeature(id: string, type: string) {
+    if (type === 'route') {
+      // Same effect as unchecking "Show on Map" in the Routes list — remove the
+      // route from the displayed set; it reappears when re-selected there.
+      this.skres.routeRemove([id]);
+    }
+  }
+
   // ** activate route / waypoint
   protected setActiveFeature() {
     if (this.overlay().type === 'waypoint') {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -2131,7 +2131,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
     if (type === 'route') {
       // Same effect as unchecking "Show on Map" in the Routes list — remove the
       // route from the displayed set; it reappears when re-selected there.
-      this.skres.routeRemove([id]);
+      this.skres.routeHide(id);
     }
   }
 

--- a/src/app/modules/map/popovers/resource-popover.component.spec.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.spec.ts
@@ -5,11 +5,11 @@ import { ResourcePopoverComponent } from './resource-popover.component';
 // rather than importing SKRoute, to avoid pulling a second deep module path
 // into the test graph (which perturbs barrel-import evaluation order and can
 // break the AppComponent bootstrap spec).
-const routeStub = () => ({
+const routeStub = (readOnly = false) => ({
   name: '',
   description: '',
   distance: 0,
-  feature: { properties: {} }
+  feature: { properties: { readOnly } }
 });
 
 /**
@@ -29,12 +29,12 @@ const appStub = {
   useInfoPanel: () => false
 };
 
-function popover(canSave: boolean) {
+function popover(canSave: boolean, readOnly = false) {
   const c = Object.create(
     ResourcePopoverComponent.prototype
   ) as ResourcePopoverComponent;
   Object.assign(c, {
-    resource: () => ['route-1', routeStub()],
+    resource: () => ['route-1', routeStub(readOnly)],
     type: () => 'route',
     active: () => undefined,
     featureCount: () => 2,
@@ -46,6 +46,7 @@ function popover(canSave: boolean) {
       showInfoButton: false,
       showModifyButton: false,
       showDeleteButton: false,
+      showHideButton: false,
       showAddNoteButton: false,
       showRelatedButton: false,
       showPointsButton: false,
@@ -60,7 +61,11 @@ function popover(canSave: boolean) {
   });
   (c as unknown as { computeControls: () => void }).computeControls();
   return c as unknown as {
-    ctrl: { showInfoButton: boolean; showSaveButton: boolean };
+    ctrl: {
+      showInfoButton: boolean;
+      showSaveButton: boolean;
+      showHideButton: boolean;
+    };
   };
 }
 
@@ -75,5 +80,34 @@ describe('ResourcePopoverComponent — route Info visibility (#533)', () => {
     const c = popover(true);
     expect(c.ctrl.showSaveButton).toBe(true);
     expect(c.ctrl.showInfoButton).toBe(false);
+  });
+});
+
+/**
+ * Hide action for the route popover (#551). Hide removes a route from the
+ * displayed set (a shortcut for the Routes-list "Show on Map" toggle) without
+ * deleting the resource. It is offered for a saved route but not for an unsaved
+ * draft — a draft isn't in the Routes list, so hiding it would leave no way to
+ * bring it back (Delete/discard is offered there instead).
+ */
+describe('ResourcePopoverComponent — route Hide visibility (#551)', () => {
+  it('offers HIDE for a saved route', () => {
+    const c = popover(false);
+    expect(c.ctrl.showHideButton).toBe(true);
+  });
+
+  it('does not offer HIDE for an unsaved route draft', () => {
+    const c = popover(true);
+    expect(c.ctrl.showSaveButton).toBe(true);
+    expect(c.ctrl.showHideButton).toBe(false);
+  });
+
+  it('offers HIDE for a read-only route (non-destructive display toggle)', () => {
+    const c = popover(false, true) as unknown as {
+      ctrl: { showHideButton: boolean; showDeleteButton: boolean };
+    };
+    // Read-only suppresses DELETE but not HIDE — hiding never touches the resource.
+    expect(c.ctrl.showDeleteButton).toBe(false);
+    expect(c.ctrl.showHideButton).toBe(true);
   });
 });

--- a/src/app/modules/map/popovers/resource-popover.component.spec.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.spec.ts
@@ -29,14 +29,14 @@ const appStub = {
   useInfoPanel: () => false
 };
 
-function popover(canSave: boolean, readOnly = false) {
+function popover(canSave: boolean, readOnly = false, active?: string) {
   const c = Object.create(
     ResourcePopoverComponent.prototype
   ) as ResourcePopoverComponent;
   Object.assign(c, {
     resource: () => ['route-1', routeStub(readOnly)],
     type: () => 'route',
-    active: () => undefined,
+    active: () => active,
     featureCount: () => 2,
     canSave: () => canSave,
     app: appStub,
@@ -65,6 +65,7 @@ function popover(canSave: boolean, readOnly = false) {
       showInfoButton: boolean;
       showSaveButton: boolean;
       showHideButton: boolean;
+      isActive: boolean;
     };
   };
 }
@@ -109,5 +110,13 @@ describe('ResourcePopoverComponent — route Hide visibility (#551)', () => {
     // Read-only suppresses DELETE but not HIDE — hiding never touches the resource.
     expect(c.ctrl.showDeleteButton).toBe(false);
     expect(c.ctrl.showHideButton).toBe(true);
+  });
+
+  it('keeps HIDE present but disabled while the route is active', () => {
+    const c = popover(false, false, 'route-1');
+    // HIDE stays visible; the template disables it via `[disabled]="ctrl.isActive"`
+    // so the route being navigated cannot be hidden out from under navigation.
+    expect(c.ctrl.showHideButton).toBe(true);
+    expect(c.ctrl.isActive).toBe(true);
   });
 });

--- a/src/app/modules/map/popovers/resource-popover.component.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.ts
@@ -25,6 +25,7 @@ interface PopoverCtrl {
   showInfoButton: boolean;
   showModifyButton: boolean;
   showDeleteButton: boolean;
+  showHideButton: boolean;
   showAddNoteButton: boolean;
   showRelatedButton: boolean;
   showPointsButton: boolean;
@@ -143,10 +144,27 @@ interface PopoverCtrl {
             </button>
           </div>
         }
-        @if (ctrl.showDeleteButton) {
+        @if (ctrl.showHideButton) {
           <div
             class="popover-action-button"
             [style.order]="type() === 'route' ? 6 : null"
+          >
+            <button
+              mat-button
+              [disabled]="ctrl.isActive"
+              (click)="emitHide()"
+              matTooltip="Hide from Chart"
+              matTooltipPosition="after"
+            >
+              <mat-icon>visibility_off</mat-icon>
+              HIDE
+            </button>
+          </div>
+        }
+        @if (ctrl.showDeleteButton) {
+          <div
+            class="popover-action-button"
+            [style.order]="type() === 'route' ? 7 : null"
           >
             <button
               mat-button
@@ -292,6 +310,7 @@ export class ResourcePopoverComponent {
   modify = output<void>();
   save = output<void>();
   delete = output<void>();
+  hide = output<void>();
   addNote = output<void>();
   activated = output<void>();
   deactivated = output<void>();
@@ -308,6 +327,7 @@ export class ResourcePopoverComponent {
     showInfoButton: false,
     showModifyButton: false,
     showDeleteButton: false,
+    showHideButton: false,
     showAddNoteButton: false,
     showRelatedButton: false,
     showPointsButton: false,
@@ -351,6 +371,9 @@ export class ResourcePopoverComponent {
       this.ctrl.showPointsButton = false;
       this.ctrl.showNotesButton = false;
       this.ctrl.showInfoButton = false;
+      // An unsaved draft isn't in the Routes list, so Hide would remove it with
+      // no way to bring it back — offer Delete (discard) instead.
+      this.ctrl.showHideButton = false;
     }
   }
 
@@ -380,6 +403,7 @@ export class ResourcePopoverComponent {
     this.ctrl.showInfoButton = false;
     this.ctrl.showModifyButton = false;
     this.ctrl.showDeleteButton = false;
+    this.ctrl.showHideButton = false;
     this.ctrl.showNotesButton = false;
     this.ctrl.showAddNoteButton = false;
     this.ctrl.showPointsButton = false;
@@ -413,6 +437,7 @@ export class ResourcePopoverComponent {
     this.ctrl.showDeleteButton = this.app.useInfoPanel()
       ? false
       : !this.ctrl.isReadOnly;
+    this.ctrl.showHideButton = false;
     this.ctrl.showNotesButton = this.app.useInfoPanel() ? false : true;
     this.ctrl.showAddNoteButton = false;
     this.ctrl.showPointsButton = false;
@@ -449,6 +474,10 @@ export class ResourcePopoverComponent {
     // Always offer Delete for routes (consistent lower-right action), even with
     // the info panel; the button itself is disabled when the route is active.
     this.ctrl.showDeleteButton = !this.ctrl.isReadOnly;
+    // Hide (remove from the displayed set) is a non-destructive shortcut for the
+    // Routes-list "Show on Map" toggle, so it is offered for every route —
+    // read-only included — and only disabled while the route is active.
+    this.ctrl.showHideButton = true;
 
     this.icon = getResourceIcon('routes', this.resource()[1]);
     this._title.set(this.resource()[1].name ?? '');
@@ -468,6 +497,7 @@ export class ResourcePopoverComponent {
     this.ctrl.showDeleteButton = this.app.useInfoPanel()
       ? false
       : !this.ctrl.isReadOnly;
+    this.ctrl.showHideButton = false;
     this.ctrl.showAddNoteButton = false;
     this.ctrl.showNotesButton = false;
     this.ctrl.showPointsButton = false;
@@ -498,6 +528,7 @@ export class ResourcePopoverComponent {
     this.ctrl.showDeleteButton = this.app.useInfoPanel()
       ? false
       : !this.ctrl.isReadOnly;
+    this.ctrl.showHideButton = false;
     this.ctrl.showAddNoteButton = false;
     this.ctrl.showNotesButton = this.app.useInfoPanel() ? false : true;
     this.ctrl.showPointsButton = false;
@@ -525,6 +556,10 @@ export class ResourcePopoverComponent {
 
   emitDelete() {
     this.delete.emit();
+  }
+
+  emitHide() {
+    this.hide.emit();
   }
 
   emitActive(activate: boolean) {

--- a/src/app/modules/skresources/components/routes/routelist.spec.ts
+++ b/src/app/modules/skresources/components/routes/routelist.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { signal, WritableSignal } from '@angular/core';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MatDialog } from '@angular/material/dialog';
+
+import { RouteListComponent } from './routelist';
+import { SKResourceService } from '../../resources.service';
+import { SKWorkerService } from 'src/app/modules/skstream/skstream.service';
+import { AppFacade } from 'src/app/app.facade';
+import { SKResourceGroupService } from '../groups/groups.service';
+import { FBRoute, FBRoutes } from 'src/app/types/resources/freeboard';
+
+/**
+ * The "Show on Map" checkbox is bound to each entry's `r[2]` flag. When a route
+ * is shown/hidden from *outside* the list (e.g. the map route popover's Hide
+ * action, #551), only the displayed route cache changes — no server delta fires
+ * — so the list must re-align its checkboxes with cache membership. These tests
+ * drive the public `skres.routes()` signal and assert the observable checkbox
+ * state, not the private sync helper.
+ *
+ * `TestBed.inject` gives a real injection context for the constructor effect
+ * without rendering the template; `TestBed.tick()` flushes the effect.
+ */
+const route = (id: string, checked: boolean): FBRoute =>
+  [id, { name: id } as never, checked] as FBRoute;
+
+const fullListOf = (c: RouteListComponent) =>
+  (c as unknown as { fullList: FBRoutes }).fullList;
+const filteredSignalOf = (c: RouteListComponent) =>
+  (c as unknown as { filteredList: WritableSignal<FBRoutes> }).filteredList;
+const checkedOf = (list: FBRoutes, id: string) =>
+  list.find((r) => r[0] === id)?.[2];
+
+describe('RouteListComponent — Show-on-Map checkbox sync (#551)', () => {
+  let routes: WritableSignal<FBRoutes>;
+  let comp: RouteListComponent;
+
+  const seed = (entries: FBRoutes) => {
+    fullListOf(comp).length = 0;
+    fullListOf(comp).push(...entries.map((e) => [...e] as FBRoute));
+    filteredSignalOf(comp).set(entries.map((e) => [...e] as FBRoute));
+  };
+
+  beforeEach(() => {
+    routes = signal<FBRoutes>([]);
+    TestBed.configureTestingModule({
+      providers: [
+        RouteListComponent,
+        { provide: SKResourceService, useValue: { routes } },
+        {
+          provide: SKWorkerService,
+          useValue: { resourceUpdate: signal({ path: '' }) }
+        },
+        { provide: AppFacade, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: SKResourceGroupService, useValue: {} }
+      ]
+    });
+    comp = TestBed.inject(RouteListComponent);
+  });
+
+  it('unticks a route removed from the displayed cache elsewhere', () => {
+    seed([route('r1', true), route('r2', true)]);
+    // External hide: r2 leaves the displayed cache.
+    routes.set([route('r1', true)]);
+    TestBed.tick();
+
+    const filtered = filteredSignalOf(comp)();
+    expect(checkedOf(filtered, 'r2')).toBe(false);
+    expect(checkedOf(filtered, 'r1')).toBe(true);
+    expect(checkedOf(fullListOf(comp), 'r2')).toBe(false);
+  });
+
+  it('re-ticks a route added back to the displayed cache', () => {
+    seed([route('r1', true), route('r2', false)]);
+    // External show: r2 re-enters the displayed cache.
+    routes.set([route('r1', true), route('r2', true)]);
+    TestBed.tick();
+
+    expect(checkedOf(filteredSignalOf(comp)(), 'r2')).toBe(true);
+  });
+});

--- a/src/app/modules/skresources/components/routes/routelist.ts
+++ b/src/app/modules/skresources/components/routes/routelist.ts
@@ -4,6 +4,7 @@ import {
   signal,
   computed,
   effect,
+  untracked,
   inject,
   output,
   input,
@@ -90,6 +91,27 @@ export class RouteListComponent extends ResourceListBase {
         this.initItems(true);
       }
     });
+    // Keep the "Show on Map" checkboxes in sync when a route is shown/hidden
+    // from outside the list (e.g. the map route popover's Hide action). Those
+    // change the displayed route cache without a server delta, so re-align each
+    // checkbox with cache membership — which is exactly "shown on map".
+    effect(() => {
+      const shown = new Set(this.skres.routes().map((r: FBRoute) => r[0]));
+      untracked(() => this.alignCheckedWithCache(shown));
+    });
+  }
+
+  /**
+   * @description Re-align each entry's checkbox with the displayed route cache.
+   * @param shown Identifiers of the routes currently shown on the map.
+   */
+  private alignCheckedWithCache(shown: Set<string>) {
+    this.fullList.forEach((item) => (item[2] = shown.has(item[0])));
+    this.filteredList.update((fl) => {
+      fl.forEach((item) => (item[2] = shown.has(item[0])));
+      return [...fl];
+    });
+    this.alignSelections();
   }
 
   ngOnInit() {

--- a/src/app/modules/skresources/resources-route-hide.spec.ts
+++ b/src/app/modules/skresources/resources-route-hide.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { signal } from '@angular/core';
+import { SKResourceService } from './resources.service';
+import { FBRoute, FBRoutes } from 'src/app/types/resources/freeboard';
+
+/**
+ * Regression tests for the route popover "Hide" action (#551). Hiding a route
+ * from the map popover must have the same durable effect as unchecking "Show on
+ * Map" in the Route list: the route leaves the displayed cache AND the selection
+ * is updated so it stays hidden across a refresh.
+ *
+ * The trap: while a collection is unfiltered (`selections.routes === null`,
+ * "show all"), `selectionRemove` is a no-op — removing only from the cache would
+ * let the route reappear on the next `refreshRoutes()` (and leave the Route list
+ * checkbox ticked). `routeHide` must first materialise the currently-shown
+ * routes into an explicit selection.
+ *
+ * `routeHide` only touches `this.app.config.selections` and the route cache
+ * signal, so exercise it on a bare prototype with a mock app — no Angular DI.
+ * `app` / `routeCacheSignal` are private, so assign and read them via narrow
+ * casts (same approach as resources-charts-opacity.spec).
+ */
+const route = (id: string): FBRoute => [id, {}, true] as unknown as FBRoute;
+
+function svc(selections: string[] | null, cache: FBRoutes): SKResourceService {
+  const s = Object.create(SKResourceService.prototype) as SKResourceService;
+  Object.assign(s as unknown as Record<string, unknown>, {
+    app: {
+      config: { selections: { routes: selections } },
+      saveConfig: () => undefined
+    },
+    routeCacheSignal: signal<FBRoutes>(cache)
+  });
+  return s;
+}
+
+const cacheIds = (s: SKResourceService) =>
+  (s as unknown as { routeCacheSignal: () => FBRoutes })
+    .routeCacheSignal()
+    .map((r) => r[0]);
+
+const selectionOf = (s: SKResourceService) =>
+  (
+    s as unknown as {
+      app: { config: { selections: { routes: string[] | null } } };
+    }
+  ).app.config.selections.routes;
+
+describe('SKResourceService.routeHide (#551)', () => {
+  it('removes the route from the displayed cache', () => {
+    const s = svc(null, [route('r1'), route('r2'), route('r3')]);
+    s.routeHide('r2');
+    expect(cacheIds(s)).toEqual(['r1', 'r3']);
+  });
+
+  it('makes the hide durable from an unfiltered collection (materialises the selection)', () => {
+    const s = svc(null, [route('r1'), route('r2'), route('r3')]);
+    s.routeHide('r2');
+    // Unfiltered ("show all") became an explicit whitelist of the routes that
+    // remain shown — so the hidden route does not reappear on the next refresh.
+    expect(selectionOf(s)).toEqual(['r1', 'r3']);
+  });
+
+  it('removes the id from an already-filtered selection', () => {
+    const s = svc(['r1', 'r2', 'r3'], [route('r1'), route('r2'), route('r3')]);
+    s.routeHide('r2');
+    expect(selectionOf(s)).toEqual(['r1', 'r3']);
+    expect(cacheIds(s)).toEqual(['r1', 'r3']);
+  });
+});

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -1306,6 +1306,25 @@ export class SKResourceService {
   }
 
   /**
+   * @description Hide a single route from the displayed set without deleting it.
+   * The persistent equivalent of unchecking "Show on Map" in the Route list: it
+   * updates the selection so the hide survives a route-cache refresh, then drops
+   * the route from the live cache. While the collection is unfiltered ("show
+   * all"), selectionRemove is a no-op, so the currently-shown routes are first
+   * materialised into an explicit selection — otherwise the route would reappear
+   * on the next refresh and the Route list checkbox would stay ticked.
+   * @param id Route identifier
+   */
+  public routeHide(id: string) {
+    if (!this.selectionIsFiltered('routes')) {
+      const shown = this.routeCacheSignal().map((r: FBRoute) => r[0]);
+      this.selectionClear('routes');
+      this.selectionAdd('routes', shown);
+    }
+    this.routeRemove([id]);
+  }
+
+  /**
    * @description Return a FBRoute object using the supplied coordinates.
    * @params coordinates - Route points
    */


### PR DESCRIPTION
## Why

When a route is selected on the chart, its popover offers Modify, Start, Points, Notes, Info and Delete — but no way to hide it. Hiding a displayed route meant opening the Routes list and unchecking "Show on Map". This adds an in-place Hide action.

## How

- **Route popover** gains a **Hide** action (`visibility_off`) that removes the route from the displayed set without touching the resource — the same effect as unchecking "Show on Map". It is offered for every saved route (read-only included, since hiding is non-destructive), disabled while the route is active, and omitted for an unsaved draft (which isn't in the Routes list, so it offers Delete/discard instead).
- **Durable hide.** Hide goes through a new `SKResourceService.routeHide(id)`. While the routes collection is unfiltered ("show all"), `selectionRemove` is a no-op, so the currently-shown routes are first materialised into an explicit selection before removing — otherwise the route would reappear on the next route refresh and the Routes-list checkbox would stay ticked.
- **Checkbox sync.** The Routes list now re-aligns its "Show on Map" checkboxes with the displayed route cache, so hiding a route from the map popover updates the list live (the two can be visible at once — the sidenav has no backdrop).

Tests: popover Hide visibility (saved / draft / read-only) and `routeHide` selection-durability regression specs.

Closes #551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Hide from Chart” action for saved routes without deleting them.
  - Hidden routes remain excluded after map refreshes.
  - Route “Show on Map” checkboxes now stay synchronized with displayed routes.

- **Bug Fixes**
  - Prevented hide controls from appearing for unsaved drafts and unsupported resource types.
  - Preserved appropriate actions for read-only routes.

- **Tests**
  - Added coverage for route hiding, refresh persistence, and popover action visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->