### PR TITLE
feat(routes): allow reordering points on unsaved routes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1587,10 +1587,13 @@ export class AppComponent {
     let v: FBRoute | SKVessel | SKSaR | SKAircraft | SKAtoN;
     if (e.type === 'route') {
       try {
-        // An unsaved draft / dirty route has no server copy — the map passes the
-        // buffer-derived route so we open the reorder dialog from it (no fetch).
-        // Navigation actions need a stored route, so hide them for a draft; the
-        // dialog persists reorders back to the buffer (#583).
+        // A route with a live edit buffer — a never-saved draft, or a stored
+        // route with pending edits — is opened from the buffer-derived route the
+        // map passes (no server fetch), and reorders persist back to the buffer
+        // (#583). Navigation is hidden for the whole buffer case (noButtons):
+        // Start/Go-to act on the *persisted* route via its href, but a draft has
+        // none and a dirty route's buffer id isn't its server href — and either
+        // way navigation would ignore the unsaved reordered geometry.
         const isBuffer = !!e.resource;
         let route: FBRoute[1];
         if (isBuffer) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1579,21 +1579,36 @@ export class AppComponent {
   }
 
   // ** show feature (vessel/AtoN/Aircraft/Route points) properties **
-  protected async featureProperties(e: { id: string; type: string }) {
+  protected async featureProperties(e: {
+    id: string;
+    type: string;
+    resource?: FBRoute;
+  }) {
     let v: FBRoute | SKVessel | SKSaR | SKAircraft | SKAtoN;
     if (e.type === 'route') {
       try {
-        this.app.sIsFetching.set(true);
-        v = await this.skres.fromServer('routes', e.id);
-        this.app.sIsFetching.set(false);
-        if (v) {
+        // An unsaved draft / dirty route has no server copy — the map passes the
+        // buffer-derived route so we open the reorder dialog from it (no fetch).
+        // Navigation actions need a stored route, so hide them for a draft; the
+        // dialog persists reorders back to the buffer (#583).
+        const isBuffer = !!e.resource;
+        let route: FBRoute[1];
+        if (isBuffer) {
+          route = e.resource[1];
+        } else {
+          this.app.sIsFetching.set(true);
+          route = await this.skres.fromServer('routes', e.id);
+          this.app.sIsFetching.set(false);
+        }
+        if (route) {
           this.bottomSheet
             .open(ActiveResourcePropertiesModal, {
               disableClose: true,
               data: {
                 title: 'Route Properties',
-                resource: [e.id, v, false],
-                type: e.type
+                resource: [e.id, route, false],
+                type: e.type,
+                noButtons: isBuffer
               }
             })
             .afterDismissed()

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -657,7 +657,7 @@
             popoverClosed()
           "
           (info)="popoverInfo(); popoverClosed()"
-          (points)="itemInfo(overlay().id, overlay().type); popoverClosed()"
+          (points)="popoverPoints(); popoverClosed()"
           (closed)="popoverClosed()"
         >
         </resource-popover>

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -136,6 +136,9 @@ import {
 interface IResource {
   id: string;
   type: string;
+  /** Pre-resolved resource. When set (an unsaved route buffer), the properties
+   *  dialog opens from it instead of fetching from the server (#583). */
+  resource?: FBRoute;
 }
 
 interface IFeatureData {
@@ -2156,6 +2159,22 @@ export class FBMapComponent implements OnInit, OnDestroy {
     } else {
       this.info.emit({ id: id, type: type });
     }
+  }
+
+  /**
+   * Popover "Points" action → opens the route's reorder dialog. A stored route
+   * takes the normal path (the parent fetches it from the server). An unsaved
+   * draft / dirty route has no server copy, so pass the buffer-derived route:
+   * the parent opens the dialog from it without a fetch and reorders persist
+   * back to the buffer (#583).
+   */
+  protected popoverPoints() {
+    const ub = this.getUnsavedRouteBuffer(this.overlay().id);
+    this.info.emit({
+      id: this.overlay().id,
+      type: this.overlay().type,
+      resource: ub ? this.bufferToFBRoute(ub) : undefined
+    });
   }
 
   protected setActiveVessel(id: string = null) {

--- a/src/app/modules/map/popovers/resource-popover.component.spec.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.spec.ts
@@ -65,6 +65,7 @@ function popover(canSave: boolean, readOnly = false, active?: string) {
       showInfoButton: boolean;
       showSaveButton: boolean;
       showHideButton: boolean;
+      showPointsButton: boolean;
       isActive: boolean;
     };
   };
@@ -118,5 +119,24 @@ describe('ResourcePopoverComponent — route Hide visibility (#551)', () => {
     // so the route being navigated cannot be hidden out from under navigation.
     expect(c.ctrl.showHideButton).toBe(true);
     expect(c.ctrl.isActive).toBe(true);
+  });
+});
+
+/**
+ * Route Points visibility (#583). The Points action reorders a route's
+ * waypoints. It was hidden for an unsaved draft because its dialog operated
+ * against the server; the dialog now edits the route buffer, so a draft's
+ * points are reorderable too and the button is shown.
+ */
+describe('ResourcePopoverComponent — route Points visibility (#583)', () => {
+  it('shows POINTS for a saved route', () => {
+    const c = popover(false);
+    expect(c.ctrl.showPointsButton).toBe(true);
+  });
+
+  it('shows POINTS for an unsaved route draft (dialog edits the buffer)', () => {
+    const c = popover(true);
+    expect(c.ctrl.showSaveButton).toBe(true);
+    expect(c.ctrl.showPointsButton).toBe(true);
   });
 });

--- a/src/app/modules/map/popovers/resource-popover.component.ts
+++ b/src/app/modules/map/popovers/resource-popover.component.ts
@@ -363,12 +363,13 @@ export class ResourcePopoverComponent {
     if (this.ctrl.showSaveButton) {
       // Unsaved draft: also offer a quick Delete (discard) shortcut, and hide
       // the actions that only work against a stored resource — Start
-      // (navigation), Route Points, Show Notes and Info — which a draft has
-      // none of. Info fetches the route from the server, which 404s for a
-      // draft; Save already opens the details dialog for title/description.
+      // (navigation), Show Notes and Info — which a draft has none of. Info
+      // fetches the route from the server, which 404s for a draft; Save already
+      // opens the details dialog for title/description. Route Points stays
+      // visible: its reorder dialog now edits the route buffer (#583), so the
+      // draft's points can be re-ordered before it is saved.
       this.ctrl.showDeleteButton = true;
       this.ctrl.canActivate = false;
-      this.ctrl.showPointsButton = false;
       this.ctrl.showNotesButton = false;
       this.ctrl.showInfoButton = false;
       // An unsaved draft isn't in the Routes list, so Hide would remove it with

--- a/src/app/modules/skresources/components/active-resource-dialog.ts
+++ b/src/app/modules/skresources/components/active-resource-dialog.ts
@@ -23,6 +23,8 @@ import { GeoUtils } from 'src/app/lib/geoutils';
 import { SKResourceService } from '../resources.service';
 import { CourseService } from '../../course';
 import { Convert } from 'src/app/lib/convert';
+import { RouteBufferRegistry } from '../../plotterext/route-buffer.registry';
+import { buildRoutePoints, editsRouteBuffer } from './route-reorder.util';
 
 @Component({
   selector: 'ap-dest-modal',
@@ -207,6 +209,7 @@ export class ActiveResourcePropertiesModal implements OnInit {
   protected modalRef = inject(MatBottomSheetRef<ActiveResourcePropertiesModal>);
   protected course = inject(CourseService);
   protected skres = inject(SKResourceService);
+  protected routeBuffers = inject(RouteBufferRegistry);
   protected data = inject<{
     title: string;
     type: string;
@@ -312,11 +315,20 @@ export class ActiveResourcePropertiesModal implements OnInit {
       moveItemInArray(this.pointMeta, e.previousIndex, e.currentIndex);
 
       this.updateFlag(selPosition);
-      this.skres.updateRouteCoords(
-        this.data.resource[0],
-        this.points,
-        this.data.resource[1].feature.properties.coordinatesMeta
-      );
+      const id = this.data.resource[0];
+      const coordsMeta =
+        this.data.resource[1].feature.properties.coordinatesMeta;
+      if (editsRouteBuffer(this.routeBuffers.get(id))) {
+        // Unsaved draft / dirty route: reorder the edit buffer (emits
+        // route.dirty). Persistence stays deferred to an explicit Save, matching
+        // how draft geometry edits already work (#583).
+        this.routeBuffers.replace(
+          id,
+          buildRoutePoints(this.points, coordsMeta)
+        );
+      } else {
+        this.skres.updateRouteCoords(id, this.points, coordsMeta);
+      }
     }
   }
 

--- a/src/app/modules/skresources/components/route-reorder.util.spec.ts
+++ b/src/app/modules/skresources/components/route-reorder.util.spec.ts
@@ -62,4 +62,19 @@ describe('buildRoutePoints (#583)', () => {
     expect(result[0].name).toBeUndefined();
     expect(result[0].description).toBeUndefined();
   });
+
+  it('does not synthesize an href for waypoint-referenced points', () => {
+    // coordinatesMeta can carry an href (a route point that references a stored
+    // waypoint), but RoutePoint / the route buffer don't model waypoint refs.
+    // buildRoutePoints only runs on buffer-derived meta, which never carries
+    // href; href-bearing routes persist through the server path, which keeps the
+    // full coordinatesMeta. Assert the rebuild carries position/name/description
+    // and never invents an href field.
+    const meta: Array<{ name?: string; description?: string; href?: string }> =
+      [{ name: 'WP-1', href: '/resources/waypoints/abc' }];
+    const result = buildRoutePoints([[-80, 25]], meta);
+    expect(result[0].position).toEqual([-80, 25]);
+    expect(result[0].name).toBe('WP-1');
+    expect('href' in result[0]).toBe(false);
+  });
 });

--- a/src/app/modules/skresources/components/route-reorder.util.spec.ts
+++ b/src/app/modules/skresources/components/route-reorder.util.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { editsRouteBuffer, buildRoutePoints } from './route-reorder.util';
+
+/**
+ * Route Points reorder persistence (#583). Dragging a point in the Points
+ * dialog persists the new order. For a stored route it PUTs to the server; for
+ * an unsaved draft / dirty route it edits the route buffer instead, leaving
+ * persistence deferred to an explicit Save — matching how draft geometry edits
+ * already work. These pure helpers carry the decision + the point rebuild; they
+ * are unit-tested here rather than through the DI-heavy dialog component (whose
+ * import graph perturbs the AppComponent bootstrap spec — see DEV-LESSONS).
+ */
+describe('editsRouteBuffer (#583)', () => {
+  it('edits the buffer for an unsaved draft', () => {
+    expect(editsRouteBuffer({ saved: false, dirty: true })).toBe(true);
+    expect(editsRouteBuffer({ saved: false, dirty: false })).toBe(true);
+  });
+
+  it('edits the buffer for a saved-but-dirty route', () => {
+    expect(editsRouteBuffer({ saved: true, dirty: true })).toBe(true);
+  });
+
+  it('persists to the server for a stored (clean) route', () => {
+    expect(editsRouteBuffer({ saved: true, dirty: false })).toBe(false);
+  });
+
+  it('persists to the server when the route has no buffer entry', () => {
+    expect(editsRouteBuffer(undefined)).toBe(false);
+  });
+});
+
+describe('buildRoutePoints (#583)', () => {
+  it('preserves per-point name/description alongside the reordered coordinates', () => {
+    const points: Array<[number, number]> = [
+      [-80.1, 25.1],
+      [-80.2, 25.2],
+      [-80.0, 25.0]
+    ];
+    const coordsMeta = [
+      { name: 'B' },
+      { name: 'C' },
+      { name: 'A', description: 'home' }
+    ];
+
+    const result = buildRoutePoints(points, coordsMeta);
+
+    expect(result.map((p) => p.position)).toEqual(points);
+    expect(result.map((p) => p.name)).toEqual(['B', 'C', 'A']);
+    expect(result[2].description).toBe('home');
+  });
+
+  it('omits name/description when there is no metadata', () => {
+    const result = buildRoutePoints([[-80, 25]]);
+    expect(result).toEqual([{ position: [-80, 25] }]);
+  });
+
+  it('omits empty name/description entries', () => {
+    const result = buildRoutePoints(
+      [[-80, 25]],
+      [{ name: '', description: '' }]
+    );
+    expect(result[0].name).toBeUndefined();
+    expect(result[0].description).toBeUndefined();
+  });
+});

--- a/src/app/modules/skresources/components/route-reorder.util.ts
+++ b/src/app/modules/skresources/components/route-reorder.util.ts
@@ -1,0 +1,37 @@
+import type { RoutePoint } from 'signalk-plotterext-bus/host';
+import type { Position } from 'src/app/types';
+
+/** Per-point metadata as stored in a route's `feature.properties.coordinatesMeta`. */
+interface PointMeta {
+  name?: string;
+  description?: string;
+}
+
+/**
+ * Whether a route's point reorder should edit the in-memory route buffer rather
+ * than persist straight to the server. True for an unsaved draft or a route with
+ * pending edits — persistence then stays deferred to an explicit Save (#583).
+ */
+export function editsRouteBuffer(
+  buffer: { saved: boolean; dirty: boolean } | undefined
+): boolean {
+  return !!buffer && (!buffer.saved || buffer.dirty);
+}
+
+/**
+ * Build route-buffer points from reordered coordinates, carrying each point's
+ * name/description so a reorder doesn't drop per-point metadata.
+ */
+export function buildRoutePoints(
+  points: Position[],
+  coordsMeta?: PointMeta[]
+): RoutePoint[] {
+  return points.map((position, i) => {
+    const m = Array.isArray(coordsMeta) ? coordsMeta[i] : undefined;
+    return {
+      position,
+      ...(m?.name ? { name: m.name } : {}),
+      ...(m?.description ? { description: m.description } : {})
+    };
+  });
+}


### PR DESCRIPTION
The route **Points** dialog reorders a route's waypoints, but it was offered
for stored routes only: it fetched the route from the server to open and PUT on
every drag, so an unsaved draft (which has no server copy) couldn't use it.

This routes the dialog through the route edit **buffer** when one exists:

- open a draft from the buffer-derived route the popover already holds — no
  server fetch;
- on reorder, update the buffer (deferring persistence to an explicit Save,
  matching how draft geometry edits already work) instead of PUTting;
- a stored route keeps the server path unchanged.

The Points button is un-hidden for unsaved routes, and a route with a live edit
buffer opens reorder-only — Start / Go-to act on the *persisted* route via its
href, which a draft doesn't have (and a dirty route's buffer id isn't its href).

The buffer-vs-server decision and the metadata-preserving point rebuild are
extracted to pure helpers (`route-reorder.util.ts`) so they're unit-testable
without importing the DI-heavy dialog (that import trips the documented `ɵcmp`
barrel trap in `app.component.spec`).

Follow-up: making the Points-dialog reorder undoable is tracked separately in
#596 (it also applies to saved routes, so it's its own change).

Closes #583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route Points are now available for both saved routes and unsaved route drafts.
  * Reordering points in an unsaved route preserves changes in the draft without immediately saving them.
  * Point names and descriptions are retained when route points are reordered.

* **Bug Fixes**
  * Improved handling of route draft details and point editing.
  * Draft routes no longer trigger unnecessary server requests or enable actions that require saved data.

* **Tests**
  * Added coverage for route point visibility, draft handling, reordering, and metadata preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->