### PR TITLE
feat(routes): extend a route by clicking open water in modify mode

### DIFF
--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -106,6 +106,7 @@ import { DrawEvent } from 'ol/interaction/Draw';
 import { Coordinate } from 'ol/coordinate';
 import { SKPosition } from 'src/app/types';
 import {
+  FBClickEvent,
   FBMapEvent,
   FBPointerEvent,
   zoomOffsetLevel,
@@ -123,7 +124,13 @@ import { Units } from 'ol/control/ScaleLine';
 import { DragBoxEvent } from 'ol/interaction/DragBox';
 import { MapService } from './ol/lib/map.service';
 import { InteractionDrawComponent } from './ol/lib/interactions/interaction-draw.component';
-import { worldCopyOffset } from './ol/lib/util';
+import { hitToleranceForPointer, worldCopyOffset } from './ol/lib/util';
+import { LineString as OLLineString } from 'ol/geom';
+import {
+  extendRouteAtClick,
+  RoutePointMeta,
+  WORLD_WIDTH_3857
+} from './route-extend';
 import { AppIconDef } from '../icons';
 import { LayerWindWeatherComponent } from './ol/lib/resources/layer-wind-weather.component';
 import { LayerCurrentsWeatherComponent } from './ol/lib/resources/layer-currents-weather.component';
@@ -775,6 +782,12 @@ export class FBMapComponent implements OnInit, OnDestroy {
     ) {
       this.onDrawClick(e.features);
     } else if (
+      // modifying a route: a click in open water extends it from the end
+      this.mapInteract.isModifying() &&
+      this.mapInteract.draw.resourceType === 'route'
+    ) {
+      this.extendRouteInModify(e);
+    } else if (
       //not interacting
       !this.mapInteract.isDrawing() &&
       !this.mapInteract.isModifying()
@@ -1121,11 +1134,12 @@ export class FBMapComponent implements OnInit, OnDestroy {
       this.mapInteract.draw.features.getArray()[0] as Feature
     )?.getGeometry();
     if (editGeom) {
-      // EPSG:3857 world width in metres (the map's Mercator projection).
-      const worldWidth = 2 * 20037508.342789244;
       const ext = editGeom.getExtent();
       const centreX = (ext[0] + ext[2]) / 2;
-      const shift = worldCopyOffset(this.clickMercX - centreX, worldWidth);
+      const shift = worldCopyOffset(
+        this.clickMercX - centreX,
+        WORLD_WIDTH_3857
+      );
       if (shift) {
         this.mapInteract.draw.features.forEach((f: Feature) =>
           f.getGeometry()?.translate(shift, 0)
@@ -1194,7 +1208,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
     // now.
     if (fid.split('.')[0] === 'route') {
       const meta = this.mapInteract.draw.forSave.coordsMetadata as
-        Array<{ name?: string; description?: string }> | undefined;
+        RoutePointMeta[] | undefined;
       this.mapInteract.pushModifyUndo({
         coordinates: (this.mapInteract.draw.coordinates as Position[]).map(
           (co) => [...co] as Position
@@ -1250,6 +1264,78 @@ export class FBMapComponent implements OnInit, OnDestroy {
     this.app.data.editingId = this.mapInteract.draw.forSave.id;
 
     this.app.debug(this.mapInteract.draw.forSave);
+  }
+
+  /**
+   * Extend the route being modified by appending a clicked open-water point as
+   * the new end point (issue #549) — so a route can be lengthened the same way
+   * it is drawn, without leaving modify mode. A click *on* the route belongs to
+   * OL Modify (move / insert / delete a vertex), so only clicks that miss it
+   * extend the route; the state kept in sync here mirrors applyModifyEnd so
+   * Undo, Finish and Cancel all see the new point.
+   */
+  private extendRouteInModify(e: FBClickEvent) {
+    const f = this.mapInteract.draw.features?.getArray()[0] as Feature;
+    const geom = f?.getGeometry();
+    if (!f || geom?.getType() !== 'LineString') {
+      return;
+    }
+    const line = geom as OLLineString;
+    // A click within the modify hit tolerance of the route itself is OL Modify's
+    // (a vertex move / insert / delete); only a genuine miss extends the route.
+    // Use a tolerance >= Modify's own pixelTolerance (OL default 10) so no single
+    // click both inserts a vertex and appends an end point. getFeaturesAtPixel is
+    // world-copy aware, matching what the user sees under wrapX.
+    const tol = hitToleranceForPointer(e.originalEvent?.pointerType, 10, 15);
+    const onRoute = this.olMap
+      .getMap()
+      .getFeaturesAtPixel(e.pixel, { hitTolerance: tol })
+      .some((ft) => ft.getId() === f.getId());
+    if (onRoute) {
+      return;
+    }
+    // Metadata may not be seeded yet if this is the first op of the session (no
+    // modifystart has run) — read it from the feature, matching onModifyStart.
+    let meta = this.mapInteract.draw.forSave.coordsMetadata as
+      RoutePointMeta[] | undefined;
+    if (!meta) {
+      const fm = f.get('pointMetadata');
+      meta = Array.isArray(fm) ? fm : undefined;
+    }
+
+    const ext = line.getExtent();
+    const result = extendRouteAtClick(
+      line.getCoordinates() as Position[],
+      meta,
+      fromLonLat(e.lonlat) as Position,
+      ext[0],
+      ext[2]
+    );
+
+    // Snapshot the pre-append state so the extension can be undone within the
+    // session (#542), mirroring applyModifyEnd.
+    this.mapInteract.pushModifyUndo(result.undo);
+    line.setCoordinates(result.after);
+    // Mirror the length-aligned metadata onto the feature so the next
+    // modifystart re-reads a correct-length array.
+    if (result.meta) {
+      f.set('pointMetadata', result.meta);
+    }
+
+    if (!this.mapInteract.draw.forSave.id) {
+      this.mapInteract.draw.forSave.id = f.getId();
+    }
+    this.mapInteract.draw.forSave.coordsMetadata = result.meta;
+    this.mapInteract.draw.coordinates = result.after;
+    const pc = this.transformCoordsArray(result.after);
+    this.mapInteract.draw.forSave['coords'] = pc;
+    this.mapInteract.measurementCoords = pc as LineString;
+
+    this.app.data.activeRouteIsEditing =
+      !!this.app.data.activeRoute &&
+      this.mapInteract.draw.forSave.id.indexOf(this.app.data.activeRoute) !==
+        -1;
+    this.app.data.editingId = this.mapInteract.draw.forSave.id;
   }
 
   /** Process pointer click in non-interaction mode */

--- a/src/app/modules/map/route-extend.spec.ts
+++ b/src/app/modules/map/route-extend.spec.ts
@@ -1,0 +1,78 @@
+import { expect, describe, it } from 'vitest';
+import { Position } from 'src/app/types';
+import {
+  WORLD_WIDTH_3857,
+  extendRouteAtClick,
+  worldAlignedPoint
+} from './route-extend';
+
+const W = WORLD_WIDTH_3857;
+
+describe('worldAlignedPoint', () => {
+  it('leaves a click in the route body world unshifted', () => {
+    // Route body around x=0; click at x=20 needs no whole-world shift.
+    expect(worldAlignedPoint([20, 5], -10, 10)).toEqual([20, 5]);
+  });
+
+  it('shifts a click a whole world to reach a route stored past the antimeridian (#572)', () => {
+    // A route crossing +180° is stored unwrapped, its body just east of +180°
+    // (render-space x ≈ +W/2). A click just past the antimeridian normalises to
+    // the primary world (x ≈ -W/2), so it must be shifted +1 world to stay
+    // contiguous with the body.
+    const centre = W / 2;
+    const p = worldAlignedPoint([-W / 2 + 50, 10], centre - 100, centre + 100);
+    expect(p[0]).toBeCloseTo(W / 2 + 50, 3);
+    expect(p[1]).toBe(10);
+  });
+
+  it('never alters latitude', () => {
+    expect(worldAlignedPoint([123, 45.6], -10, 10)[1]).toBe(45.6);
+  });
+});
+
+describe('extendRouteAtClick', () => {
+  const before: Position[] = [
+    [0, 0],
+    [10, 0]
+  ];
+
+  it('appends the clicked point as the new END of the route', () => {
+    const r = extendRouteAtClick(before, undefined, [20, 5], -10, 10);
+    expect(r.after).toHaveLength(3);
+    expect(r.after[r.after.length - 1]).toEqual([20, 5]);
+    // existing points are unchanged and stay first
+    expect(r.after.slice(0, 2)).toEqual(before);
+  });
+
+  it('grows per-point metadata in step, the new end point unnamed', () => {
+    const meta = [{ name: 'A' }, { name: 'B', description: 'b' }];
+    const r = extendRouteAtClick(before, meta, [20, 5], -10, 10);
+    expect(r.meta).toEqual([
+      { name: 'A' },
+      { name: 'B', description: 'b' },
+      { name: '' }
+    ]);
+    // input metadata is not mutated
+    expect(meta).toHaveLength(2);
+  });
+
+  it('leaves metadata undefined for a route that carries none', () => {
+    const r = extendRouteAtClick(before, undefined, [20, 5], -10, 10);
+    expect(r.meta).toBeUndefined();
+    expect(r.undo.coordsMetadata).toBeUndefined();
+  });
+
+  it('captures a pre-append undo snapshot decoupled from the inputs', () => {
+    const r = extendRouteAtClick(
+      before,
+      [{ name: 'A' }, { name: 'B' }],
+      [20, 5],
+      -10,
+      10
+    );
+    expect(r.undo.coordinates).toEqual(before);
+    // deep clone — mutating the snapshot must not reach the source geometry
+    r.undo.coordinates[0][0] = 999;
+    expect(before[0][0]).toBe(0);
+  });
+});

--- a/src/app/modules/map/route-extend.ts
+++ b/src/app/modules/map/route-extend.ts
@@ -1,0 +1,66 @@
+import { Position } from 'src/app/types';
+import { worldCopyOffset } from './ol/lib/util';
+
+/** EPSG:3857 world width in metres (the map's Mercator projection). */
+export const WORLD_WIDTH_3857 = 2 * 20037508.342789244;
+
+/** Per-point route metadata carried alongside the geometry. */
+export interface RoutePointMeta {
+  name?: string;
+  description?: string;
+}
+
+/** Everything the caller needs to apply a route extension (issue #549). */
+export interface RouteExtension {
+  /** The route geometry with the clicked point appended (render space). */
+  after: Position[];
+  /** Per-point metadata, length-aligned with `after`, or undefined when the
+   *  route carries none. */
+  meta?: RoutePointMeta[];
+  /** Pre-append snapshot for the Modify undo stack. */
+  undo: { coordinates: Position[]; coordsMetadata?: RoutePointMeta[] };
+}
+
+/**
+ * Render-space (EPSG:3857) coordinate to append when extending a route by a
+ * clicked open-water point. `base` is the click in the primary world; the
+ * result is shifted whole worlds so it lands in the same world copy as the
+ * route body (given by its x-extent), keeping the new segment contiguous under
+ * wrapX while the stored lon/lat stays world-agnostic (#572).
+ */
+export function worldAlignedPoint(
+  base: Position,
+  extentMinX: number,
+  extentMaxX: number,
+  worldWidth = WORLD_WIDTH_3857
+): Position {
+  const centreX = (extentMinX + extentMaxX) / 2;
+  const shift = worldCopyOffset(centreX - base[0], worldWidth);
+  return [base[0] + shift, base[1]];
+}
+
+/**
+ * Append a clicked open-water point to the end of a route being modified, the
+ * "quick add end point" behaviour of issue #549. Returns the new geometry, the
+ * length-aligned metadata (the new end point has no name/description, matching a
+ * drawn route), and the pre-append undo snapshot. Pure: the caller applies the
+ * result to the feature and session state.
+ */
+export function extendRouteAtClick(
+  before: Position[],
+  meta: RoutePointMeta[] | undefined,
+  base: Position,
+  extentMinX: number,
+  extentMaxX: number,
+  worldWidth = WORLD_WIDTH_3857
+): RouteExtension {
+  const newPoint = worldAlignedPoint(base, extentMinX, extentMaxX, worldWidth);
+  return {
+    after: [...before, newPoint],
+    meta: meta ? [...meta, { name: '' }] : undefined,
+    undo: {
+      coordinates: before.map((co) => [...co] as Position),
+      coordsMetadata: meta ? meta.map((m) => ({ ...m })) : undefined
+    }
+  };
+}


### PR DESCRIPTION
While modifying a route, a click that misses the route now appends that point
as the new **end point** — so a route can be lengthened the same way it is
drawn, without leaving modify mode.

Clicks that land **on** the route stay OpenLayers `Modify`'s job (move / insert /
delete a vertex); the extend only fires on a genuine miss, using a hit tolerance
≥ Modify's own `pixelTolerance` so no single click both inserts a vertex and
appends an end point. The appended point is world-copy aligned so the new segment
stays contiguous under wrapX, while the stored lon/lat stays canonical. The edit
flows through the same session state as a vertex op, so Undo (Ctrl-Z), the
distance read-out, and Finish/Cancel all account for it.

The world-copy alignment and append logic are extracted into a small pure module
(`route-extend.ts`) with unit coverage.

Closes #549


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Routes can now be extended in Modify mode by clicking an open-water location.
  - New route endpoints remain continuous across wrapped map views.
  - Added undo support for route extensions, including route metadata and editing state.

- **Bug Fixes**
  - Improved route alignment near the antimeridian.
  - Ensured route metadata remains consistent when adding new points.

- **Tests**
  - Added coverage for world wrapping, route extension, metadata handling, and undo snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->