### PR TITLE
feat(map): combine center and follow vessel into one button

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -543,27 +543,13 @@
                     [matTooltip]="
                       app.uiConfig().mapMove
                         ? 'Turn off Follow Vessel'
-                        : 'Follow Vessel'
+                        : 'Center & Follow Vessel'
                     "
                     matTooltipPosition="right"
                   >
                     <mat-icon class="ob" svgIcon="cent-iec"></mat-icon>
                   </button>
                 </div>
-                @if (!app.uiConfig().mapMove) {
-                  <div class="buttonPanelItem">
-                    <button
-                      class="button-toolbar"
-                      mat-mini-fab
-                      (click)="centerVessel()"
-                      [disabled]="!app.data.vessels.showSelf"
-                      matTooltip="Center Vessel"
-                      matTooltipPosition="right"
-                    >
-                      <mat-icon> center_focus_strong </mat-icon>
-                    </button>
-                  </div>
-                }
                 <div class="buttonPanelItem">
                   <button
                     class="button-toolbar"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1481,14 +1481,6 @@ export class AppComponent {
     }
   }
 
-  /**
-   * Center the map relative to the vessel position
-   */
-  protected centerVessel() {
-    const pos = this.app.calcMapCenter();
-    this.centerAndZoom(pos);
-  }
-
   protected toggleAisTargets() {
     this.app.config.ui.showAisTargets = !this.app.config.ui.showAisTargets;
     if (this.app.config.ui.showAisTargets) {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,10 @@
 import { FBAppData, IAppConfig, TemperatureUnitDef } from './types';
 import { Convert } from './lib/convert';
+import {
+  clampCenterOffset,
+  legacyCenterOffset,
+  legacyPanBehavior
+} from './lib/follow-offset';
 import { SKVessel } from './modules';
 import { DefaultOptions } from './modules/map/ol/lib/charts/s57.service';
 
@@ -138,14 +143,22 @@ export function cleanConfig(
   if (typeof settings.map.labelsMinZoom === 'undefined') {
     settings.map.labelsMinZoom = 8;
   }
-  if (typeof settings.map.lockMoveMap === 'undefined') {
-    settings.map.lockMoveMap = false;
+  if (typeof settings.map.panBehavior === 'undefined') {
+    const legacy = settings.map as unknown as { lockMoveMap?: boolean };
+    settings.map.panBehavior = legacyPanBehavior(legacy.lockMoveMap);
+    delete legacy.lockMoveMap;
   }
   if (typeof settings.map.popoverMulti === 'undefined') {
     settings.map.popoverMulti = false;
   }
   if (typeof settings.map.centerOffset === 'undefined') {
     settings.map.centerOffset = 0;
+  } else if (!Number.isInteger(settings.map.centerOffset)) {
+    // A fractional value is the superseded 0-0.7 preset; the setting now holds
+    // a whole percentage.
+    settings.map.centerOffset = legacyCenterOffset(settings.map.centerOffset);
+  } else {
+    settings.map.centerOffset = clampCenterOffset(settings.map.centerOffset);
   }
   if (typeof settings.map.doubleClickZoom === 'undefined') {
     settings.map.doubleClickZoom = false;
@@ -511,7 +524,7 @@ export function defaultConfig(): IAppConfig {
       zoomLevel: 2,
       center: [0, 0],
       rotation: 0,
-      lockMoveMap: true,
+      panBehavior: 'offset',
       animate: false,
       labelsMinZoom: 8,
       doubleClickZoom: false, // true=zoom

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -10,6 +10,11 @@ import { Subject } from 'rxjs';
 
 import { InfoService, IndexedDB, AppInfoDef } from './lib/services';
 import { isTrackShown, toggleTrackSelection } from './lib/vessel-track';
+import {
+  centerOffsetFromPan,
+  edgeDistanceInDirection,
+  mapCenterForOffset
+} from './lib/follow-offset';
 
 import {
   AlertDialog,
@@ -896,45 +901,67 @@ export class AppFacade extends InfoService {
     );
   }
 
+  private activeVesselCourse(): number | null {
+    return (
+      this.data.vessels.active.cogTrue ?? this.data.vessels.active.headingTrue
+    );
+  }
+
+  /** Metres from the viewport centre to the screen edge on the given course. */
+  private viewEdgeDistance(course: number): number {
+    return edgeDistanceInDirection(
+      GeoUtils.distanceTo(
+        this.config.map.center as Position,
+        this.mapViewRightCenter()
+      ),
+      GeoUtils.distanceTo(
+        this.config.map.center as Position,
+        this.mapViewTopCenter()
+      ),
+      course,
+      this.mapViewRotation()
+    );
+  }
+
   /** Calculate the position to center the map.
-   * Tales into account the amount of offset to apply
+   * @param applyOffset false to centre the vessel exactly, ignoring the
+   * configured vessel centre offset.
    */
-  calcMapCenter(): Position {
-    const cog =
-      this.data.vessels.active.cogTrue ?? this.data.vessels.active.headingTrue;
-    if (cog === null) {
-      return this.data.vessels.active.position;
+  calcMapCenter(applyOffset = true): Position {
+    const position = this.data.vessels.active.position;
+    const cog = this.activeVesselCourse();
+    const offset = this.config.map.centerOffset ?? 0;
+    if (cog === null || !applyOffset || !offset) {
+      return position;
     }
-    // Compute the geodetic distance from the viewport centre to the screen
-    // edge in the exact CoG direction. This correctly handles any map rotation
-    // mode (north-up or heading-up) and any screen aspect ratio.
-    //
-    // In OL, a CW bearing β has projected-space direction (sin β, cos β).
-    // With OL view rotation rot (CCW), the screen-space components are:
-    //   sx = sin(β + rot)  (rightward)   sy = cos(β + rot)  (upward)
-    // The edge of the viewport rectangle lies at min(hw/|sx|, hh/|sy|)
-    // where hw = geodetic half-width, hh = geodetic half-height.
-    const hh = GeoUtils.distanceTo(
-      this.config.map.center as Position,
-      this.mapViewTopCenter()
-    );
-    const hw = GeoUtils.distanceTo(
-      this.config.map.center as Position,
-      this.mapViewRightCenter()
-    );
-    const rot = this.mapViewRotation();
-    const sx = Math.abs(Math.sin(cog + rot));
-    const sy = Math.abs(Math.cos(cog + rot));
-    const edgeDistance = Math.min(
-      sx > 1e-10 ? hw / sx : Infinity,
-      sy > 1e-10 ? hh / sy : Infinity
-    );
-    const offsetDistance = edgeDistance * (this.config.map.centerOffset ?? 0.5);
-    return GeoUtils.destCoordinate(
-      this.data.vessels.active.position,
+    return mapCenterForOffset(
+      position,
       cog,
-      offsetDistance
+      this.viewEdgeDistance(cog),
+      offset
     );
+  }
+
+  /**
+   * Adopt a chart pan as the vessel centre offset.
+   * @returns true when the setting changed and needs persisting.
+   */
+  setCenterOffsetFromPan(mapCenter: Position): boolean {
+    const cog = this.activeVesselCourse();
+    if (cog === null) {
+      return false;
+    }
+    const offset = centerOffsetFromPan(
+      this.data.vessels.active.position,
+      mapCenter,
+      cog,
+      this.viewEdgeDistance(cog)
+    );
+    if (offset === null || offset === this.config.map.centerOffset) {
+      return false;
+    }
+    this.config.map.centerOffset = offset;
+    return true;
   }
 
   /**

--- a/src/app/lib/follow-offset.spec.ts
+++ b/src/app/lib/follow-offset.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CENTER_OFFSET_LIMIT,
+  centerOffsetFromPan,
+  clampCenterOffset,
+  edgeDistanceInDirection,
+  legacyCenterOffset,
+  legacyPanBehavior,
+  mapCenterForOffset
+} from './follow-offset';
+import { Position } from '../types';
+
+const VESSEL: Position = [-80.5, 25.0];
+const NORTH = 0;
+const EAST = Math.PI / 2;
+const EDGE_DISTANCE = 2000; // metres from the viewport centre to the edge
+
+/** Positions 1km from the vessel, for panning the map centre to. */
+const NORTH_1KM: Position = [-80.5, 25.0 + 1000 / 111320];
+const SOUTH_1KM: Position = [-80.5, 25.0 - 1000 / 111320];
+const EAST_1KM: Position = [
+  -80.5 + 1000 / (111320 * Math.cos(25.0 * (Math.PI / 180))),
+  25.0
+];
+
+describe('clampCenterOffset', () => {
+  it('keeps the vessel on screen by clamping to the limit', () => {
+    expect(clampCenterOffset(140)).toBe(CENTER_OFFSET_LIMIT);
+    expect(clampCenterOffset(-140)).toBe(-CENTER_OFFSET_LIMIT);
+  });
+
+  it('rounds to a whole percentage', () => {
+    expect(clampCenterOffset(12.6)).toBe(13);
+    expect(clampCenterOffset(-12.6)).toBe(-13);
+  });
+
+  it('falls back to no offset for a non-numeric entry', () => {
+    expect(clampCenterOffset(NaN)).toBe(0);
+  });
+});
+
+describe('legacyCenterOffset', () => {
+  it('converts the superseded fractional presets to percentages', () => {
+    expect(legacyCenterOffset(0.2)).toBe(20);
+    expect(legacyCenterOffset(0.5)).toBe(50);
+    expect(legacyCenterOffset(0.7)).toBe(70);
+  });
+});
+
+describe('legacyPanBehavior', () => {
+  it('maps a checked "Lock Follow Vessel" to holding the panned-to offset', () => {
+    // Locked meant "panning does not drop me out of follow mode".
+    expect(legacyPanBehavior(true)).toBe('offset');
+  });
+
+  it('maps an unchecked "Lock Follow Vessel" to releasing follow mode', () => {
+    expect(legacyPanBehavior(false)).toBe('exit');
+  });
+
+  it('treats a config predating the checkbox as releasing follow mode', () => {
+    expect(legacyPanBehavior(undefined)).toBe('exit');
+  });
+});
+
+describe('edgeDistanceInDirection', () => {
+  it('reaches the top edge on a northerly course in north-up', () => {
+    expect(edgeDistanceInDirection(1000, 500, NORTH, 0)).toBe(500);
+  });
+
+  it('reaches the side edge on an easterly course in north-up', () => {
+    expect(edgeDistanceInDirection(1000, 500, EAST, 0)).toBe(1000);
+  });
+
+  it('follows the rotation in heading-up, where the course is always up', () => {
+    // Heading-up rotates the view by -course, so the course direction is the
+    // top of the screen whatever the compass bearing.
+    expect(edgeDistanceInDirection(1000, 500, EAST, -EAST)).toBe(500);
+  });
+});
+
+describe('mapCenterForOffset', () => {
+  it('places the map centre ahead of the vessel for a positive offset', () => {
+    const centre = mapCenterForOffset(VESSEL, NORTH, EDGE_DISTANCE, 50);
+    // 50% of a 2000m edge = 1000m ahead.
+    expect(centre[1]).toBeCloseTo(NORTH_1KM[1], 4);
+    expect(centre[0]).toBeCloseTo(VESSEL[0], 4);
+  });
+
+  it('places the map centre astern for a negative offset', () => {
+    const centre = mapCenterForOffset(VESSEL, NORTH, EDGE_DISTANCE, -50);
+    expect(centre[1]).toBeCloseTo(SOUTH_1KM[1], 4);
+  });
+
+  it('applies the offset along the course, not due north', () => {
+    const centre = mapCenterForOffset(VESSEL, EAST, EDGE_DISTANCE, 50);
+    expect(centre[0]).toBeCloseTo(EAST_1KM[0], 4);
+    expect(centre[1]).toBeCloseTo(VESSEL[1], 4);
+  });
+
+  it('centres the vessel exactly when there is no offset', () => {
+    expect(mapCenterForOffset(VESSEL, NORTH, EDGE_DISTANCE, 0)).toEqual(VESSEL);
+  });
+});
+
+describe('centerOffsetFromPan', () => {
+  it('reads a pan ahead of the vessel as a positive percentage', () => {
+    expect(centerOffsetFromPan(VESSEL, NORTH_1KM, NORTH, EDGE_DISTANCE)).toBe(
+      50
+    );
+  });
+
+  it('reads a pan astern of the vessel as a negative percentage', () => {
+    expect(centerOffsetFromPan(VESSEL, SOUTH_1KM, NORTH, EDGE_DISTANCE)).toBe(
+      -50
+    );
+  });
+
+  it('keeps only the along-course part of an off-course pan', () => {
+    // Panning abeam contributes nothing: the setting is a single along-course
+    // value, so the vessel springs back onto the course line.
+    expect(centerOffsetFromPan(VESSEL, EAST_1KM, NORTH, EDGE_DISTANCE)).toBe(0);
+  });
+
+  it('measures against the course, not the compass', () => {
+    expect(centerOffsetFromPan(VESSEL, EAST_1KM, EAST, EDGE_DISTANCE)).toBe(50);
+  });
+
+  it('clamps a pan that would push the vessel off screen', () => {
+    expect(centerOffsetFromPan(VESSEL, NORTH_1KM, NORTH, 500)).toBe(
+      CENTER_OFFSET_LIMIT
+    );
+  });
+
+  it('leaves the setting alone when the vessel has no course', () => {
+    expect(
+      centerOffsetFromPan(VESSEL, NORTH_1KM, null, EDGE_DISTANCE)
+    ).toBeNull();
+  });
+
+  it('round-trips: applying a captured offset restores the panned-to centre', () => {
+    const offset = centerOffsetFromPan(VESSEL, NORTH_1KM, NORTH, EDGE_DISTANCE);
+    const centre = mapCenterForOffset(VESSEL, NORTH, EDGE_DISTANCE, offset!);
+    expect(centre[0]).toBeCloseTo(NORTH_1KM[0], 4);
+    expect(centre[1]).toBeCloseTo(NORTH_1KM[1], 4);
+  });
+});

--- a/src/app/lib/follow-offset.ts
+++ b/src/app/lib/follow-offset.ts
@@ -1,0 +1,132 @@
+import { getGreatCircleBearing } from 'geolib';
+import { Convert } from './convert';
+import { GeoUtils } from './geoutils';
+import { MapPanBehavior, Position } from '../types';
+
+/**
+ * The vessel centre offset is a whole percentage of the distance from the
+ * viewport centre to the screen edge, measured along the vessel's course:
+ * positive puts the map centre ahead of the vessel (look ahead), negative puts
+ * it astern (look behind). Clamped short of the edge so the vessel can never be
+ * pushed off screen.
+ */
+export const CENTER_OFFSET_LIMIT = 90;
+
+/** Round and clamp an entered or panned-to offset to a usable percentage. */
+export function clampCenterOffset(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(
+    -CENTER_OFFSET_LIMIT,
+    Math.min(CENTER_OFFSET_LIMIT, Math.round(value))
+  );
+}
+
+/**
+ * Convert the superseded fractional offset (the 0–0.7 preset dropdown) to a
+ * percentage. Legacy values are the only non-integers the setting can hold.
+ */
+export function legacyCenterOffset(value: number): number {
+  return clampCenterOffset(value * 100);
+}
+
+/**
+ * Map the superseded "Lock Follow Vessel" checkbox onto a pan behavior.
+ * Locked meant "stay in follow mode when I pan", so it becomes the option that
+ * keeps follow on and honours the pan; unlocked dropped out of follow mode,
+ * which is also what a config predating the checkbox did.
+ */
+export function legacyPanBehavior(lockMoveMap?: boolean): MapPanBehavior {
+  return lockMoveMap ? 'offset' : 'exit';
+}
+
+const TWO_PI = Math.PI * 2;
+
+/** Normalise an angle to `[0, 2π)`. */
+const normalise = (radians: number): number =>
+  ((radians % TWO_PI) + TWO_PI) % TWO_PI;
+
+/**
+ * Geodetic distance from the viewport centre to the screen edge in the given
+ * course direction. This correctly handles any map rotation mode (north-up or
+ * heading-up) and any screen aspect ratio.
+ *
+ * In OL, a CW bearing β has projected-space direction (sin β, cos β). With OL
+ * view rotation rot (CCW), the screen-space components are:
+ *   sx = sin(β + rot)  (rightward)   sy = cos(β + rot)  (upward)
+ * The edge of the viewport rectangle lies at min(hw/|sx|, hh/|sy|).
+ * @param halfWidth geodetic distance from the centre to the side edge
+ * @param halfHeight geodetic distance from the centre to the top edge
+ * @param course vessel COG (or heading) in radians
+ * @param rotation OL view rotation in radians
+ */
+export function edgeDistanceInDirection(
+  halfWidth: number,
+  halfHeight: number,
+  course: number,
+  rotation: number
+): number {
+  const sx = Math.abs(Math.sin(course + rotation));
+  const sy = Math.abs(Math.cos(course + rotation));
+  return Math.min(
+    sx > 1e-10 ? halfWidth / sx : Infinity,
+    sy > 1e-10 ? halfHeight / sy : Infinity
+  );
+}
+
+/**
+ * Resolve the vessel centre offset to a map centre for the vessel's current
+ * position and course.
+ * @param vessel vessel position `[lon, lat]`
+ * @param course vessel COG (or heading) in radians
+ * @param edgeDistance metres from the viewport centre to the edge on that course
+ * @param offset the configured offset percentage
+ */
+export function mapCenterForOffset(
+  vessel: Position,
+  course: number,
+  edgeDistance: number,
+  offset: number
+): Position {
+  const distance = edgeDistance * (offset / 100);
+  if (!distance || !Number.isFinite(distance)) {
+    return vessel;
+  }
+  return GeoUtils.destCoordinate(
+    vessel,
+    distance < 0 ? normalise(course + Math.PI) : normalise(course),
+    Math.abs(distance)
+  );
+}
+
+/**
+ * Derive the vessel centre offset from a chart pan, by projecting the
+ * vessel → map-centre displacement onto the vessel's course. The setting is a
+ * single along-course value, so panning off the course line contributes only
+ * its along-course component.
+ *
+ * Returns null when the vessel has no course to measure against, in which case
+ * the pan leaves the configured offset alone.
+ * @param vessel vessel position `[lon, lat]`
+ * @param mapCenter map centre the user panned to `[lon, lat]`
+ * @param course vessel COG (or heading) in radians; null when not under way
+ * @param edgeDistance metres from the viewport centre to the edge on that course
+ */
+export function centerOffsetFromPan(
+  vessel: Position,
+  mapCenter: Position,
+  course: number | null,
+  edgeDistance: number
+): number | null {
+  if (course === null || !edgeDistance || !Number.isFinite(edgeDistance)) {
+    return null;
+  }
+  const distance = GeoUtils.distanceTo(vessel, mapCenter) ?? 0;
+  // getGreatCircleBearing returns degrees; the map works in radians.
+  const bearing = Convert.degreesToRadians(
+    getGreatCircleBearing(vessel, mapCenter) ?? 0
+  );
+  const alongCourse = distance * Math.cos(bearing - course);
+  return clampCenterOffset((alongCourse / edgeDistance) * 100);
+}

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -166,6 +166,10 @@ enum INTERACTION_MODE {
   MODIFY
 }
 
+/** How long the vessel is held dead centre after follow mode is turned on,
+ * before the configured centre offset is applied. */
+const OFFSET_GRACE_PERIOD = 2000;
+
 @Component({
   selector: 'fb-map',
   imports: [
@@ -299,6 +303,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   private saveTimer;
   private isDirty = false;
+  /** A user drag is in flight under the 'offset' pan behavior — the resulting
+   * map centre becomes the new vessel centre offset. */
+  private userPanned = false;
+  private offsetGraceTimer;
+  /** True while the vessel is held dead centre just after follow mode is
+   * turned on (see startOffsetGrace). */
+  private offsetSuppressed = false;
   /**
    * EPSG:3857-metre offset of the world copy the most recent click landed in.
    * Passed to overlays so a popover is drawn in the copy the user clicked, not
@@ -394,6 +405,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.stopSaveTimer();
+    this.stopOffsetGrace();
     this.obsList.forEach((i) => i.unsubscribe());
   }
 
@@ -415,10 +427,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
     if (changes && changes.movingMap && !changes.movingMap.firstChange) {
       if (changes.movingMap.currentValue) {
         this.startSaveTimer();
+        this.startOffsetGrace();
       } else {
         this.stopSaveTimer();
+        // Leave the chart where it is when follow mode is released — snapping
+        // back to the vessel would undo the pan that just released it.
+        this.stopOffsetGrace();
+        this.userPanned = false;
       }
-      this.centerVessel();
     }
     if (changes && changes.northUp) {
       this.rotateMap();
@@ -657,6 +673,17 @@ export class FBMapComponent implements OnInit, OnDestroy {
     this.app.mapViewRotation.update(() => e.rotation);
     this.app.config.map.center = e.lonlat as Position;
 
+    if (this.userPanned) {
+      // Adopt where the user left the vessel on screen only once the pan (and
+      // any kinetic glide) has settled, so the offset matches what they see.
+      // The pan IS the offset gesture, so it also ends the post-tap grace.
+      this.userPanned = false;
+      this.stopOffsetGrace();
+      if (this.app.setCenterOffsetFromPan(e.lonlat as Position)) {
+        this.app.saveConfigDebounced();
+      }
+    }
+
     this.drawVesselLines();
     if (!this.movingMap) {
       // debounce: a flurry of pans/zooms collapses into one save
@@ -723,10 +750,17 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   protected onMapPointerDrag() {
-    if (!this.app.config.map.lockMoveMap && this.app.uiConfig().mapMove) {
+    if (!this.app.uiConfig().mapMove) {
+      return;
+    }
+    if (this.app.config.map.panBehavior === 'exit') {
       // pointer-drag runs outside the Angular zone (see MapComponent); re-enter
       // so exiting "move map" mode propagates to the UI. Rare one-off transition.
       this.ngZone.run(() => this.exitMovingMap.emit(true));
+    } else if (this.app.config.map.panBehavior === 'offset') {
+      // Follow mode stays on; onMapMoveEnd() captures the new look-ahead once
+      // the drag settles.
+      this.userPanned = true;
     }
   }
 
@@ -1967,8 +2001,35 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   // center map to active vessel position
   private centerVessel() {
-    const pos = this.app.calcMapCenter();
+    if (this.userPanned) {
+      // A pan is in flight under the 'offset' behavior: a position update
+      // arriving mid-drag would snatch the chart back from the user.
+      return;
+    }
+    const pos = this.app.calcMapCenter(!this.offsetSuppressed);
     this.mapCenterPositon.update(() => pos);
+  }
+
+  /**
+   * Hold the vessel dead centre for a moment after follow mode is turned on
+   * before easing out to the configured centre offset. A second tap of the
+   * button inside that window therefore leaves the vessel exactly centred,
+   * which is how "just centre it" is expressed now that one button does both.
+   */
+  private startOffsetGrace() {
+    this.stopOffsetGrace();
+    this.offsetSuppressed = true;
+    this.centerVessel();
+    this.offsetGraceTimer = setTimeout(() => {
+      this.offsetSuppressed = false;
+      this.centerVessel();
+    }, OFFSET_GRACE_PERIOD);
+  }
+
+  private stopOffsetGrace() {
+    clearTimeout(this.offsetGraceTimer);
+    this.offsetGraceTimer = undefined;
+    this.offsetSuppressed = false;
   }
 
   /** construct vessel lines for rendering */

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -477,16 +477,18 @@
                     </mat-form-field>
                   </div>
                   <div class="setting-card-row-item">
-                    <mat-form-field style="width: 100%">
-                      <mat-label>Offset Vessel Center</mat-label>
-                      <mat-select
+                    <mat-form-field style="width: 100%" floatLabel="always">
+                      <mat-label>Offset Vessel Center (%)</mat-label>
+                      <input
+                        matInput
+                        type="number"
+                        #centerOffset="ngModel"
+                        [min]="-centerOffsetLimit"
+                        [max]="centerOffsetLimit"
                         [(ngModel)]="facade.settings.map.centerOffset"
-                        (selectionChange)="persistModel()"
-                      >
-                        @for(i of options.map.centerOffset; track i[0]) {
-                        <mat-option [value]="i[0]">{{i[1]}}</mat-option>
-                        }
-                      </mat-select>
+                        (change)="parseCenterOffset(centerOffset)"
+                        matTooltip="How far ahead of the vessel to centre the map, as a percentage of the distance to the screen edge. Use a negative value to look behind."
+                      />
                     </mat-form-field>
                   </div>
                   <div class="setting-card-row-item">
@@ -520,14 +522,18 @@
                     </mat-checkbox>
                   </div>
                   <div class="setting-card-row-item">
-                    <mat-checkbox
-                      [(ngModel)]="facade.settings.map.lockMoveMap"
-                      (change)="persistModel()"
-                      matTooltip="Do not exit follow vessel when map is panned."
-                      label="after"
-                    >
-                      Lock Follow Vessel
-                    </mat-checkbox>
+                    <mat-form-field style="width: 100%">
+                      <mat-label>Map Pan When Following</mat-label>
+                      <mat-select
+                        [(ngModel)]="facade.settings.map.panBehavior"
+                        (selectionChange)="persistModel()"
+                        matTooltip="What panning the chart does while following the vessel."
+                      >
+                        @for(i of options.map.panBehavior; track i[0]) {
+                        <mat-option [value]="i[0]">{{i[1]}}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
                   </div>
                 </div>
               </mat-card-content>

--- a/src/app/modules/settings/components/settings-dialog.ts
+++ b/src/app/modules/settings/components/settings-dialog.ts
@@ -38,6 +38,10 @@ import { SettingsOptions } from '../settings.facade';
 import { S57Service } from '../../map/ol';
 import { AppFacade } from 'src/app/app.facade';
 import { Convert, TARGET_UNIT } from 'src/app/lib/convert';
+import {
+  CENTER_OFFSET_LIMIT,
+  clampCenterOffset
+} from 'src/app/lib/follow-offset';
 import { RadarAPIService, SKRadar } from '../../radar/radar-api.service';
 
 interface PreferredPathsResult {
@@ -78,6 +82,7 @@ export class SettingsDialog implements OnInit {
   };
 
   protected options: SettingsOptions;
+  protected readonly centerOffsetLimit = CENTER_OFFSET_LIMIT;
 
   protected aisStateFilter = {
     moored: false,
@@ -220,6 +225,15 @@ export class SettingsDialog implements OnInit {
    */
   toggleFavourites() {
     this.show.favourites.update((current) => !current);
+  }
+
+  /**
+   * Parse the entered vessel centre offset, clamping it to a whole percentage
+   * that keeps the vessel on screen. Negative values look behind the vessel.
+   */
+  parseCenterOffset(e: NgModel) {
+    e.reset(typeof e.model === 'number' ? clampCenterOffset(e.model) : 0);
+    this.persistModel();
   }
 
   /**

--- a/src/app/modules/settings/settings.facade.ts
+++ b/src/app/modules/settings/settings.facade.ts
@@ -4,7 +4,13 @@ import { Injectable } from '@angular/core';
 
 import { AppFacade } from 'src/app/app.facade';
 import { SignalKClient } from 'signalk-client-angular';
-import { FBAppData, IAppConfig, Position, WindIndicator } from 'src/app/types';
+import {
+  FBAppData,
+  IAppConfig,
+  MapPanBehavior,
+  Position,
+  WindIndicator
+} from 'src/app/types';
 import { Observable, Subject } from 'rxjs';
 
 interface SKAppsList {
@@ -83,12 +89,10 @@ export class SettingsOptions {
   };
 
   map = {
-    centerOffset: new Map([
-      [0, '0%'],
-      [0.2, '20%'],
-      [0.3, '30%'],
-      [0.5, '50%'],
-      [0.7, '70%']
+    panBehavior: new Map<MapPanBehavior, string>([
+      ['offset', 'Set Follow Offset'],
+      ['exit', 'Exit Follow Mode'],
+      ['none', 'Do nothing']
     ]),
     s57: {
       graphicsStyle: new Map([

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -28,6 +28,12 @@ export type MFBAction = 'wpt' | 'pob' | 'autopilot' | 'radar';
 // component inputs.
 export type WindIndicator = 'arrow' | 'barb';
 
+// What panning the chart does while follow-vessel mode is on.
+// 'offset' holds the panned-to look-ahead until follow is turned off,
+// 'exit' releases follow mode, 'none' keeps the vessel centred (the map
+// returns to it on the next position update).
+export type MapPanBehavior = 'offset' | 'exit' | 'none';
+
 export interface SKApiResponse {
   state: 'FAILED' | 'COMPLETED' | 'PENDING';
   statusCode: number;
@@ -124,12 +130,12 @@ export interface IAppConfig {
     zoomLevel: number;
     center: Position;
     rotation: number;
-    lockMoveMap: boolean;
+    panBehavior: MapPanBehavior; // what panning the chart does while following the vessel
     animate: boolean;
     labelsMinZoom: number;
     doubleClickZoom: boolean; // true=zoom
     overZoomTiles: boolean; // keep tiles visible beyond chart max zoom
-    centerOffset: number; // vessel offset south of center (%)
+    centerOffset: number; // whole % of the distance to the screen edge that the map centre sits ahead of the vessel (negative = astern)
     s57Options: Options; // S57 chart Options
     popoverMulti: boolean; // close popovers using cose button
   };

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -349,15 +349,15 @@
             </li>
             <li class="nobullet">
               <i class="material-icons">my_location</i>
-              <b>Centre &amp; Follow Vessel:</b>
-              Turns on <i>Follow Vessel</i> mode, centring the vessel on screen
+              <b>Center &amp; Follow Vessel:</b>
+              Turns on <i>Follow Vessel</i> mode, centering the vessel on screen
               and keeping it there. The button is highlighted while follow mode
               is on; press it again to turn follow mode off, leaving the chart
               where it is.<br />
-              The vessel is held exactly centred for a couple of seconds before
+              The vessel is held exactly centered for a couple of seconds before
               easing out to your <b>Offset Vessel Center</b> setting, so a
-              second press straight away leaves it dead centre — press twice to
-              simply centre the vessel.<br />
+              second press straight away leaves it dead center — press twice to
+              simply center the vessel.<br />
               <i
                 >Note: this option is disabled when vessel position is not
                 available.</i
@@ -2357,10 +2357,10 @@
             </li>
             <li>
               <b>Offset Vessel Center (%)</b>: How far ahead of the vessel the
-              map is centred while in "Follow Vessel" mode, giving you more
+              map is centered while in "Follow Vessel" mode, giving you more
               visible chart in front of the vessel. The value is a percentage of
-              the distance from the centre of the screen to its edge, so
-              <b>50</b> places the vessel half way between the centre and the
+              the distance from the center of the screen to its edge, so
+              <b>50</b> places the vessel half way between the center and the
               trailing edge. Enter a negative value to look behind the vessel
               instead.<br />
               You can also set this by eye: with

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -349,19 +349,17 @@
             </li>
             <li class="nobullet">
               <i class="material-icons">my_location</i>
-              <b>Follow Vessel On / Off:</b>
-              Toggles <i>Follow Vessel</i> mode to keep the vessel at the centre
-              of the screen.<br />
+              <b>Centre &amp; Follow Vessel:</b>
+              Turns on <i>Follow Vessel</i> mode, centring the vessel on screen
+              and keeping it there. The button is highlighted while follow mode
+              is on; press it again to turn follow mode off, leaving the chart
+              where it is.<br />
+              The vessel is held exactly centred for a couple of seconds before
+              easing out to your <b>Offset Vessel Center</b> setting, so a
+              second press straight away leaves it dead centre — press twice to
+              simply centre the vessel.<br />
               <i
                 >Note: this option is disabled when vessel position is not
-                available.</i
-              >
-            </li>
-            <li class="nobullet">
-              <i class="material-icons">center_focus_strong</i>
-              <b>Centre Vessel on screen:</b>
-              <i
-                >Note: This option is disabled when vessel position is not
                 available.</i
               >
             </li>
@@ -2358,11 +2356,16 @@
               zoom levels below this value.
             </li>
             <li>
-              <b>Offset Vessel Center</b>: Select the offset to be applied when
-              in "Move Map" mode. This provides more visible map in front of the
-              vessel.<br />
-              The setting will place the vessel at a location the selected
-              percentage, from the map center and the bottom of the screen.<br />
+              <b>Offset Vessel Center (%)</b>: How far ahead of the vessel the
+              map is centred while in "Follow Vessel" mode, giving you more
+              visible chart in front of the vessel. The value is a percentage of
+              the distance from the centre of the screen to its edge, so
+              <b>50</b> places the vessel half way between the centre and the
+              trailing edge. Enter a negative value to look behind the vessel
+              instead.<br />
+              You can also set this by eye: with
+              <b>Map Pan When Following</b> set to <b>Set Follow Offset</b>,
+              simply pan the chart to put the vessel where you want it.<br />
             </li>
             <li>
               <b>Popover close with button</b>: Select this option in order to a
@@ -2374,8 +2377,21 @@
               the map with a double click.
             </li>
             <li>
-              <b>Lock Follow Vessel</b>: Check this box to remain in "Follow
-              Vessel" mode when map is panned / moved.
+              <b>Map Pan When Following</b>: Choose what panning the chart does
+              while "Follow Vessel" mode is on.
+              <ul>
+                <li>
+                  <b>Set Follow Offset</b>: Follow mode stays on and panning
+                  sets the <b>Offset Vessel Center</b> value above, so you can
+                  position the vessel on screen by eye. The offset is saved and
+                  used from then on.
+                </li>
+                <li><b>Exit Follow Mode</b>: Panning turns follow mode off.</li>
+                <li>
+                  <b>Do nothing</b>: Follow mode stays on and the vessel returns
+                  to its usual position on the next position update.
+                </li>
+              </ul>
             </li>
           </ul>
           <b>Vector Charts:</b><br />


### PR DESCRIPTION
Follow Vessel and Center Vessel occupied two toolbar slots for what is really one
intent, which costs real estate on a phone. They are now one button.

**Button** — a tap centres the vessel and turns follow mode on (highlighted); a
tap while on turns it off and leaves the chart where it is. The configured centre
offset is held off for two seconds after follow mode starts, so a second tap
straight away leaves the vessel dead centre — that is how "just centre it"
survives the merge into one button.

**Panning while following** — the old *Lock Follow Vessel* checkbox becomes a
*Map Pan When Following* choice:

- **Set Follow Offset** — follow stays on and the pan sets the offset by eye
- **Exit Follow Mode** — panning releases follow (what unlocked used to do)
- **Do nothing** — vessel returns to position on the next fix (what locked used
  to do); keeps an accidental screen tap from disturbing anything

Existing configs migrate on load: locked → *Set Follow Offset* (it meant "panning
must not drop me out of follow mode"), unlocked or absent → *Exit Follow Mode*.

**Offset Vessel Center** is now entered directly as a signed whole percentage
(±90) instead of chosen from a preset list, so panning has somewhere to write to
and a look-behind is expressible. Stored fractions migrate ×100; a non-integer is
the reliable tell for a legacy value.

The offset is a single along-course value, so a pan off the course line
contributes only its along-course component and the vessel springs back onto the
course line.

Releasing follow mode no longer re-centres the vessel — under one button that
would undo the pan that just released it.

Closes #541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable map panning behavior while following a vessel: set a follow offset, exit follow mode, or do nothing.
  * Replaced the offset preset selector with a percentage input, including validation and limits.
  * Panning while following can now automatically calculate and save the vessel’s follow offset.
  * Added smoother follow-mode centering to prevent abrupt snap-backs after map interactions.

* **Documentation**
  * Updated tooltips and help content to explain vessel centering, follow offsets, and map-panning options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->