### PR TITLE
feat(features): show a feature's newest changes above its instructions

### DIFF
--- a/features/route-planning.md
+++ b/features/route-planning.md
@@ -9,15 +9,6 @@ category: Routes
 Draw a route on the chart, review and adjust it, then save it for later —
 or skip saving and just use it right away.
 
-## New in 3.1
-
-- **One editing card** for both drawing and modifying, with the commit and
-  **Cancel** actions always in the same place.
-- **Undo** while drawing or editing — an Undo button, or Ctrl-Z / ⌘-Z.
-- **Extend a saved route** by clicking open water, without leaving Modify.
-- **Reorder points on an unsaved draft**, not just on saved routes.
-- **Hide** a route from the chart directly from its popover.
-
 **To draw a route**, open the edit menu (pencil icon) and choose **Draw
 Route**. Tap each point along your intended route. A small editing card
 shows the running distance and a **Finish** button — tap **Finish** (or

--- a/src/app/modules/features/feature-browser-dialog.css
+++ b/src/app/modules/features/feature-browser-dialog.css
@@ -118,6 +118,51 @@ figure.shot figcaption {
   opacity: 0.7;
 }
 
+/* "New in x.y" strip: the current release series' changes, above the body so a
+   reader skimming what's new never has to reach the history table below it.
+   Colours come from the primary-container tokens, which the dark-theme block at
+   the foot of this file redefines — so this follows the theme for free. */
+.whats-new {
+  display: flow-root; /* narrow beside the lead figure, not forced below it */
+  margin: 0 0 14px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border-left: 3px solid var(--mat-sys-primary, #415f91);
+  background: var(--mat-sys-primary-container, #d7e2ff);
+  color: var(--mat-sys-on-primary-container, #274777);
+}
+.whats-new-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.whats-new-title mat-icon {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+}
+.whats-new ul {
+  margin: 5px 0 0;
+  padding-left: 20px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+.whats-new-more {
+  margin-top: 5px;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  font-size: 0.8rem;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 /* PR history table in the details pane (most recent first). */
 .pr-history {
   display: flow-root; /* flow beside the floated figures, not forced below them */

--- a/src/app/modules/features/feature-browser-dialog.html
+++ b/src/app/modules/features/feature-browser-dialog.html
@@ -60,6 +60,28 @@
         <span class="since">Unreleased</span>
         }
       </div>
+      @if (f.recentChanges; as rc) {
+      <div class="whats-new">
+        <div class="whats-new-title">
+          <mat-icon>tips_and_updates</mat-icon>
+          <span>{{ rc.label }}</span>
+        </div>
+        <ul>
+          @for (title of rc.shown; track $index) {
+          <li>{{ title }}</li>
+          }
+        </ul>
+        @if (rc.more) {
+        <button
+          type="button"
+          class="whats-new-more"
+          (click)="scrollToHistory()"
+        >
+          +{{ rc.more }} more
+        </button>
+        }
+      </div>
+      }
       <div class="body">
         <remark [processor]="mdProcessor" [markdown]="f.body">
           <ng-template remarkTemplate="image" let-node>

--- a/src/app/modules/features/feature-browser-dialog.spec.ts
+++ b/src/app/modules/features/feature-browser-dialog.spec.ts
@@ -17,6 +17,7 @@ function feature(id: string, title: string): CompiledFeature {
     since: '2.1.0',
     latestKind: 'new',
     events: [],
+    recentChanges: null,
     images: []
   };
 }

--- a/src/app/modules/features/feature-browser-dialog.spec.ts
+++ b/src/app/modules/features/feature-browser-dialog.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { EMPTY } from 'rxjs';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CompiledFeature } from './feature-corpus';
 import { FeatureCorpusService } from './feature-corpus.service';
@@ -71,5 +71,75 @@ describe('FeatureBrowserDialog details scroll', () => {
     fixture.detectChanges();
 
     expect(detailsPane().scrollTop).toBe(0);
+  });
+});
+
+describe('FeatureBrowserDialog what’s-new strip', () => {
+  let fixture: ComponentFixture<FeatureBrowserDialog>;
+
+  const withStrip: CompiledFeature = {
+    ...feature('route-planning', 'Route Planning'),
+    events: [
+      { pr: 2, date: '2026-07-02', title: 'reverse a route' },
+      { pr: 1, date: '2026-07-01', title: 'plan a route' }
+    ],
+    recentChanges: {
+      label: 'New in 3.1',
+      shown: ['reverse a route', 'plan a route', 'undo while drawing'],
+      more: 2
+    }
+  };
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [FeatureBrowserDialog],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: FeatureCorpusService,
+          useValue: { load: async () => [withStrip], hueFor: () => 0 }
+        },
+        {
+          provide: MatDialogRef,
+          useValue: { keydownEvents: () => EMPTY, close: () => undefined }
+        }
+      ]
+    });
+
+    fixture = TestBed.createComponent(FeatureBrowserDialog);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  it('shows the label and only the capped titles', () => {
+    const strip = fixture.nativeElement.querySelector('.whats-new');
+    expect(strip).toBeTruthy();
+    expect(strip.querySelector('.whats-new-title').textContent).toContain(
+      'New in 3.1'
+    );
+    const titles = Array.from(strip.querySelectorAll('li')) as HTMLElement[];
+    expect(titles.map((li) => li.textContent?.trim())).toEqual([
+      'reverse a route',
+      'plan a route',
+      'undo while drawing'
+    ]);
+  });
+
+  it('scrolls to the history table from the "+N more" affordance', () => {
+    const history = fixture.nativeElement.querySelector(
+      '.pr-history'
+    ) as HTMLElement;
+    expect(history).toBeTruthy();
+    const scrollIntoView = vi.fn();
+    history.scrollIntoView = scrollIntoView;
+
+    const more = fixture.nativeElement.querySelector(
+      '.whats-new-more'
+    ) as HTMLElement;
+    expect(more.textContent).toContain('+2 more');
+
+    more.click();
+    expect(scrollIntoView).toHaveBeenCalled();
   });
 });

--- a/src/app/modules/features/feature-browser-dialog.ts
+++ b/src/app/modules/features/feature-browser-dialog.ts
@@ -199,6 +199,13 @@ export class FeatureBrowserDialog implements OnInit {
     }
   }
 
+  /** Jump to the full history from the "+N more" affordance on the strip. */
+  protected scrollToHistory() {
+    this.host.nativeElement
+      .querySelector<HTMLElement>('.pr-history')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
   protected isActive(feature: CompiledFeature): boolean {
     return this.activeFeature()?.id === feature.id;
   }

--- a/src/app/modules/features/feature-corpus.spec.ts
+++ b/src/app/modules/features/feature-corpus.spec.ts
@@ -9,8 +9,12 @@ import {
   stripTypePrefix,
   categoryHue,
   extractImages,
+  releaseSeries,
+  currentReleaseSeries,
+  MAX_RECENT_SHOWN,
   CompiledFeature,
-  FeatureCorpusPayload
+  FeatureCorpusPayload,
+  FeatureLedgerRow
 } from './feature-corpus';
 
 const doc = (id: string, front: Record<string, string>, body: string) => ({
@@ -189,6 +193,171 @@ describe('compileCorpus', () => {
   });
 });
 
+describe('releaseSeries', () => {
+  it('reduces a release to its major.minor', () => {
+    expect(releaseSeries('v3.1.2')).toBe('3.1');
+    expect(releaseSeries('2.8.4')).toBe('2.8');
+    expect(releaseSeries('v3.1.0-beta.1')).toBe('3.1');
+  });
+
+  it('is null for a blank or series-less value', () => {
+    expect(releaseSeries(null)).toBeNull();
+    expect(releaseSeries('')).toBeNull();
+    expect(releaseSeries('v3')).toBeNull();
+  });
+});
+
+describe('currentReleaseSeries', () => {
+  it('takes the newest released row, ignoring unreleased and skip rows', () => {
+    expect(
+      currentReleaseSeries([
+        { feature: 'a', kind: 'new', since: 'v3.0.0' },
+        { feature: 'a', kind: 'enhanced', since: 'v3.1.1' },
+        { feature: 'a', kind: 'enhanced' },
+        { feature: null, kind: 'skip', since: 'v9.9.9' }
+      ])
+    ).toBe('3.1');
+  });
+
+  it('is null when nothing has been released', () => {
+    expect(currentReleaseSeries([{ feature: 'a', kind: 'new' }])).toBeNull();
+  });
+});
+
+describe('compileCorpus → recentChanges', () => {
+  const build = (ledger: FeatureLedgerRow[]): CompiledFeature =>
+    compileCorpus({
+      docs: [
+        doc('routes', { title: 'Route Planning', category: 'Navigation' }, 'b')
+      ],
+      ledger
+    })[0];
+
+  it('covers the whole series, so a patch release hides nothing', () => {
+    const f = build([
+      {
+        feature: 'routes',
+        pr: 1,
+        kind: 'new',
+        since: 'v3.1.0',
+        date: '2026-07-01',
+        title: 'feat(routes): plan a route'
+      },
+      {
+        feature: 'routes',
+        pr: 2,
+        kind: 'enhanced',
+        since: 'v3.1.1',
+        date: '2026-07-10',
+        title: 'feat(routes): reverse a route'
+      }
+    ]);
+    expect(f.recentChanges?.label).toBe('New in 3.1');
+    expect(f.recentChanges?.shown).toEqual(['reverse a route', 'plan a route']);
+  });
+
+  it('shows nothing for a feature untouched since an earlier series', () => {
+    const f = build([
+      {
+        feature: 'routes',
+        pr: 1,
+        kind: 'new',
+        since: 'v2.9.0',
+        date: '2025-01-01',
+        title: 'feat(routes): plan a route'
+      },
+      {
+        feature: 'elsewhere',
+        pr: 9,
+        kind: 'enhanced',
+        since: 'v3.1.0',
+        date: '2026-07-01',
+        title: 'feat(x): something newer'
+      }
+    ]);
+    expect(f.recentChanges).toBeNull();
+  });
+
+  it('labels a feature that only gained enhancements in the series', () => {
+    const f = build([
+      {
+        feature: 'routes',
+        pr: 1,
+        kind: 'new',
+        since: 'v3.0.0',
+        date: '2026-01-01',
+        title: 'feat(routes): plan a route'
+      },
+      {
+        feature: 'routes',
+        pr: 2,
+        kind: 'enhanced',
+        since: 'v3.1.0',
+        date: '2026-07-01',
+        title: 'feat(routes): reverse a route'
+      }
+    ]);
+    expect(f.recentChanges?.label).toBe('Updated in 3.1');
+    expect(f.recentChanges?.shown).toEqual(['reverse a route']);
+  });
+
+  it('never announces unreleased work under the shipped release name', () => {
+    const f = build([
+      {
+        feature: 'routes',
+        pr: 1,
+        kind: 'new',
+        since: 'v3.1.0',
+        date: '2026-07-01',
+        title: 'feat(routes): plan a route'
+      },
+      {
+        feature: 'routes',
+        pr: 2,
+        kind: 'enhanced',
+        date: '2026-07-20',
+        title: 'feat(routes): reverse a route'
+      }
+    ]);
+    expect(f.recentChanges?.label).toBe('Unreleased');
+    expect(f.recentChanges?.shown).toEqual(['reverse a route']);
+  });
+
+  it('labels a corpus with nothing released yet as unreleased', () => {
+    const f = build([
+      {
+        feature: 'routes',
+        pr: 1,
+        kind: 'new',
+        date: '2026-07-01',
+        title: 'feat(routes): plan a route'
+      }
+    ]);
+    expect(f.recentChanges?.label).toBe('Unreleased');
+    expect(f.recentChanges?.shown).toEqual(['plan a route']);
+  });
+
+  it('caps the list and reports the remainder', () => {
+    const f = build(
+      Array.from({ length: 5 }, (_, i) => ({
+        feature: 'routes',
+        pr: i + 1,
+        kind: 'enhanced' as const,
+        since: 'v3.1.0',
+        date: `2026-07-0${i + 1}`,
+        title: `feat(routes): change ${i + 1}`
+      }))
+    );
+    expect(f.recentChanges?.shown).toHaveLength(MAX_RECENT_SHOWN);
+    expect(f.recentChanges?.shown[0]).toBe('change 5');
+    expect(f.recentChanges?.more).toBe(2);
+  });
+
+  it('is null for a doc with no ledger rows', () => {
+    expect(build([]).recentChanges).toBeNull();
+  });
+});
+
 describe('sortFeatures', () => {
   const feats: CompiledFeature[] = [
     mk('a', 'Alpha', 'Radar', 'v2.1.0'),
@@ -324,6 +493,7 @@ function mk(
     since,
     latestKind: since ? 'new' : null,
     events: [],
+    recentChanges: null,
     images: []
   };
 }

--- a/src/app/modules/features/feature-corpus.ts
+++ b/src/app/modules/features/feature-corpus.ts
@@ -60,6 +60,23 @@ export interface FeatureImage {
   alt: string;
 }
 
+/**
+ * A feature's changes in the current release series — the "New in x.y" strip
+ * shown above the body, so a reader skimming what's new doesn't have to reach
+ * the history table at the bottom of the pane.
+ */
+export interface RecentChanges {
+  /** Heading: "New in 3.1", "Updated in 3.1", or "Unreleased". */
+  label: string;
+  /** Change titles, most recent first, capped at `MAX_RECENT_SHOWN`. */
+  shown: string[];
+  /** Changes beyond `shown` — 0 when everything fits. */
+  more: number;
+}
+
+/** Titles listed before the strip defers the rest to the history table. */
+export const MAX_RECENT_SHOWN = 3;
+
 /** A feature ready for display in the browser. */
 export interface CompiledFeature {
   id: string;
@@ -73,6 +90,8 @@ export interface CompiledFeature {
   latestKind: Exclude<FeatureChangeKind, 'skip'> | null;
   /** PRs that changed this feature, most recent first. */
   events: FeatureEvent[];
+  /** What's new in the current release series, or null if nothing is. */
+  recentChanges: RecentChanges | null;
   /** Images embedded in the body, in order; `images[0]` is the lead figure. */
   images: FeatureImage[];
 }
@@ -164,6 +183,63 @@ export function compareSince(a: string | null, b: string | null): number {
 }
 
 /**
+ * The `major.minor` series of a release string (`v3.1.2` → `3.1`), or null if it
+ * names no series. Patch releases share a series deliberately: "New in 3.1" must
+ * mean everything since 3.0, for the whole life of 3.1.
+ */
+export function releaseSeries(since: string | null | undefined): string | null {
+  if (!since) return null;
+  const parts = String(since).replace(/^v/i, '').split('.');
+  return parts.length < 2 ? null : `${parts[0]}.${parts[1]}`;
+}
+
+/**
+ * The newest release series anywhere in the ledger — what "current" means for
+ * the strip. Null when nothing has shipped yet (only unreleased rows).
+ */
+export function currentReleaseSeries(
+  ledger: FeatureLedgerRow[]
+): string | null {
+  let newest: string | null = null;
+  for (const row of ledger) {
+    if (!row || row.kind === 'skip' || !row.since) continue;
+    if (compareSince(row.since, newest) > 0) newest = row.since;
+  }
+  return releaseSeries(newest);
+}
+
+/**
+ * A feature's strip. Unreleased rows win when present: they belong to the *next*
+ * series, so folding them into the current one would announce work that hasn't
+ * shipped under the shipped release's name. Users never see that branch — only
+ * dev and beta builds carry unstamped rows, and it keeps them from being blank.
+ *
+ * Otherwise the strip is the feature's rows in `series`, and null when it has
+ * none — which is how the strip ages out on its own once the next series ships.
+ */
+function buildRecentChanges(
+  rows: FeatureLedgerRow[],
+  series: string | null
+): RecentChanges | null {
+  // `rows` arrives newest-first, so filtering preserves that order.
+  const unreleased = rows.filter((r) => !r.since);
+  const group = unreleased.length
+    ? unreleased
+    : rows.filter((r) => releaseSeries(r.since) === series);
+  const titles = group
+    .map((r) => stripTypePrefix(r.title ?? ''))
+    .filter((t) => t.length > 0);
+  if (titles.length === 0) return null;
+
+  const kind = group.some((r) => r.kind === 'new') ? 'New' : 'Updated';
+  return {
+    label: unreleased.length ? 'Unreleased' : `${kind} in ${series}`,
+    shown: titles.slice(0, MAX_RECENT_SHOWN),
+    more: Math.max(0, titles.length - MAX_RECENT_SHOWN)
+  };
+}
+
+/**
  * Join the raw docs with the ledger into displayable features. Each feature's
  * non-skip rows become its `events` (most recent first, by date then PR); the
  * most recent row also drives `since`/`latestKind`. `skip` rows and rows for
@@ -175,6 +251,7 @@ export function compileCorpus(
   const docs = payload?.docs ?? [];
   const ledger = payload?.ledger ?? [];
 
+  const series = currentReleaseSeries(ledger);
   const rowsByFeature = new Map<string, FeatureLedgerRow[]>();
   for (const row of ledger) {
     if (!row || row.kind === 'skip' || !row.feature) continue;
@@ -209,6 +286,7 @@ export function compileCorpus(
         date: r.date ?? null,
         title: stripTypePrefix(r.title ?? '')
       })),
+      recentChanges: buildRecentChanges(rows, series),
       images
     };
   });

--- a/src/app/modules/features/whats-new.spec.ts
+++ b/src/app/modules/features/whats-new.spec.ts
@@ -16,6 +16,7 @@ function feature(id: string, prs: number[]): CompiledFeature {
     since: null,
     latestKind: 'new',
     events: prs.map((pr) => ({ pr, date: null, title: `change ${pr}` })),
+    recentChanges: null,
     images: []
   };
 }


### PR DESCRIPTION
A feature's changes were only visible in the History table at the very bottom of
the details pane, below the whole instruction body — so anyone skimming "what's
new" had to read past the instructions to reach it, and most never scrolled that
far. Moving the History table up would only invert the problem.

Instead the details pane now carries a short generated strip between the meta
chips and the body: the feature's changes in the **current release series**,
titles only, capped at three with a `+N more` affordance that scrolls to the full
history. The History table is untouched.

The strip is computed from the ledger rows already in `features/changelog.json`,
so nothing is written into any `features/*.md`, it cannot drift from the history
table, and it ages out on its own — once 3.2 ships, the 3.1 strip stops rendering
with no action taken. This replaces the hand-written `## New in 3.1` section in
`route-planning.md`, which would have rotted for exactly that reason.

**Scoped by `major.minor`, not the exact `since`.** "New in 3.1" has to mean
everything after 3.0 for the whole life of 3.1. Matching the newest release
exactly would break on a patch: one enhancement stamped `v3.1.1` becomes the
newest release and every 3.1.0 strip disappears mid-series. There's a regression
test for that case.

**Unreleased rows form their own group**, labelled `Unreleased`, rather than
joining the current series. Folding them in would announce not-yet-shipped work
under the shipped release's name — against the real ledger today that would print
"New in 3.0" over five changes headed for 3.1. Released builds never carry
unstamped rows, so this branch only affects dev and beta builds, where it keeps
the strip from being blank.

Verified in the running app (light and dark) against the real corpus.

Closes #603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “What’s New” strip in the feature details pane, shown when recent updates exist.
  - Displays a capped list (up to three) of recent change titles, labeled by release context (including “Unreleased” when applicable).
  - Includes a “+N more” control that smoothly jumps to the full PR history.

- **Documentation**
  - Removed the outdated “New in 3.1” route-planning bullet list (route-instruction narrative remains).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->