### PR TITLE
feat(plotterext): emit map.view when the chart viewport changes

### DIFF
--- a/docs/freeboard/freeboard-plotter-ext-support.md
+++ b/docs/freeboard/freeboard-plotter-ext-support.md
@@ -245,6 +245,37 @@ neither field present), `nightMode.notSupported`.
 | `src/app/modules/plotterext/plotterext.service.ts` | binds the handlers (`readNightMode`/`applyNightMode`) and emits `nightMode.changed` (`emitNightModeChange`) |
 | `src/app/modules/skstream/skstream.facade.ts` | `selfNightMode` signal + `refreshSelfNightMode()` |
 
+## The `map` capability
+
+`map` exposes the chart viewport: `map.getView` reads it, `map.center` /
+`map.fitBounds` drive it, and `map.view` follows it.
+
+Moves are routed through Freeboard's own centering path
+(`AppFacade.mapMoveRequest` → `AppComponent` effect → `centerAndZoom`), never by
+reaching into the OpenLayers view directly — driving the OL view bypasses the
+`mapCenter`/`mapZoom` signal flow, so chart and resource layers would not refresh
+after the move.
+
+### Events (`map.view`)
+
+`map.view` (`{ center, zoom, bounds }`) is emitted for **every** settled viewport
+change regardless of origin — the user panning/zooming, Freeboard recentring on
+the vessel, or an extension's own `map.center` / `map.fitBounds`. The seam is
+`fb-map.component.ts`'s `onMapMoveEnd`, the OpenLayers `moveend` handler, which
+writes `config.map.center`, `config.map.zoomLevel` and the `mapExtent` signal; a
+reactive `effect` on `mapExtent` therefore fires once per settled move rather than
+per frame. `mapView()` builds the payload so the event and `map.getView` provably
+share one shape, and `emitMapViewChange` de-dupes — OL hands over a fresh extent
+array on every `moveend`, so an unchanged view still re-assigns the signal and the
+comparison must be by value.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `src/app/modules/plotterext/plotterext.service.ts` | the `map.*` handlers, `mapView()`, and `map.view` emission (`emitMapViewChange`) |
+| `src/app/modules/map/fb-map.component.ts` | `onMapMoveEnd` — the OL `moveend` seam that updates the view state |
+
 ## Extending the host API? Update the agent bridge
 
 When you add or change a host API method here, also add or update the matching

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "google-protobuf": "^4.0.1",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
-        "signalk-plotterext-bus": "^0.10.0",
+        "signalk-plotterext-bus": "^0.11.0",
         "tslib": "^2.0.0",
         "unified": "^11.0.5",
         "uuid": "^14.0.1"
@@ -10973,9 +10973,9 @@
       }
     },
     "node_modules/signalk-plotterext-bus": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.10.0.tgz",
-      "integrity": "sha512-KhUICGdTRJVQcRFR62phxUfUg2qeQpUg9HdcNqLmiSjVF1QKakYWcxwjYGPuHZileovnJV9h0+e4VxUzCklGDg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/signalk-plotterext-bus/-/signalk-plotterext-bus-0.11.0.tgz",
+      "integrity": "sha512-a9cc9Wa3tJ9HIquN11wzE0/ifzArmpIQHKT1AKWoQjIbl6bDxMvAz04NxJY+oQeuRwdqk74twNu843mA1z4X/A==",
       "license": "MIT"
     },
     "node_modules/sigstore": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "google-protobuf": "^4.0.1",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
-    "signalk-plotterext-bus": "^0.10.0",
+    "signalk-plotterext-bus": "^0.11.0",
     "tslib": "^2.0.0",
     "unified": "^11.0.5",
     "uuid": "^14.0.1"

--- a/src/app/modules/plotterext/map-view-event.spec.ts
+++ b/src/app/modules/plotterext/map-view-event.spec.ts
@@ -135,7 +135,10 @@ describe('PlotterExtensionService map.view event', () => {
 
   it('publishes for a zoom-only change', () => {
     moveEnd([-80.0, 25.5], 12, [-80.5, 25.0, -79.5, 26.0]);
-    moveEnd([-80.0, 25.5], 13, [-80.25, 25.25, -79.75, 25.75]);
+    // Centre and bounds are deliberately held identical — a real zoom would move
+    // the bounds too, but pinning them proves zoom alone is event-worthy rather
+    // than the bounds comparison carrying the test.
+    moveEnd([-80.0, 25.5], 13, [-80.5, 25.0, -79.5, 26.0]);
     const views = published.filter((p) => p.event === 'map.view');
     expect(views).toHaveLength(2);
     expect(views[1].params).toMatchObject({ zoom: 13 });

--- a/src/app/modules/plotterext/map-view-event.spec.ts
+++ b/src/app/modules/plotterext/map-view-event.spec.ts
@@ -1,0 +1,143 @@
+import { TestBed } from '@angular/core/testing';
+import { signal, WritableSignal } from '@angular/core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MatDialog } from '@angular/material/dialog';
+import { SignalKClient } from 'signalk-client-angular';
+
+import { PlotterExtensionService } from './plotterext.service';
+import { RouteBufferRegistry } from './route-buffer.registry';
+import { AppFacade } from '../../app.facade';
+import { SKResourceService } from '../skresources/resources.service';
+import { MapService } from '../map/ol/lib/map.service';
+import { SKStreamFacade } from '../skstream/skstream.facade';
+
+// The `map` capability's change event: every settled viewport move (an OL
+// moveend, whatever caused it) publishes one `map.view` carrying the same
+// { center, zoom, bounds } shape `map.getView` returns.
+describe('PlotterExtensionService map.view event', () => {
+  let appStub: {
+    config: {
+      display: { nightMode: boolean };
+      map: { center: [number, number]; zoomLevel: number };
+      plotterExtensions: { widgets: [] };
+    };
+    mapExtent: WritableSignal<number[]>;
+    uiCtrl: WritableSignal<{ forceNightMode: boolean }>;
+    uiConfig: WritableSignal<{ autoNightMode: boolean }>;
+    debug: () => void;
+  };
+  let published: Array<{ event: string; params: unknown }>;
+  let service: PlotterExtensionService;
+
+  /** Stand in for the map settling: what fb-map's onMapMoveEnd writes. */
+  const moveEnd = (
+    center: [number, number],
+    zoom: number,
+    bounds: number[]
+  ) => {
+    appStub.config.map.center = center;
+    appStub.config.map.zoomLevel = zoom;
+    appStub.mapExtent.set(bounds);
+    TestBed.tick();
+  };
+
+  const getView = () =>
+    (
+      service as unknown as {
+        mapMethods: () => Record<
+          string,
+          (p: unknown, c: unknown) => Promise<unknown>
+        >;
+      }
+    )
+      .mapMethods()
+      ['map.getView']({}, {});
+
+  beforeEach(() => {
+    published = [];
+    appStub = {
+      config: {
+        display: { nightMode: false },
+        map: { center: [-80.19, 25.77], zoomLevel: 13 },
+        plotterExtensions: { widgets: [] }
+      },
+      mapExtent: signal<number[]>([]),
+      uiCtrl: signal({ forceNightMode: false }),
+      uiConfig: signal({ autoNightMode: false }),
+      debug: () => {}
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        PlotterExtensionService,
+        RouteBufferRegistry,
+        { provide: AppFacade, useValue: appStub },
+        { provide: SignalKClient, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        {
+          provide: SKResourceService,
+          useValue: { routes: signal([]), charts: signal([]) }
+        },
+        { provide: MapService, useValue: {} },
+        {
+          provide: SKStreamFacade,
+          useValue: {
+            selfNightMode: signal(false),
+            refreshSelfNightMode: () => {}
+          }
+        }
+      ]
+    });
+    service = TestBed.inject(PlotterExtensionService);
+    // A live context recording what the host publishes to it, so the real
+    // broadcast path runs rather than a stubbed emitter.
+    (
+      service as unknown as {
+        contexts: Set<{
+          conn: { publish: (event: string, params: unknown) => void };
+        }>;
+      }
+    ).contexts.add({
+      conn: { publish: (event, params) => published.push({ event, params }) }
+    });
+    // Seed the effect with the starting view; the first run emits nothing.
+    TestBed.tick();
+  });
+
+  it('publishes map.view once per settled move', () => {
+    moveEnd([-80.0, 25.5], 12, [-80.5, 25.0, -79.5, 26.0]);
+    const views = published.filter((p) => p.event === 'map.view');
+    expect(views).toHaveLength(1);
+    expect(views[0].params).toEqual({
+      center: [-80.0, 25.5],
+      zoom: 12,
+      bounds: [-80.5, 25.0, -79.5, 26.0]
+    });
+  });
+
+  it('publishes the same shape map.getView returns', async () => {
+    moveEnd([-64.75, 32.3], 9, [-65.5, 31.8, -64.0, 32.8]);
+    const view = published.filter((p) => p.event === 'map.view').at(-1)?.params;
+    expect(view).toEqual(await getView());
+  });
+
+  it('does not publish on the initial view before the map has moved', () => {
+    expect(published.filter((p) => p.event === 'map.view')).toHaveLength(0);
+  });
+
+  it('does not publish when a moveend leaves the view where it was', () => {
+    moveEnd([-80.0, 25.5], 12, [-80.5, 25.0, -79.5, 26.0]);
+    // OL hands us a fresh extent array on every moveend, so an unchanged view
+    // still re-assigns the signal — the event must compare values, not refs.
+    moveEnd([-80.0, 25.5], 12, [-80.5, 25.0, -79.5, 26.0]);
+    expect(published.filter((p) => p.event === 'map.view')).toHaveLength(1);
+  });
+
+  it('publishes for a zoom-only change', () => {
+    moveEnd([-80.0, 25.5], 12, [-80.5, 25.0, -79.5, 26.0]);
+    moveEnd([-80.0, 25.5], 13, [-80.25, 25.25, -79.75, 25.75]);
+    const views = published.filter((p) => p.event === 'map.view');
+    expect(views).toHaveLength(2);
+    expect(views[1].params).toMatchObject({ zoom: 13 });
+  });
+});

--- a/src/app/modules/plotterext/plotterext.embedding-host.spec.ts
+++ b/src/app/modules/plotterext/plotterext.embedding-host.spec.ts
@@ -35,11 +35,14 @@ describe('PlotterExtensionService embedding host (reverse embedding, #507)', () 
           useValue: {
             // Deep enough for the constructor effects (which an async test
             // flushes, unlike a synchronous spec): readNightMode() reads
-            // uiCtrl() and config.display.nightMode.
+            // uiCtrl() and config.display.nightMode; mapView() reads
+            // config.map and mapExtent().
             config: {
               plotterExtensions: { widgets: [] },
-              display: { nightMode: false }
+              display: { nightMode: false },
+              map: { center: [0, 0], zoomLevel: 10 }
             },
+            mapExtent: signal([]),
             debug: () => {},
             isTopWindow: () => false,
             uiCtrl: signal({ forceNightMode: false })

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -32,6 +32,7 @@ import { FBCharts, FBNotes, LineString, Position } from 'src/app/types';
 import {
   type BusPort,
   HostConnection,
+  type MapView,
   MethodHandler,
   type NightModeState,
   RoutePoint,
@@ -602,6 +603,11 @@ export class PlotterExtensionService {
     // Auto-only changes that don't move the resolved state are emitted directly
     // by applyNightMode; emitNightModeChange dedups so each real change fires once.
     effect(() => this.emitNightModeChange(this.readNightMode()));
+    // Emit `map.view` whenever the chart viewport settles, whether the user
+    // panned/zoomed, the host recentred, or an extension called map.center /
+    // map.fitBounds (origin-transparent). mapExtent is written once per OL
+    // moveend, so the effect fires per settled change, not per frame.
+    effect(() => this.emitMapViewChange(this.mapView()));
   }
 
   /**
@@ -1987,15 +1993,50 @@ export class PlotterExtensionService {
   // directly bypasses Freeboard's mapCenter/mapZoom signal flow, so chart
   // and resource layers do not refresh after the move.
 
+  /**
+   * The current chart viewport — the single shape shared by `map.getView` and
+   * the `map.view` event, so a following extension seeds and updates from
+   * identical data. Reads mapExtent() reactively; the effect that emits
+   * `map.view` depends on it.
+   */
+  private mapView(): MapView {
+    return {
+      center: this.app.config.map.center as [number, number],
+      zoom: this.app.config.map.zoomLevel,
+      bounds: this.app.mapExtent() as [number, number, number, number]
+    };
+  }
+
+  /** Last viewport broadcast, for de-duping `map.view`. */
+  private prevMapView: MapView | null = null;
+
+  /**
+   * Broadcast `map.view` when the viewport actually moved. Seeds silently on the
+   * first run (matching the chart/night-mode event pattern). mapExtent is
+   * re-assigned on every OL moveend even when the view came back to where it
+   * started, so compare values rather than trusting the signal to have changed.
+   */
+  private emitMapViewChange(view: MapView): void {
+    const prev = this.prevMapView;
+    this.prevMapView = view;
+    if (prev === null) {
+      return;
+    }
+    const same =
+      prev.zoom === view.zoom &&
+      prev.center[0] === view.center[0] &&
+      prev.center[1] === view.center[1] &&
+      prev.bounds.length === view.bounds.length &&
+      prev.bounds.every((v, i) => v === view.bounds[i]);
+    if (same) {
+      return;
+    }
+    this.broadcastMessage('map.view', view);
+  }
+
   private mapMethods(): Record<string, MethodHandler> {
     return {
-      'map.getView': async () => {
-        return {
-          center: this.app.config.map.center,
-          zoom: this.app.config.map.zoomLevel,
-          bounds: this.app.mapExtent()
-        };
-      },
+      'map.getView': async () => this.mapView(),
       'map.center': async (params) => {
         const { position, zoom } = (params ?? {}) as {
           position?: [number, number];


### PR DESCRIPTION
Implements the `map.view` host event in the reference host, per the contract
merged in #606.

An extension whose work depends on what the user is looking at — search-in-view,
area downloads, an overlay that refetches for the visible box — previously had no
way to learn the viewport moved and had to poll `map.getView`.

`onMapMoveEnd` (the OpenLayers `moveend` handler) already writes all three view
values, so a reactive `effect` on `mapExtent` gives one emission per *settled*
pan/zoom rather than per frame, and it is origin-transparent for free: OL fires
`moveend` for the user dragging, for Freeboard recentring on the vessel, and for
an extension's own `map.center` / `map.fitBounds`.

Two details worth a reviewer's eye:

- `map.getView` and the event now build their payload from one `mapView()`
  helper, so the method and the event cannot drift apart — the spec requires them
  to carry the same shape.
- `emitMapViewChange` compares by **value**. OL hands over a fresh extent array
  on every `moveend`, so the signal is re-assigned even when the view came back to
  where it started; a reference check would emit spurious events.

`plotterext.embedding-host.spec.ts` needed a deeper `AppFacade` stub: its async
tests flush the constructor effects, and the new one reads `config.map`. That is
the trap already documented in `DEV-LESSONS-LEARNED.md` under *When testing*.

Requires `signalk-plotterext-bus` ^0.11.0 (published), which adds the `MapView`
type this imports.

Closes #565


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plotter Extensions can now access the chart viewport and request map movements.
  * Added `map.view` events containing the current center, zoom, and bounds after the view settles.
  * Repeated events are suppressed when the viewport has not changed.

* **Documentation**
  * Documented viewport access, movement requests, and map view event behavior for extensions.

* **Tests**
  * Added coverage for viewport events, unchanged views, and zoom-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->