### PR TITLE
fix(routes): report the leg ending at the dragged vertex when modifying a route

### DIFF
--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -131,6 +131,7 @@ import {
   RoutePointMeta,
   WORLD_WIDTH_3857
 } from './route-extend';
+import { modifiedLegIndex } from './route-modify-leg';
 import { AppIconDef } from '../icons';
 import { LayerWindWeatherComponent } from './ol/lib/resources/layer-wind-weather.component';
 import { LayerCurrentsWeatherComponent } from './ol/lib/resources/layer-currents-weather.component';
@@ -1065,6 +1066,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
     if (!f) {
       return;
     }
+    // Capture the geometry before it is replaced: diffed against the restored
+    // coordinates it tells the Leg read-out which vertex the undo puts back
+    // (#581).
+    const undone = f.getGeometry().getCoordinates() as Position[];
     // setCoordinates fires the feature's 'change' event; the active OL Modify
     // interaction listens for it (handleFeatureChange_) and rebuilds its
     // segment/vertex index whenever the geometry changes outside its own drag
@@ -1083,6 +1088,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
     const pc = this.transformCoordsArray(snap.coordinates) as LineString;
     this.mapInteract.draw.forSave['coords'] = pc;
     this.mapInteract.measurementCoords = pc;
+    this.mapInteract.measurementIndex = modifiedLegIndex(
+      undone,
+      snap.coordinates
+    );
   }
 
   /** Handle OL interaction end event */
@@ -1261,6 +1270,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
     if (fid.split('.')[0] === 'route') {
       pc = this.transformCoordsArray(c);
       this.mapInteract.measurementCoords = pc;
+      // Report the leg ending at the vertex just moved rather than whatever the
+      // last leg happens to be (#581). draw.coordinates still holds the geometry
+      // as it was at modifystart, so it is the pre-operation side of the diff.
+      this.mapInteract.measurementIndex = modifiedLegIndex(
+        this.mapInteract.draw.coordinates as Position[],
+        c as Position[]
+      );
     } else if (fid.split('.')[0] === 'region') {
       for (let e = 0; e < c.length; e++) {
         if (this.isCoordsArray(c[e])) {
@@ -1364,6 +1380,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
     const pc = this.transformCoordsArray(result.after);
     this.mapInteract.draw.forSave['coords'] = pc;
     this.mapInteract.measurementCoords = pc as LineString;
+    this.mapInteract.measurementIndex = modifiedLegIndex(
+      result.undo.coordinates,
+      result.after
+    );
 
     this.app.data.activeRouteIsEditing =
       !!this.app.data.activeRoute &&

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -183,7 +183,7 @@ export class FBMapInteractService {
     });
   }
 
-  /** set the leg to report in measurement data (-1 = the last leg) */
+  /** -1 reports the last leg, otherwise the leg starting at that index */
   set measurementIndex(value: number) {
     this.measurement.update((current) => {
       return Object.assign({}, current, { index: value });

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -183,6 +183,13 @@ export class FBMapInteractService {
     });
   }
 
+  /** set the leg to report in measurement data (-1 = the last leg) */
+  set measurementIndex(value: number) {
+    this.measurement.update((current) => {
+      return Object.assign({}, current, { index: value });
+    });
+  }
+
   /** set center position in measurment data */
   set measurementCenter(value: Position) {
     this.measurement.update((current) => {

--- a/src/app/modules/map/route-modify-leg.spec.ts
+++ b/src/app/modules/map/route-modify-leg.spec.ts
@@ -17,7 +17,7 @@ const moveVertex = (at: number, to: Position): Position[] =>
 describe('modifiedLegIndex', () => {
   it('reports the leg ENDING at the dragged vertex, not the last leg (#581)', () => {
     // Dragging the middle point (index 2) describes the leg from point 1 to
-    // point 2 — leg index 1. Before the fix the read-out stayed on leg 3.
+    // point 2 — leg index 1.
     expect(modifiedLegIndex(route, moveVertex(2, [20, 15]))).toBe(1);
   });
 

--- a/src/app/modules/map/route-modify-leg.spec.ts
+++ b/src/app/modules/map/route-modify-leg.spec.ts
@@ -1,0 +1,81 @@
+import { expect, describe, it } from 'vitest';
+import { Position } from 'src/app/types';
+import { modifiedLegIndex } from './route-modify-leg';
+
+/** A five-point route: legs 0..3 join points 0-1, 1-2, 2-3, 3-4. */
+const route: Position[] = [
+  [0, 0],
+  [10, 0],
+  [20, 0],
+  [30, 0],
+  [40, 0]
+];
+
+const moveVertex = (at: number, to: Position): Position[] =>
+  route.map((p, i) => (i === at ? to : p));
+
+describe('modifiedLegIndex', () => {
+  it('reports the leg ENDING at the dragged vertex, not the last leg (#581)', () => {
+    // Dragging the middle point (index 2) describes the leg from point 1 to
+    // point 2 — leg index 1. Before the fix the read-out stayed on leg 3.
+    expect(modifiedLegIndex(route, moveVertex(2, [20, 15]))).toBe(1);
+  });
+
+  it('reports the preceding leg for every interior vertex', () => {
+    expect(modifiedLegIndex(route, moveVertex(1, [10, 15]))).toBe(0);
+    expect(modifiedLegIndex(route, moveVertex(3, [30, 15]))).toBe(2);
+  });
+
+  it('reports the final leg when the END point is dragged', () => {
+    expect(modifiedLegIndex(route, moveVertex(4, [40, 15]))).toBe(3);
+  });
+
+  it('reports the leg leaving the first point when it is dragged', () => {
+    // Point 0 has no preceding leg, so describe the one it starts.
+    expect(modifiedLegIndex(route, moveVertex(0, [0, 15]))).toBe(0);
+  });
+
+  it('detects a move by latitude alone', () => {
+    expect(modifiedLegIndex(route, moveVertex(2, [20, 0.5]))).toBe(1);
+  });
+
+  it('reports the leg into a newly inserted vertex', () => {
+    const after = [...route];
+    after.splice(2, 0, [15, 5]);
+    expect(modifiedLegIndex(route, after)).toBe(1);
+  });
+
+  it('reports the newly joined leg when a vertex is deleted', () => {
+    // Removing point 2 joins point 1 to point 3 — that merged leg is index 1.
+    const after = route.filter((_, i) => i !== 2);
+    expect(modifiedLegIndex(route, after)).toBe(1);
+  });
+
+  it('reports the new final leg when a point is appended (route extend)', () => {
+    const after: Position[] = [...route, [50, 0]];
+    expect(modifiedLegIndex(route, after)).toBe(4);
+  });
+
+  it('reports the final leg when the end point is deleted', () => {
+    const after = route.slice(0, -1);
+    expect(modifiedLegIndex(route, after)).toBe(2);
+  });
+
+  it('falls back to the default when nothing moved', () => {
+    expect(modifiedLegIndex(route, [...route])).toBe(-1);
+  });
+
+  it('falls back to the default when there is no leg to describe', () => {
+    expect(modifiedLegIndex([[0, 0]], [[5, 5]])).toBe(-1);
+    expect(modifiedLegIndex([], [])).toBe(-1);
+  });
+
+  it('never returns an index past the last leg', () => {
+    const two: Position[] = [
+      [0, 0],
+      [10, 0]
+    ];
+    // Dragging the end point of a two-point route still describes leg 0.
+    expect(modifiedLegIndex(two, [two[0], [10, 5]])).toBe(0);
+  });
+});

--- a/src/app/modules/map/route-modify-leg.ts
+++ b/src/app/modules/map/route-modify-leg.ts
@@ -18,7 +18,7 @@ export function modifiedLegIndex(
   before: Position[],
   after: Position[]
 ): number {
-  if (!Array.isArray(after) || after.length < 2 || !Array.isArray(before)) {
+  if (after.length < 2) {
     return -1;
   }
   const lastLeg = after.length - 2;

--- a/src/app/modules/map/route-modify-leg.ts
+++ b/src/app/modules/map/route-modify-leg.ts
@@ -1,0 +1,34 @@
+import { Position } from 'src/app/types';
+
+/**
+ * The leg the "Leg" read-out should describe after a Modify operation: the
+ * segment *ending* at the vertex just touched, i.e. from the previous point to
+ * the one the user dragged (issue #581). Measurement legs are numbered by their
+ * start vertex, so that leg is `touched - 1`; the first point has no preceding
+ * leg, so dragging it reports the leg leaving it instead.
+ *
+ * `before` and `after` are the geometry either side of a single operation, in
+ * render space. The first index at which they differ identifies the vertex
+ * touched — for a move the vertex itself, for an insert the new vertex, and for
+ * a delete the vertex that closed the gap, so a deletion reports the newly
+ * joined leg. Returns -1 (the component's "last leg" default) when nothing
+ * changed or there is no leg to describe.
+ */
+export function modifiedLegIndex(
+  before: Position[],
+  after: Position[]
+): number {
+  if (!Array.isArray(after) || after.length < 2 || !Array.isArray(before)) {
+    return -1;
+  }
+  const lastLeg = after.length - 2;
+  const shared = Math.min(before.length, after.length);
+  for (let i = 0; i < shared; i++) {
+    if (before[i][0] !== after[i][0] || before[i][1] !== after[i][1]) {
+      return Math.min(Math.max(i - 1, 0), lastLeg);
+    }
+  }
+  // The shared prefix is identical, so the operation only touched the tail
+  // (appending or removing an end point) — or nothing moved at all.
+  return before.length === after.length ? -1 : lastLeg;
+}


### PR DESCRIPTION
The **Leg** read-out shown while modifying a route always described the *last* segment, whatever the user was actually dragging. `measurement().index` was set to `-1` when the interaction started and never updated, and `-1` means "last leg" — so moving a middle vertex left the read-out unchanged and it appeared to work only when the end point moved.

A Modify operation already gives both sides of the geometry, so the touched vertex is just the first index at which they differ — for a move the vertex itself, for an insert the new vertex, and for a delete the vertex that closed the gap. The read-out reports the leg *ending* at that vertex, i.e. from the previous point to the one dragged; the first point has no preceding leg, so dragging it reports the leg leaving it.

That decision is a pure function (`route-modify-leg.ts`) called from the three paths that update measurement coords during a route modify — a vertex move/insert/delete, an undo, and a route extend — so undo and extend keep the read-out in step rather than leaving a stale index behind.

Surfaced by #545, which makes the read-out prominent.

Closes #581

### Test plan

- [x] `npm run test:ci` — 404 passing, incl. 12 new cases covering move / insert / delete / append / first-point / end-point / no-op
- [x] Red→green verified: with the helper stubbed to the old `-1` behaviour, 10 of the 12 new cases fail
- [x] `npm run build:all` clean
- [x] Manually exercised against a local Signal K server: drag middle / first / end vertex, insert, delete, undo, extend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved measurement leg selection when route vertices are moved, undone, inserted, deleted, or extended.
  * Corrected the displayed leg and vertex readout for edits at the start, middle, and end of a route.
  * Added safeguards to keep selected leg indexes within valid route bounds.

* **Tests**
  * Added coverage for route editing scenarios, including vertex movement, insertion, deletion, extension, and unchanged routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->