### PR TITLE
fix(routes): don't append an end point on the click that deletes a vertex

### DIFF
--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -129,8 +129,10 @@ import { LineString as OLLineString } from 'ol/geom';
 import {
   extendRouteAtClick,
   RoutePointMeta,
+  shouldExtendRoute,
   WORLD_WIDTH_3857
 } from './route-extend';
+import { vertexDeleted } from './ol/lib/vertex-delete';
 import { modifiedLegIndex } from './route-modify-leg';
 import { AppIconDef } from '../icons';
 import { LayerWindWeatherComponent } from './ol/lib/resources/layer-wind-weather.component';
@@ -1321,8 +1323,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
    * the new end point (issue #549) — so a route can be lengthened the same way
    * it is drawn, without leaving modify mode. A click *on* the route belongs to
    * OL Modify (move / insert / delete a vertex), so only clicks that miss it
-   * extend the route; the state kept in sync here mirrors applyModifyEnd so
-   * Undo, Finish and Cancel all see the new point.
+   * extend the route — and never the click that completes a vertex delete
+   * (#608); the state kept in sync here mirrors applyModifyEnd so Undo, Finish
+   * and Cancel all see the new point.
    */
   private extendRouteInModify(e: FBClickEvent) {
     const f = this.mapInteract.draw.features?.getArray()[0] as Feature;
@@ -1341,7 +1344,14 @@ export class FBMapComponent implements OnInit, OnDestroy {
       .getMap()
       .getFeaturesAtPixel(e.pixel, { hitTolerance: tol })
       .some((ft) => ft.getId() === f.getId());
-    if (onRoute) {
+    // A delete has already moved the line away from the clicked pixel, so the
+    // hit-test above cannot recognise the release that completed it (#608).
+    if (
+      !shouldExtendRoute({
+        onRoute,
+        vertexDeleted: vertexDeleted(this.olMap.getMap())
+      })
+    ) {
       return;
     }
     // Metadata may not be seeded yet if this is the first op of the session (no

--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.spec.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.spec.ts
@@ -1,5 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { vertexDeleteCondition } from './interaction-modify.component';
+import { vertexDeleted } from '../vertex-delete';
 
 // Minimal stand-in for the OL map: only get/set of the delete-on-release flag
 // are read by the condition.
@@ -51,5 +52,25 @@ describe('vertexDeleteCondition', () => {
     expect(
       vertexDeleteCondition(ev('pointerup', { map: fakeMap(false) }))
     ).toBe(false);
+  });
+
+  // #608: the release that deletes also produces a click, which the route
+  // extend handler would read as open water once the line has snapped away.
+  it('flags vertexDeletedInGesture when a tap-hold release deletes', () => {
+    const map = fakeMap(true);
+    vertexDeleteCondition(ev('pointerup', { map }));
+    expect(vertexDeleted(map)).toBe(true);
+  });
+
+  it('flags vertexDeletedInGesture when Ctrl-Click deletes', () => {
+    const map = fakeMap();
+    vertexDeleteCondition(ev('click', { ctrlKey: true, map }));
+    expect(vertexDeleted(map)).toBe(true);
+  });
+
+  it('leaves vertexDeletedInGesture unset when nothing is deleted', () => {
+    const map = fakeMap(false);
+    vertexDeleteCondition(ev('click', { map }));
+    expect(vertexDeleted(map)).toBe(false);
   });
 });

--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
@@ -11,6 +11,7 @@ import { Geometry } from 'ol/geom';
 import { Modify } from 'ol/interaction';
 import { ModifyEvent } from 'ol/interaction/Modify';
 import { MapComponent } from '../map.component';
+import { markVertexDeleted } from '../vertex-delete';
 
 /**
  * Decides whether a map event should delete the grabbed route vertex.
@@ -27,6 +28,9 @@ import { MapComponent } from '../map.component';
  * never re-snaps the grabbed vertex (its pointerdown is not a primary action), so
  * it would delete whatever vertex was last touched rather than the one clicked
  * (#575); and Freeboard already uses right-click for the map context menu.
+ *
+ * Either gesture flags `VERTEX_DELETED_IN_GESTURE` so the click the same release
+ * produces is not also read as a route extension (#608).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const vertexDeleteCondition = (e: MapBrowserEvent<any>): boolean => {
@@ -37,10 +41,15 @@ export const vertexDeleteCondition = (e: MapBrowserEvent<any>): boolean => {
     e.map.get('vertexDeleteOnRelease')
   ) {
     e.map.set('vertexDeleteOnRelease', false);
+    markVertexDeleted(e.map);
     return true;
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return e.type === 'click' && (e.originalEvent as any).ctrlKey;
+  if (e.type === 'click' && (e.originalEvent as any).ctrlKey) {
+    markVertexDeleted(e.map);
+    return true;
+  }
+  return false;
 };
 
 @Component({

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -26,7 +26,7 @@ import { Coordinate } from 'ol/coordinate';
 import { FeatureLike } from 'ol/Feature';
 import { Extent, getWidth } from 'ol/extent';
 import { hitToleranceForPointer, worldCopyOffset } from './util';
-import { tryDeleteHeldVertexOnHold } from './vertex-delete';
+import { clearVertexDeleted, tryDeleteHeldVertexOnHold } from './vertex-delete';
 
 export interface FBMapEvent extends MapEvent {
   lonlat: Coordinate;
@@ -366,9 +366,15 @@ export class MapComponent implements OnInit, OnDestroy {
     this.ngZone.run(() =>
       this.mapSingleClick.emit(this.augmentClickEvent(event))
     );
+    // Consumers have now seen this click, so a vertex delete it completed is
+    // spent and must not suppress the next one (#608).
+    clearVertexDeleted(this.map);
   };
   private emitDblClickEvent = (event: MapBrowserEvent<PointerEvent>) => {
     this.ngZone.run(() => this.mapDblClick.emit(this.augmentClickEvent(event)));
+    // A double click cancels the pending singleclick, so retire the marker here
+    // instead (#608).
+    clearVertexDeleted(this.map);
   };
 
   // Render-space offset (EPSG:3857 metres) of the world copy a click landed in,
@@ -426,6 +432,9 @@ export class MapComponent implements OnInit, OnDestroy {
     // Only a real move (beyond tolerance) cancels the hold / pending delete —
     // a real drag means "move the vertex", a jitter does not.
     this.clearTimerIfMoved(event);
+    // A gesture that has dragged emits no click at all, so no click is left to
+    // suppress and the marker would otherwise go stale (#608).
+    clearVertexDeleted(this.map);
     this.mapPointerDrag.emit(this.augmentPointerEvent(event));
   };
   private emitPointerMoveEvent = (event: MapBrowserEvent<PointerEvent>) => {

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -26,7 +26,12 @@ import { Coordinate } from 'ol/coordinate';
 import { FeatureLike } from 'ol/Feature';
 import { Extent, getWidth } from 'ol/extent';
 import { hitToleranceForPointer, worldCopyOffset } from './util';
-import { clearVertexDeleted, tryDeleteHeldVertexOnHold } from './vertex-delete';
+import {
+  clearVertexDeleted,
+  clearVertexDeletedOnDrag,
+  startPointerGesture,
+  tryDeleteHeldVertexOnHold
+} from './vertex-delete';
 
 export interface FBMapEvent extends MapEvent {
   lonlat: Coordinate;
@@ -308,6 +313,7 @@ export class MapComponent implements OnInit, OnDestroy {
     this.ngZone.run(() => {
       this.evCache[event.pointerId] = event;
       this.map.set('vertexDeleteOnRelease', false);
+      startPointerGesture(this.map);
       this.touchStartXY = { x: event.clientX, y: event.clientY };
       // A vertex delete during Modify needs a deliberate long hold (1500 ms) so a
       // pause mid-edit doesn't delete a point; the chart context-menu long-press
@@ -432,9 +438,10 @@ export class MapComponent implements OnInit, OnDestroy {
     // Only a real move (beyond tolerance) cancels the hold / pending delete —
     // a real drag means "move the vertex", a jitter does not.
     this.clearTimerIfMoved(event);
-    // A gesture that has dragged emits no click at all, so no click is left to
-    // suppress and the marker would otherwise go stale (#608).
-    clearVertexDeleted(this.map);
+    // A gesture that has dragged emits no click at all, so its own delete
+    // marker has nothing left to consume it. Only this gesture's marker —
+    // a later drag must not retire one whose click is still pending (#608).
+    clearVertexDeletedOnDrag(this.map);
     this.mapPointerDrag.emit(this.augmentPointerEvent(event));
   };
   private emitPointerMoveEvent = (event: MapBrowserEvent<PointerEvent>) => {

--- a/src/app/modules/map/ol/lib/vertex-delete.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.spec.ts
@@ -4,7 +4,9 @@ import { Collection } from 'ol';
 import { Modify } from 'ol/interaction';
 import {
   clearVertexDeleted,
+  clearVertexDeletedOnDrag,
   markVertexDeleted,
+  startPointerGesture,
   tryDeleteHeldVertexOnHold,
   vertexDeleted
 } from './vertex-delete';
@@ -78,8 +80,8 @@ describe('tryDeleteHeldVertexOnHold', () => {
 
 // OpenLayers delays `singleclick` by 250 ms, so the click completing a delete
 // can arrive after the user has pressed down again. The marker is therefore
-// retired only by an explicit clear at the points where a click resolves —
-// never as a side effect of a new gesture starting (#608).
+// retired only where that click resolves — never as a side effect of a new
+// gesture starting (#608).
 describe('vertexDeleted marker', () => {
   it('reads false on a map that has never deleted a vertex', () => {
     expect(vertexDeleted(fakeMap([]))).toBe(false);
@@ -87,10 +89,16 @@ describe('vertexDeleted marker', () => {
 
   it('stays set until explicitly cleared, outliving the gesture that set it', () => {
     const map = fakeMap([]);
+    startPointerGesture(map);
     markVertexDeleted(map);
     expect(vertexDeleted(map)).toBe(true);
 
-    clearVertexDeleted(map);
+    // A fast follow-up press begins a new gesture while the delete's click is
+    // still pending — the marker must survive it.
+    startPointerGesture(map);
+    expect(vertexDeleted(map)).toBe(true);
+
+    clearVertexDeleted(map); // the pending singleclick finally lands
     expect(vertexDeleted(map)).toBe(false);
   });
 
@@ -98,7 +106,30 @@ describe('vertexDeleted marker', () => {
     // The delete lands mid-hold, so the release still produces a click — the
     // marker must survive the whole gesture for that click to be suppressed.
     const map = fakeMap([activeModify(true)]);
+    startPointerGesture(map);
     tryDeleteHeldVertexOnHold(map as Map, src('mouse'));
+    expect(vertexDeleted(map)).toBe(true);
+  });
+
+  it('is retired when the deleting gesture itself drags (no click will come)', () => {
+    const map = fakeMap([]);
+    startPointerGesture(map);
+    markVertexDeleted(map);
+
+    clearVertexDeletedOnDrag(map);
+    expect(vertexDeleted(map)).toBe(false);
+  });
+
+  it('survives a LATER gesture dragging while the delete click is pending', () => {
+    // Delete a vertex, then immediately pan the chart. That drag belongs to a
+    // new gesture; retiring the marker there would let the still-pending
+    // singleclick from the delete append an end point.
+    const map = fakeMap([]);
+    startPointerGesture(map);
+    markVertexDeleted(map);
+
+    startPointerGesture(map); // the pan begins
+    clearVertexDeletedOnDrag(map);
     expect(vertexDeleted(map)).toBe(true);
   });
 });

--- a/src/app/modules/map/ol/lib/vertex-delete.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.spec.ts
@@ -2,7 +2,12 @@ import { expect, describe, it, vi } from 'vitest';
 import { Map } from 'ol';
 import { Collection } from 'ol';
 import { Modify } from 'ol/interaction';
-import { tryDeleteHeldVertexOnHold } from './vertex-delete';
+import {
+  clearVertexDeleted,
+  markVertexDeleted,
+  tryDeleteHeldVertexOnHold,
+  vertexDeleted
+} from './vertex-delete';
 
 // Minimal stand-in for the OL map: only the members the helper touches.
 function fakeMap(interactions: unknown[]) {
@@ -68,5 +73,32 @@ describe('tryDeleteHeldVertexOnHold', () => {
     const map = fakeMap([]);
     expect(tryDeleteHeldVertexOnHold(map as Map, src('mouse'))).toBe(false);
     expect(map.get('vertexDeleteOnRelease')).toBeUndefined();
+  });
+});
+
+// OpenLayers delays `singleclick` by 250 ms, so the click completing a delete
+// can arrive after the user has pressed down again. The marker is therefore
+// retired only by an explicit clear at the points where a click resolves —
+// never as a side effect of a new gesture starting (#608).
+describe('vertexDeleted marker', () => {
+  it('reads false on a map that has never deleted a vertex', () => {
+    expect(vertexDeleted(fakeMap([]))).toBe(false);
+  });
+
+  it('stays set until explicitly cleared, outliving the gesture that set it', () => {
+    const map = fakeMap([]);
+    markVertexDeleted(map);
+    expect(vertexDeleted(map)).toBe(true);
+
+    clearVertexDeleted(map);
+    expect(vertexDeleted(map)).toBe(false);
+  });
+
+  it('is left set by a long-press delete, for the pending click to consume', () => {
+    // The delete lands mid-hold, so the release still produces a click — the
+    // marker must survive the whole gesture for that click to be suppressed.
+    const map = fakeMap([activeModify(true)]);
+    tryDeleteHeldVertexOnHold(map as Map, src('mouse'));
+    expect(vertexDeleted(map)).toBe(true);
   });
 });

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -2,6 +2,44 @@ import { Map } from 'ol';
 import { Modify } from 'ol/interaction';
 
 /**
+ * Map property marking that a vertex delete has been performed and the click it
+ * produces is still outstanding. The release completing a delete also produces a
+ * `singleclick`, which would otherwise be read as a click in open water and
+ * extend the route (#608) — the delete has already moved the line away from the
+ * clicked pixel, so a hit-test alone cannot tell the two apart.
+ *
+ * The marker deliberately outlives the gesture that set it: OpenLayers delays
+ * `singleclick` by 250 ms (`MapBrowserEventHandler`), so a fast follow-up press
+ * begins a new gesture while that click is still pending. It is cleared where
+ * the click resolves instead — see `clearVertexDeleted`.
+ */
+export const VERTEX_DELETED_IN_GESTURE = 'vertexDeletedInGesture';
+
+/** Mark that a vertex delete has been performed (#608). */
+export function markVertexDeleted(map: Pick<Map, 'set'>): void {
+  map.set(VERTEX_DELETED_IN_GESTURE, true);
+}
+
+/**
+ * Whether the click being handled is the tail of a vertex delete, and so must
+ * not also extend the route.
+ */
+export function vertexDeleted(map: Pick<Map, 'get'>): boolean {
+  return !!map.get(VERTEX_DELETED_IN_GESTURE);
+}
+
+/**
+ * Release the marker once the click it belongs to has resolved. OpenLayers
+ * resolves a gesture as exactly one of `singleclick`, `dblclick` (which cancels
+ * the pending `singleclick`) or a drag (a gesture that has dragged emits no
+ * click at all), so clearing at those three points retires the marker without
+ * ever cutting short a click that is still pending.
+ */
+export function clearVertexDeleted(map: Pick<Map, 'set'>): void {
+  map.set(VERTEX_DELETED_IN_GESTURE, false);
+}
+
+/**
  * On a long press during route editing, remove the grabbed vertex.
  *
  * Runs for **any** pointer — a long left-click gives mouse users parity with the
@@ -38,6 +76,7 @@ export function tryDeleteHeldVertexOnHold(map: Map, src: MouseEvent): boolean {
     );
     if (modify.removePoint()) {
       map.set('vertexDeleteOnRelease', false);
+      markVertexDeleted(map);
     }
   } catch {
     // Fall back to delete-on-release via the deleteCondition flag.

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -1,23 +1,38 @@
 import { Map } from 'ol';
 import { Modify } from 'ol/interaction';
 
+/** Map property holding a monotonic id for the pointer gesture in progress. */
+export const POINTER_GESTURE_SEQ = 'pointerGestureSeq';
+
 /**
- * Map property marking that a vertex delete has been performed and the click it
- * produces is still outstanding. The release completing a delete also produces a
- * `singleclick`, which would otherwise be read as a click in open water and
- * extend the route (#608) — the delete has already moved the line away from the
- * clicked pixel, so a hit-test alone cannot tell the two apart.
+ * Map property naming the gesture whose vertex delete is still awaiting its
+ * click, or `null` when none is outstanding. The release completing a delete
+ * also produces a `singleclick`, which would otherwise be read as a click in
+ * open water and extend the route (#608) — the delete has already moved the
+ * line away from the clicked pixel, so a hit-test alone cannot tell the two
+ * apart.
  *
  * The marker deliberately outlives the gesture that set it: OpenLayers delays
  * `singleclick` by 250 ms (`MapBrowserEventHandler`), so a fast follow-up press
- * begins a new gesture while that click is still pending. It is cleared where
- * the click resolves instead — see `clearVertexDeleted`.
+ * begins a new gesture while that click is still pending. It is retired where
+ * the click resolves instead — see `clearVertexDeleted`. It records *which*
+ * gesture deleted rather than a bare flag so a later gesture cannot retire a
+ * marker that is not its own.
  */
 export const VERTEX_DELETED_IN_GESTURE = 'vertexDeletedInGesture';
 
-/** Mark that a vertex delete has been performed (#608). */
-export function markVertexDeleted(map: Pick<Map, 'set'>): void {
-  map.set(VERTEX_DELETED_IN_GESTURE, true);
+/** Open a new pointer gesture, called from the `pointerdown` handler. */
+export function startPointerGesture(map: Pick<Map, 'get' | 'set'>): void {
+  map.set(POINTER_GESTURE_SEQ, gestureSeq(map) + 1);
+}
+
+function gestureSeq(map: Pick<Map, 'get'>): number {
+  return (map.get(POINTER_GESTURE_SEQ) as number) ?? 0;
+}
+
+/** Mark that the current gesture has deleted a vertex (#608). */
+export function markVertexDeleted(map: Pick<Map, 'get' | 'set'>): void {
+  map.set(VERTEX_DELETED_IN_GESTURE, gestureSeq(map));
 }
 
 /**
@@ -25,18 +40,32 @@ export function markVertexDeleted(map: Pick<Map, 'set'>): void {
  * not also extend the route.
  */
 export function vertexDeleted(map: Pick<Map, 'get'>): boolean {
-  return !!map.get(VERTEX_DELETED_IN_GESTURE);
+  return map.get(VERTEX_DELETED_IN_GESTURE) != null;
 }
 
 /**
- * Release the marker once the click it belongs to has resolved. OpenLayers
- * resolves a gesture as exactly one of `singleclick`, `dblclick` (which cancels
- * the pending `singleclick`) or a drag (a gesture that has dragged emits no
- * click at all), so clearing at those three points retires the marker without
- * ever cutting short a click that is still pending.
+ * Retire the marker once the click it belongs to has resolved — at `singleclick`
+ * (after consumers have read it) and at `dblclick` (which cancels the pending
+ * `singleclick`, so no click is coming).
  */
 export function clearVertexDeleted(map: Pick<Map, 'set'>): void {
-  map.set(VERTEX_DELETED_IN_GESTURE, false);
+  map.set(VERTEX_DELETED_IN_GESTURE, null);
+}
+
+/**
+ * Retire the marker when the gesture that set it starts dragging: a gesture that
+ * has dragged emits no click at all, so nothing is left to consume the marker
+ * and it would otherwise go stale.
+ *
+ * Only that gesture's own drag counts. A *later* gesture may begin dragging
+ * while the delete's `singleclick` is still pending (delete a vertex, then
+ * immediately pan the chart), and retiring the marker there would let that
+ * pending click extend the route — the very bug this guards against.
+ */
+export function clearVertexDeletedOnDrag(map: Pick<Map, 'get' | 'set'>): void {
+  if (map.get(VERTEX_DELETED_IN_GESTURE) === gestureSeq(map)) {
+    clearVertexDeleted(map);
+  }
 }
 
 /**

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -1,7 +1,17 @@
 import { Map } from 'ol';
 import { Modify } from 'ol/interaction';
 
-/** Map property holding a monotonic id for the pointer gesture in progress. */
+/**
+ * Map property holding a monotonic id for the pointer gesture in progress.
+ *
+ * Gestures need identity because a delete marker can outlive the gesture that
+ * set it (see `VERTEX_DELETED_IN_GESTURE`): without an id, a *later* gesture's
+ * drag would retire a marker whose click is still pending, and that click would
+ * then extend the route. OpenLayers offers nothing usable here — `down_`, the
+ * clone its click events carry, does not exist yet when a long-press sets the
+ * marker mid-gesture, and it is a fresh `PointerEvent`, so a tag put on the DOM
+ * `pointerdown` never reaches it.
+ */
 export const POINTER_GESTURE_SEQ = 'pointerGestureSeq';
 
 /**

--- a/src/app/modules/map/route-extend.spec.ts
+++ b/src/app/modules/map/route-extend.spec.ts
@@ -3,10 +3,34 @@ import { Position } from 'src/app/types';
 import {
   WORLD_WIDTH_3857,
   extendRouteAtClick,
+  shouldExtendRoute,
   worldAlignedPoint
 } from './route-extend';
 
 const W = WORLD_WIDTH_3857;
+
+describe('shouldExtendRoute', () => {
+  it('extends on a click in open water', () => {
+    expect(shouldExtendRoute({ onRoute: false, vertexDeleted: false })).toBe(
+      true
+    );
+  });
+
+  it('leaves a click on the route to OL Modify', () => {
+    expect(shouldExtendRoute({ onRoute: true, vertexDeleted: false })).toBe(
+      false
+    );
+  });
+
+  it('does NOT extend on the release that deleted a vertex — regression for #608', () => {
+    // The delete moves the line away from the clicked pixel, so the hit-test
+    // reports open water; without the gesture flag the same release both
+    // removed the vertex and appended a new end point there.
+    expect(shouldExtendRoute({ onRoute: false, vertexDeleted: true })).toBe(
+      false
+    );
+  });
+});
 
 describe('worldAlignedPoint', () => {
   it('leaves a click in the route body world unshifted', () => {

--- a/src/app/modules/map/route-extend.ts
+++ b/src/app/modules/map/route-extend.ts
@@ -21,6 +21,28 @@ export interface RouteExtension {
   undo: { coordinates: Position[]; coordsMetadata?: RoutePointMeta[] };
 }
 
+/** What a map click during route modify is judged against (issue #608). */
+export interface ExtendClickContext {
+  /** The click landed on the route being modified, within Modify's own pixel
+   *  tolerance — it belongs to OL Modify (move / insert / delete a vertex). */
+  onRoute: boolean;
+  /** This same pointer gesture already removed a vertex (long-press or
+   *  Ctrl-Click). */
+  vertexDeleted: boolean;
+}
+
+/**
+ * Whether a map click in modify mode should append a new end point.
+ *
+ * The hit-test alone is not enough: a delete moves the line away from the pixel
+ * that was clicked, so the release completing a delete looks like open water by
+ * the time the click is handled and would extend the route (#608). A gesture
+ * that deleted a vertex never extends.
+ */
+export function shouldExtendRoute(ctx: ExtendClickContext): boolean {
+  return !ctx.onRoute && !ctx.vertexDeleted;
+}
+
 /**
  * Render-space (EPSG:3857) coordinate to append when extending a route by a
  * clicked open-water point. `base` is the click in the primary world; the


### PR DESCRIPTION
Deleting a route vertex also appended a new end point to the route, so the end
of the route jumped to where the deleted point was (#608, a regression from the
route-extend behaviour in #598).

The delete and the extend ride the same pointer release. `extendRouteInModify`
guarded only on a `getFeaturesAtPixel` hit-test against the route's *current*
geometry — but by the time the resulting `singleclick` is handled the vertex is
already gone and the line has snapped away from the clicked pixel, so the
hit-test misses and the click is classified as open water.

Both delete paths are affected: the mid-hold `removePoint()` in
`tryDeleteHeldVertexOnHold` (which clears `vertexDeleteOnRelease` on success, so
nothing marked the release at all) and the delete-on-release consumed by
`vertexDeleteCondition` — the latter covering Ctrl-Click as well as tap-hold.
Both now mark the delete on the map, and the extend decision moves into a pure
`shouldExtendRoute()` predicate in `route-extend.ts` so it can be tested directly.

The marker deliberately outlives the gesture that set it. OpenLayers delays
`singleclick` by 250 ms and nothing cancels it at `pointerdown`, so clearing the
marker there loses a race: a fast follow-up press clears it before the pending
click is handled and the route is extended anyway. It is retired where a gesture
resolves instead — `singleclick`, `dblclick` (which cancels the pending
`singleclick`), and a drag (`dragging_` is sticky per gesture and gates click
emulation, so a gesture that has dragged emits no click at all).

Tested on a local dev server: long-press delete removes the vertex and nothing
else changes; a click in open water still extends the route.

Closes #608


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental route extension after vertex deletion gestures.
  * Improved tap-hold, Ctrl-click, and long-press deletion handling so follow-up clicks/undo behavior stay in sync.
  * Ensured vertex-deletion suppression markers are properly retired or cleared across single clicks, double-clicks, and drag gestures.
* **Tests**
  * Added/expanded unit coverage for route-extension decision logic and the vertex-deleted gesture-marker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->