### PR TITLE
feat(map): offset the vessel abeam as well as ahead when following

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -160,6 +160,9 @@ export function cleanConfig(
   } else {
     settings.map.centerOffset = clampCenterOffset(settings.map.centerOffset);
   }
+  settings.map.centerOffsetAbeam = clampCenterOffset(
+    settings.map.centerOffsetAbeam ?? 0
+  );
   if (typeof settings.map.doubleClickZoom === 'undefined') {
     settings.map.doubleClickZoom = false;
   }
@@ -530,6 +533,7 @@ export function defaultConfig(): IAppConfig {
       doubleClickZoom: false, // true=zoom
       overZoomTiles: true, // keep tiles visible beyond chart max zoom
       centerOffset: 0,
+      centerOffsetAbeam: 0,
       s57Options: {
         graphicsStyle: 'Paper',
         boundaries: 'Plain',

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -11,8 +11,9 @@ import { Subject } from 'rxjs';
 import { InfoService, IndexedDB, AppInfoDef } from './lib/services';
 import { isTrackShown, toggleTrackSelection } from './lib/vessel-track';
 import {
+  CenterOffset,
   centerOffsetFromPan,
-  edgeDistanceInDirection,
+  MapViewport,
   mapCenterForOffset
 } from './lib/follow-offset';
 
@@ -907,20 +908,33 @@ export class AppFacade extends InfoService {
     );
   }
 
-  /** Metres from the viewport centre to the screen edge on the given course. */
-  private viewEdgeDistance(course: number): number {
-    return edgeDistanceInDirection(
-      GeoUtils.distanceTo(
+  /**
+   * The viewport an offset is measured against, or null until the map has
+   * reported an extent — the viewport signals hold [0, 0] until then, which
+   * would size the offset against the distance to null island.
+   */
+  private mapViewport(): MapViewport | null {
+    if (!this.mapExtent().length) {
+      return null;
+    }
+    return {
+      halfWidth: GeoUtils.distanceTo(
         this.config.map.center as Position,
         this.mapViewRightCenter()
       ),
-      GeoUtils.distanceTo(
+      halfHeight: GeoUtils.distanceTo(
         this.config.map.center as Position,
         this.mapViewTopCenter()
       ),
-      course,
-      this.mapViewRotation()
-    );
+      rotation: this.mapViewRotation()
+    };
+  }
+
+  private get centerOffset(): CenterOffset {
+    return {
+      ahead: this.config.map.centerOffset ?? 0,
+      abeam: this.config.map.centerOffsetAbeam ?? 0
+    };
   }
 
   /** Calculate the position to center the map.
@@ -930,16 +944,13 @@ export class AppFacade extends InfoService {
   calcMapCenter(applyOffset = true): Position {
     const position = this.data.vessels.active.position;
     const cog = this.activeVesselCourse();
-    const offset = this.config.map.centerOffset ?? 0;
-    if (cog === null || !applyOffset || !offset) {
+    const offset = this.centerOffset;
+    const viewport =
+      applyOffset && (offset.ahead || offset.abeam) ? this.mapViewport() : null;
+    if (cog === null || !viewport) {
       return position;
     }
-    return mapCenterForOffset(
-      position,
-      cog,
-      this.viewEdgeDistance(cog),
-      offset
-    );
+    return mapCenterForOffset(position, cog, viewport, offset);
   }
 
   /**
@@ -948,19 +959,25 @@ export class AppFacade extends InfoService {
    */
   setCenterOffsetFromPan(mapCenter: Position): boolean {
     const cog = this.activeVesselCourse();
-    if (cog === null) {
+    const viewport = this.mapViewport();
+    if (cog === null || !viewport) {
       return false;
     }
     const offset = centerOffsetFromPan(
       this.data.vessels.active.position,
       mapCenter,
       cog,
-      this.viewEdgeDistance(cog)
+      viewport
     );
-    if (offset === null || offset === this.config.map.centerOffset) {
+    const current = this.centerOffset;
+    if (
+      offset === null ||
+      (offset.ahead === current.ahead && offset.abeam === current.abeam)
+    ) {
       return false;
     }
-    this.config.map.centerOffset = offset;
+    this.config.map.centerOffset = offset.ahead;
+    this.config.map.centerOffsetAbeam = offset.abeam;
     return true;
   }
 

--- a/src/app/lib/follow-offset.spec.ts
+++ b/src/app/lib/follow-offset.spec.ts
@@ -34,6 +34,14 @@ const fromVessel = (centre: Position) => ({
   bearing: Convert.degreesToRadians(getGreatCircleBearing(VESSEL, centre) ?? 0)
 });
 
+/** A heading-up viewport on an easterly course, taller than it is wide: the
+ *  course points up the screen, and the two axes have different edge distances. */
+const ROTATED: MapViewport = {
+  halfWidth: 800,
+  halfHeight: 2000,
+  rotation: -EAST
+};
+
 /** A map centre panned `distance` metres from the vessel on `bearing`. */
 const panTo = (bearing: number, distance: number) =>
   GeoUtils.destCoordinate(VESSEL, bearing, distance);
@@ -240,5 +248,26 @@ describe('centerOffsetFromPan', () => {
     const centre = mapCenterForOffset(VESSEL, NORTH, SQUARE, offset!);
     expect(centre[0]).toBeCloseTo(panned[0], 3);
     expect(centre[1]).toBeCloseTo(panned[1], 3);
+  });
+
+  it('round-trips through a rotated, non-square viewport', () => {
+    // Heading-up on an easterly course, narrow screen: the two axes have
+    // different edge distances and neither aligns with north.
+    const panned = panTo(EAST + Math.PI / 5, 600);
+    const offset = centerOffsetFromPan(VESSEL, panned, EAST, ROTATED);
+    const centre = mapCenterForOffset(VESSEL, EAST, ROTATED, offset!);
+    expect(centre[0]).toBeCloseTo(panned[0], 3);
+    expect(centre[1]).toBeCloseTo(panned[1], 3);
+  });
+
+  it('constrains a pan that drags the vessel off a rotated viewport', () => {
+    // Dragged well beyond the narrow edge: the stored pair must be the one the
+    // renderer actually uses, or the vessel springs back from the drop point.
+    const panned = panTo(EAST + Math.PI / 4, 4000);
+    const offset = centerOffsetFromPan(VESSEL, panned, EAST, ROTATED)!;
+    const centre = mapCenterForOffset(VESSEL, EAST, ROTATED, offset);
+    const rendered = centerOffsetFromPan(VESSEL, centre, EAST, ROTATED)!;
+    expect(rendered.ahead).toBeCloseTo(offset.ahead, 0);
+    expect(rendered.abeam).toBeCloseTo(offset.abeam, 0);
   });
 });

--- a/src/app/lib/follow-offset.spec.ts
+++ b/src/app/lib/follow-offset.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { getGreatCircleBearing } from 'geolib';
 import {
   CENTER_OFFSET_LIMIT,
   centerOffsetFromPan,
@@ -6,22 +7,36 @@ import {
   edgeDistanceInDirection,
   legacyCenterOffset,
   legacyPanBehavior,
-  mapCenterForOffset
+  mapCenterForOffset,
+  MapViewport
 } from './follow-offset';
+import { Convert } from './convert';
+import { GeoUtils } from './geoutils';
 import { Position } from '../types';
 
 const VESSEL: Position = [-80.5, 25.0];
 const NORTH = 0;
 const EAST = Math.PI / 2;
-const EDGE_DISTANCE = 2000; // metres from the viewport centre to the edge
+const SOUTH = Math.PI;
+const WEST = Math.PI * 1.5;
 
-/** Positions 1km from the vessel, for panning the map centre to. */
-const NORTH_1KM: Position = [-80.5, 25.0 + 1000 / 111320];
-const SOUTH_1KM: Position = [-80.5, 25.0 - 1000 / 111320];
-const EAST_1KM: Position = [
-  -80.5 + 1000 / (111320 * Math.cos(25.0 * (Math.PI / 180))),
-  25.0
-];
+/** A square north-up viewport 2km to every edge, so a percentage of the edge
+ *  distance means the same thing in any direction. */
+const SQUARE: MapViewport = {
+  halfWidth: 2000,
+  halfHeight: 2000,
+  rotation: 0
+};
+
+/** Distance (m) and bearing (radians) from the vessel to a resolved map centre. */
+const fromVessel = (centre: Position) => ({
+  distance: GeoUtils.distanceTo(VESSEL, centre),
+  bearing: Convert.degreesToRadians(getGreatCircleBearing(VESSEL, centre) ?? 0)
+});
+
+/** A map centre panned `distance` metres from the vessel on `bearing`. */
+const panTo = (bearing: number, distance: number) =>
+  GeoUtils.destCoordinate(VESSEL, bearing, distance);
 
 describe('clampCenterOffset', () => {
   it('keeps the vessel on screen by clamping to the limit', () => {
@@ -37,6 +52,10 @@ describe('clampCenterOffset', () => {
   it('falls back to no offset for a non-numeric entry', () => {
     expect(clampCenterOffset(NaN)).toBe(0);
   });
+
+  it('normalises the -0 that rounding a hair of negative produces', () => {
+    expect(clampCenterOffset(-0.4)).toBe(0);
+  });
 });
 
 describe('legacyCenterOffset', () => {
@@ -49,7 +68,6 @@ describe('legacyCenterOffset', () => {
 
 describe('legacyPanBehavior', () => {
   it('maps a checked "Lock Follow Vessel" to holding the panned-to offset', () => {
-    // Locked meant "panning does not drop me out of follow mode".
     expect(legacyPanBehavior(true)).toBe('offset');
   });
 
@@ -79,68 +97,148 @@ describe('edgeDistanceInDirection', () => {
 });
 
 describe('mapCenterForOffset', () => {
-  it('places the map centre ahead of the vessel for a positive offset', () => {
-    const centre = mapCenterForOffset(VESSEL, NORTH, EDGE_DISTANCE, 50);
-    // 50% of a 2000m edge = 1000m ahead.
-    expect(centre[1]).toBeCloseTo(NORTH_1KM[1], 4);
-    expect(centre[0]).toBeCloseTo(VESSEL[0], 4);
+  it('places the map centre ahead of the vessel for a positive ahead offset', () => {
+    const { distance, bearing } = fromVessel(
+      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 50, abeam: 0 })
+    );
+    expect(distance).toBeCloseTo(1000, -1);
+    expect(bearing).toBeCloseTo(NORTH, 2);
   });
 
-  it('places the map centre astern for a negative offset', () => {
-    const centre = mapCenterForOffset(VESSEL, NORTH, EDGE_DISTANCE, -50);
-    expect(centre[1]).toBeCloseTo(SOUTH_1KM[1], 4);
+  it('places the map centre astern for a negative ahead offset', () => {
+    const { distance, bearing } = fromVessel(
+      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: -50, abeam: 0 })
+    );
+    expect(distance).toBeCloseTo(1000, -1);
+    expect(bearing).toBeCloseTo(SOUTH, 2);
   });
 
-  it('applies the offset along the course, not due north', () => {
-    const centre = mapCenterForOffset(VESSEL, EAST, EDGE_DISTANCE, 50);
-    expect(centre[0]).toBeCloseTo(EAST_1KM[0], 4);
-    expect(centre[1]).toBeCloseTo(VESSEL[1], 4);
+  it('places the map centre to starboard for a positive abeam offset', () => {
+    const { distance, bearing } = fromVessel(
+      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 0, abeam: 50 })
+    );
+    expect(distance).toBeCloseTo(1000, -1);
+    expect(bearing).toBeCloseTo(EAST, 2);
+  });
+
+  it('places the map centre to port for a negative abeam offset', () => {
+    const { bearing } = fromVessel(
+      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 0, abeam: -50 })
+    );
+    expect(bearing).toBeCloseTo(WEST, 2);
+  });
+
+  it('combines both axes into a diagonal offset', () => {
+    const { bearing } = fromVessel(
+      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 50, abeam: 50 })
+    );
+    // Equal parts ahead and to starboard puts the centre on the bow quarter.
+    expect(bearing).toBeCloseTo(Math.PI / 4, 2);
+  });
+
+  it('holds the offset in the vessel frame as the vessel turns', () => {
+    // The same "ahead" offset must point east once the vessel heads east, or a
+    // look-ahead would show the water already passed.
+    const { bearing } = fromVessel(
+      mapCenterForOffset(VESSEL, EAST, SQUARE, { ahead: 50, abeam: 0 })
+    );
+    expect(bearing).toBeCloseTo(EAST, 2);
   });
 
   it('centres the vessel exactly when there is no offset', () => {
-    expect(mapCenterForOffset(VESSEL, NORTH, EDGE_DISTANCE, 0)).toEqual(VESSEL);
+    expect(
+      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 0, abeam: 0 })
+    ).toEqual(VESSEL);
+  });
+
+  it('holds a single-axis offset at the full limit without shrinking it', () => {
+    const { distance } = fromVessel(
+      mapCenterForOffset(VESSEL, NORTH, SQUARE, {
+        ahead: CENTER_OFFSET_LIMIT,
+        abeam: 0
+      })
+    );
+    expect(distance).toBeCloseTo(1800, -1);
+  });
+
+  it('shrinks a corner offset that would push the vessel off screen', () => {
+    // 90% ahead with 90% abeam lands diagonally outside the viewport corner,
+    // which neither per-axis clamp catches on its own.
+    const { distance, bearing } = fromVessel(
+      mapCenterForOffset(VESSEL, NORTH, SQUARE, {
+        ahead: CENTER_OFFSET_LIMIT,
+        abeam: CENTER_OFFSET_LIMIT
+      })
+    );
+    const limit = (CENTER_OFFSET_LIMIT / 100) * 1.01;
+    expect(Math.abs(distance * Math.cos(bearing))).toBeLessThanOrEqual(
+      SQUARE.halfHeight * limit
+    );
+    expect(Math.abs(distance * Math.sin(bearing))).toBeLessThanOrEqual(
+      SQUARE.halfWidth * limit
+    );
+    // Still on the bow quarter — the shrink is uniform, not per axis.
+    expect(bearing).toBeCloseTo(Math.PI / 4, 2);
   });
 });
 
 describe('centerOffsetFromPan', () => {
-  it('reads a pan ahead of the vessel as a positive percentage', () => {
-    expect(centerOffsetFromPan(VESSEL, NORTH_1KM, NORTH, EDGE_DISTANCE)).toBe(
-      50
-    );
+  it('reads a pan ahead of the vessel as a positive ahead offset', () => {
+    expect(
+      centerOffsetFromPan(VESSEL, panTo(NORTH, 1000), NORTH, SQUARE)
+    ).toEqual({ ahead: 50, abeam: 0 });
   });
 
-  it('reads a pan astern of the vessel as a negative percentage', () => {
-    expect(centerOffsetFromPan(VESSEL, SOUTH_1KM, NORTH, EDGE_DISTANCE)).toBe(
-      -50
-    );
+  it('reads a pan astern as a negative ahead offset', () => {
+    expect(
+      centerOffsetFromPan(VESSEL, panTo(SOUTH, 1000), NORTH, SQUARE)
+    ).toEqual({ ahead: -50, abeam: 0 });
   });
 
-  it('keeps only the along-course part of an off-course pan', () => {
-    // Panning abeam contributes nothing: the setting is a single along-course
-    // value, so the vessel springs back onto the course line.
-    expect(centerOffsetFromPan(VESSEL, EAST_1KM, NORTH, EDGE_DISTANCE)).toBe(0);
+  it('keeps the sideways part of a pan instead of discarding it', () => {
+    // The single-axis behaviour this replaces projected the pan onto the course
+    // and sprang the vessel back onto the course line (#615).
+    expect(
+      centerOffsetFromPan(VESSEL, panTo(EAST, 1000), NORTH, SQUARE)
+    ).toEqual({ ahead: 0, abeam: 50 });
+  });
+
+  it('reads a pan to port as a negative abeam offset', () => {
+    expect(
+      centerOffsetFromPan(VESSEL, panTo(WEST, 1000), NORTH, SQUARE)
+    ).toEqual({ ahead: 0, abeam: -50 });
+  });
+
+  it('resolves a diagonal pan into both axes', () => {
+    // 1000m on the bow quarter is ~707m on each axis, ~35% of a 2000m edge.
+    expect(
+      centerOffsetFromPan(VESSEL, panTo(Math.PI / 4, 1000), NORTH, SQUARE)
+    ).toEqual({ ahead: 35, abeam: 35 });
   });
 
   it('measures against the course, not the compass', () => {
-    expect(centerOffsetFromPan(VESSEL, EAST_1KM, EAST, EDGE_DISTANCE)).toBe(50);
+    expect(
+      centerOffsetFromPan(VESSEL, panTo(EAST, 1000), EAST, SQUARE)
+    ).toEqual({ ahead: 50, abeam: 0 });
   });
 
   it('clamps a pan that would push the vessel off screen', () => {
-    expect(centerOffsetFromPan(VESSEL, NORTH_1KM, NORTH, 500)).toBe(
-      CENTER_OFFSET_LIMIT
-    );
+    expect(
+      centerOffsetFromPan(VESSEL, panTo(NORTH, 4000), NORTH, SQUARE)?.ahead
+    ).toBe(CENTER_OFFSET_LIMIT);
   });
 
   it('leaves the setting alone when the vessel has no course', () => {
     expect(
-      centerOffsetFromPan(VESSEL, NORTH_1KM, null, EDGE_DISTANCE)
+      centerOffsetFromPan(VESSEL, panTo(NORTH, 1000), null, SQUARE)
     ).toBeNull();
   });
 
   it('round-trips: applying a captured offset restores the panned-to centre', () => {
-    const offset = centerOffsetFromPan(VESSEL, NORTH_1KM, NORTH, EDGE_DISTANCE);
-    const centre = mapCenterForOffset(VESSEL, NORTH, EDGE_DISTANCE, offset!);
-    expect(centre[0]).toBeCloseTo(NORTH_1KM[0], 4);
-    expect(centre[1]).toBeCloseTo(NORTH_1KM[1], 4);
+    const panned = panTo(Math.PI / 4, 1000);
+    const offset = centerOffsetFromPan(VESSEL, panned, NORTH, SQUARE);
+    const centre = mapCenterForOffset(VESSEL, NORTH, SQUARE, offset!);
+    expect(centre[0]).toBeCloseTo(panned[0], 3);
+    expect(centre[1]).toBeCloseTo(panned[1], 3);
   });
 });

--- a/src/app/lib/follow-offset.ts
+++ b/src/app/lib/follow-offset.ts
@@ -140,6 +140,38 @@ function onScreenScale(
 }
 
 /**
+ * Scale an offset pair back until the vessel is inside the viewport, so that a
+ * stored offset is the one actually rendered. Panning the vessel clean off the
+ * screen otherwise stores a pair the renderer then shrinks, and the vessel
+ * springs back from where it was dropped.
+ * @param offset the offset percentages to constrain
+ * @param course vessel COG (or heading) in radians
+ * @param viewport the current map viewport
+ */
+export function constrainCenterOffset(
+  offset: CenterOffset,
+  course: number,
+  viewport: MapViewport
+): CenterOffset {
+  const { ahead, abeam } = offsetComponents(course, viewport, offset);
+  const distance = Math.hypot(ahead, abeam);
+  if (!distance || !Number.isFinite(distance)) {
+    return offset;
+  }
+  const scale = onScreenScale(
+    normalise(course + Math.atan2(abeam, ahead)),
+    distance,
+    viewport
+  );
+  return scale >= 1
+    ? offset
+    : {
+        ahead: clampCenterOffset(offset.ahead * scale),
+        abeam: clampCenterOffset(offset.abeam * scale)
+      };
+}
+
+/**
  * Resolve the configured offset to a map centre for the vessel's current
  * position and course.
  * @param vessel vessel position `[lon, lat]`
@@ -216,8 +248,14 @@ export function centerOffsetFromPan(
     getGreatCircleBearing(vessel, mapCenter) ?? 0
   );
   const delta = bearing - course;
-  return {
-    ahead: clampCenterOffset(((distance * Math.cos(delta)) / aheadEdge) * 100),
-    abeam: clampCenterOffset(((distance * Math.sin(delta)) / abeamEdge) * 100)
-  };
+  return constrainCenterOffset(
+    {
+      ahead: clampCenterOffset(
+        ((distance * Math.cos(delta)) / aheadEdge) * 100
+      ),
+      abeam: clampCenterOffset(((distance * Math.sin(delta)) / abeamEdge) * 100)
+    },
+    course,
+    viewport
+  );
 }

--- a/src/app/lib/follow-offset.ts
+++ b/src/app/lib/follow-offset.ts
@@ -4,12 +4,25 @@ import { GeoUtils } from './geoutils';
 import { MapPanBehavior, Position } from '../types';
 
 /**
- * The vessel centre offset is a whole percentage of the distance from the
- * viewport centre to the screen edge, measured along the vessel's course:
- * positive puts the map centre ahead of the vessel (look ahead), negative puts
- * it astern (look behind). Clamped short of the edge so the vessel can never be
- * pushed off screen.
+ * Where the map centre sits relative to the vessel, as whole percentages of the
+ * distance from the viewport centre to the screen edge. The offset is held in
+ * the vessel's frame rather than the screen's, so it rotates with the boat —
+ * a look-ahead has to stay ahead in north-up too, or a vessel heading south
+ * would be shown the water it has already passed.
  */
+export interface CenterOffset {
+  ahead: number; // along the course; negative places the centre astern
+  abeam: number; // to starboard of the course; negative places it to port
+}
+
+/** The viewport the offset is measured against. */
+export interface MapViewport {
+  halfWidth: number; // metres from the centre to the side edge
+  halfHeight: number; // metres from the centre to the top edge
+  rotation: number; // OL view rotation in radians
+}
+
+/** Neither axis may exceed this share of the distance to the screen edge. */
 export const CENTER_OFFSET_LIMIT = 90;
 
 /** Round and clamp an entered or panned-to offset to a usable percentage. */
@@ -17,10 +30,13 @@ export function clampCenterOffset(value: number): number {
   if (!Number.isFinite(value)) {
     return 0;
   }
-  return Math.max(
-    -CENTER_OFFSET_LIMIT,
-    Math.min(CENTER_OFFSET_LIMIT, Math.round(value))
-  );
+  const rounded = Math.round(value);
+  // Resolving a pan leaves a hair of rounding error on the axis the user did
+  // not move along, and Math.round turns that into -0. Normalise it so "no
+  // offset" is always the same value.
+  return rounded === 0
+    ? 0
+    : Math.max(-CENTER_OFFSET_LIMIT, Math.min(CENTER_OFFSET_LIMIT, rounded));
 }
 
 /**
@@ -42,6 +58,7 @@ export function legacyPanBehavior(lockMoveMap?: boolean): MapPanBehavior {
 }
 
 const TWO_PI = Math.PI * 2;
+const QUARTER_TURN = Math.PI / 2;
 
 /** Normalise an angle to `[0, 2π)`. */
 const normalise = (radians: number): number =>
@@ -49,7 +66,7 @@ const normalise = (radians: number): number =>
 
 /**
  * Geodetic distance from the viewport centre to the screen edge in the given
- * course direction. This correctly handles any map rotation mode (north-up or
+ * direction. This correctly handles any map rotation mode (north-up or
  * heading-up) and any screen aspect ratio.
  *
  * In OL, a CW bearing β has projected-space direction (sin β, cos β). With OL
@@ -58,68 +75,139 @@ const normalise = (radians: number): number =>
  * The edge of the viewport rectangle lies at min(hw/|sx|, hh/|sy|).
  * @param halfWidth geodetic distance from the centre to the side edge
  * @param halfHeight geodetic distance from the centre to the top edge
- * @param course vessel COG (or heading) in radians
+ * @param bearing direction of interest in radians
  * @param rotation OL view rotation in radians
  */
 export function edgeDistanceInDirection(
   halfWidth: number,
   halfHeight: number,
-  course: number,
+  bearing: number,
   rotation: number
 ): number {
-  const sx = Math.abs(Math.sin(course + rotation));
-  const sy = Math.abs(Math.cos(course + rotation));
+  const sx = Math.abs(Math.sin(bearing + rotation));
+  const sy = Math.abs(Math.cos(bearing + rotation));
   return Math.min(
     sx > 1e-10 ? halfWidth / sx : Infinity,
     sy > 1e-10 ? halfHeight / sy : Infinity
   );
 }
 
+/** The two axis offsets in metres, measured in the vessel's frame. */
+function offsetComponents(
+  course: number,
+  viewport: MapViewport,
+  offset: CenterOffset
+): { ahead: number; abeam: number } {
+  const { halfWidth, halfHeight, rotation } = viewport;
+  return {
+    ahead:
+      edgeDistanceInDirection(halfWidth, halfHeight, course, rotation) *
+      (offset.ahead / 100),
+    abeam:
+      edgeDistanceInDirection(
+        halfWidth,
+        halfHeight,
+        course + QUARTER_TURN,
+        rotation
+      ) *
+      (offset.abeam / 100)
+  };
+}
+
 /**
- * Resolve the vessel centre offset to a map centre for the vessel's current
+ * Shrink factor keeping the vessel on screen. Each axis is clamped against the
+ * edge distance in its *own* direction, which is not enough once both are in
+ * play: 90% ahead combined with 90% abeam lands diagonally outside the corner.
+ * Offsets on a single axis are always within bounds, so this returns 1 for them
+ * and only bites on a genuine corner offset.
+ */
+function onScreenScale(
+  bearing: number,
+  distance: number,
+  viewport: MapViewport
+): number {
+  const { halfWidth, halfHeight, rotation } = viewport;
+  const fx =
+    halfWidth > 0
+      ? Math.abs(distance * Math.sin(bearing + rotation)) / halfWidth
+      : 0;
+  const fy =
+    halfHeight > 0
+      ? Math.abs(distance * Math.cos(bearing + rotation)) / halfHeight
+      : 0;
+  const excess = Math.max(fx, fy) / (CENTER_OFFSET_LIMIT / 100);
+  return excess > 1 ? 1 / excess : 1;
+}
+
+/**
+ * Resolve the configured offset to a map centre for the vessel's current
  * position and course.
  * @param vessel vessel position `[lon, lat]`
  * @param course vessel COG (or heading) in radians
- * @param edgeDistance metres from the viewport centre to the edge on that course
- * @param offset the configured offset percentage
+ * @param viewport the current map viewport
+ * @param offset the configured offset percentages
  */
 export function mapCenterForOffset(
   vessel: Position,
   course: number,
-  edgeDistance: number,
-  offset: number
+  viewport: MapViewport,
+  offset: CenterOffset
 ): Position {
-  const distance = edgeDistance * (offset / 100);
+  const { ahead, abeam } = offsetComponents(course, viewport, offset);
+  const distance = Math.hypot(ahead, abeam);
   if (!distance || !Number.isFinite(distance)) {
     return vessel;
   }
+  // atan2 carries the sign of both axes, so an astern or to-port offset needs
+  // no special case — it simply points the other way.
+  const bearing = normalise(course + Math.atan2(abeam, ahead));
   return GeoUtils.destCoordinate(
     vessel,
-    distance < 0 ? normalise(course + Math.PI) : normalise(course),
-    Math.abs(distance)
+    bearing,
+    distance * onScreenScale(bearing, distance, viewport)
   );
 }
 
 /**
- * Derive the vessel centre offset from a chart pan, by projecting the
- * vessel → map-centre displacement onto the vessel's course. The setting is a
- * single along-course value, so panning off the course line contributes only
- * its along-course component.
+ * Derive the offset from a chart pan, by resolving the vessel → map-centre
+ * displacement into its along-course and abeam components so the vessel stays
+ * where the user dragged it.
  *
  * Returns null when the vessel has no course to measure against, in which case
  * the pan leaves the configured offset alone.
  * @param vessel vessel position `[lon, lat]`
  * @param mapCenter map centre the user panned to `[lon, lat]`
  * @param course vessel COG (or heading) in radians; null when not under way
- * @param edgeDistance metres from the viewport centre to the edge on that course
+ * @param viewport the current map viewport
  */
 export function centerOffsetFromPan(
   vessel: Position,
   mapCenter: Position,
   course: number | null,
-  edgeDistance: number
-): number | null {
-  if (course === null || !edgeDistance || !Number.isFinite(edgeDistance)) {
+  viewport: MapViewport
+): CenterOffset | null {
+  if (course === null) {
+    return null;
+  }
+  const { halfWidth, halfHeight, rotation } = viewport;
+  const aheadEdge = edgeDistanceInDirection(
+    halfWidth,
+    halfHeight,
+    course,
+    rotation
+  );
+  const abeamEdge = edgeDistanceInDirection(
+    halfWidth,
+    halfHeight,
+    course + QUARTER_TURN,
+    rotation
+  );
+  if (
+    !aheadEdge ||
+    !abeamEdge ||
+    !Number.isFinite(aheadEdge) ||
+    !Number.isFinite(abeamEdge)
+  ) {
     return null;
   }
   const distance = GeoUtils.distanceTo(vessel, mapCenter) ?? 0;
@@ -127,6 +215,9 @@ export function centerOffsetFromPan(
   const bearing = Convert.degreesToRadians(
     getGreatCircleBearing(vessel, mapCenter) ?? 0
   );
-  const alongCourse = distance * Math.cos(bearing - course);
-  return clampCenterOffset((alongCourse / edgeDistance) * 100);
+  const delta = bearing - course;
+  return {
+    ahead: clampCenterOffset(((distance * Math.cos(delta)) / aheadEdge) * 100),
+    abeam: clampCenterOffset(((distance * Math.sin(delta)) / abeamEdge) * 100)
+  };
 }

--- a/src/app/modules/settings/components/settings-dialog.css
+++ b/src/app/modules/settings/components/settings-dialog.css
@@ -35,6 +35,29 @@
   padding-right: 15px;
   flex: 1 1 auto;
 }
+/* A label shared by several related inputs, standing in for the mat-label a
+   single control would carry. An empty one is a spacer keeping a neighbouring
+   single control's box level with the group's boxes. */
+.settings .setting-field-group-title {
+  font-size: 10pt;
+  font-family: Arial, Helvetica, sans-serif;
+  opacity: 0.7;
+  line-height: 1.4;
+  min-height: 1.4em;
+  padding-bottom: 2px;
+}
+/* Must wrap: a non-wrapping row wider than the panel stretches the whole card
+   and pushes controls in its sibling rows off screen. */
+.settings .setting-field-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+/* Sized for a two or three digit entry rather than stretched to fill the row. */
+.settings .setting-field-group mat-form-field {
+  flex: 0 1 150px;
+  min-width: 80px;
+}
 
 /*ipads*/
 @media only screen and (min-device-width: 768px) and (max-device-width: 1024px),

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -464,6 +464,10 @@
               <mat-card-content>
                 <div class="setting-card-row" style="padding-bottom: 10px">
                   <div class="setting-card-row-item">
+                    <!-- spacer keeping this control level with the offset group -->
+                    <div class="setting-field-group-title" aria-hidden="true">
+                      &nbsp;
+                    </div>
                     <mat-form-field style="width: 100%">
                       <mat-label>Feature label zoom level</mat-label>
                       <mat-select
@@ -477,19 +481,37 @@
                     </mat-form-field>
                   </div>
                   <div class="setting-card-row-item">
-                    <mat-form-field style="width: 100%" floatLabel="always">
-                      <mat-label>Offset Vessel Center (%)</mat-label>
-                      <input
-                        matInput
-                        type="number"
-                        #centerOffset="ngModel"
-                        [min]="-centerOffsetLimit"
-                        [max]="centerOffsetLimit"
-                        [(ngModel)]="facade.settings.map.centerOffset"
-                        (change)="parseCenterOffset(centerOffset)"
-                        matTooltip="How far ahead of the vessel to centre the map, as a percentage of the distance to the screen edge. Use a negative value to look behind."
-                      />
-                    </mat-form-field>
+                    <div class="setting-field-group-title">
+                      Offset Vessel Center (%)
+                    </div>
+                    <div class="setting-field-group">
+                      <mat-form-field floatLabel="always">
+                        <mat-label>Ahead</mat-label>
+                        <input
+                          matInput
+                          type="number"
+                          #centerOffset="ngModel"
+                          [min]="-centerOffsetLimit"
+                          [max]="centerOffsetLimit"
+                          [(ngModel)]="facade.settings.map.centerOffset"
+                          (change)="parseCenterOffset(centerOffset)"
+                          matTooltip="How far ahead of the vessel to centre the map, as a percentage of the distance to the screen edge. Use a negative value to look behind."
+                        />
+                      </mat-form-field>
+                      <mat-form-field floatLabel="always">
+                        <mat-label>Abeam</mat-label>
+                        <input
+                          matInput
+                          type="number"
+                          #centerOffsetAbeam="ngModel"
+                          [min]="-centerOffsetLimit"
+                          [max]="centerOffsetLimit"
+                          [(ngModel)]="facade.settings.map.centerOffsetAbeam"
+                          (change)="parseCenterOffset(centerOffsetAbeam)"
+                          matTooltip="How far to one side of the vessel to centre the map, as a percentage of the distance to the screen edge. Positive is to starboard, negative to port."
+                        />
+                      </mat-form-field>
+                    </div>
                   </div>
                   <div class="setting-card-row-item">
                     <mat-checkbox

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -136,6 +136,7 @@ export interface IAppConfig {
     doubleClickZoom: boolean; // true=zoom
     overZoomTiles: boolean; // keep tiles visible beyond chart max zoom
     centerOffset: number; // whole % of the distance to the screen edge that the map centre sits ahead of the vessel (negative = astern)
+    centerOffsetAbeam: number; // as above, to starboard of the vessel's course (negative = to port)
     s57Options: Options; // S57 chart Options
     popoverMulti: boolean; // close popovers using cose button
   };

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -2356,14 +2356,25 @@
               zoom levels below this value.
             </li>
             <li>
-              <b>Offset Vessel Center (%)</b>: How far ahead of the vessel the
-              map is centered while in "Follow Vessel" mode, giving you more
-              visible chart in front of the vessel. The value is a percentage of
-              the distance from the center of the screen to its edge, so
-              <b>50</b> places the vessel half way between the center and the
-              trailing edge. Enter a negative value to look behind the vessel
-              instead.<br />
-              You can also set this by eye: with
+              <b>Offset Vessel Center (%)</b>: Where the vessel sits on screen
+              while in "Follow Vessel" mode, so you can give yourself more
+              visible chart in the direction you care about. Each value is a
+              percentage of the distance from the center of the screen to its
+              edge, and both are measured relative to your course, so the view
+              keeps its bearings as the vessel turns.
+              <ul>
+                <li>
+                  <b>Ahead</b>: moves the vessel back from the center to show
+                  more chart in front of it, so <b>50</b> places the vessel half
+                  way between the center and the trailing edge. A negative value
+                  looks behind the vessel instead.
+                </li>
+                <li>
+                  <b>Abeam</b>: moves the vessel to one side. A positive value
+                  shows more chart to starboard, a negative value more to port.
+                </li>
+              </ul>
+              You can also set both by eye: with
               <b>Map Pan When Following</b> set to <b>Set Follow Offset</b>,
               simply pan the chart to put the vessel where you want it.<br />
             </li>
@@ -2382,7 +2393,7 @@
               <ul>
                 <li>
                   <b>Set Follow Offset</b>: Follow mode stays on and panning
-                  sets the <b>Offset Vessel Center</b> value above, so you can
+                  sets the <b>Offset Vessel Center</b> values above, so you can
                   position the vessel on screen by eye. The offset is saved and
                   used from then on.
                 </li>


### PR DESCRIPTION
Panning under *Set Follow Offset* projected the drag onto the course line and
threw away the sideways part, so dragging the vessel off to one side sprang it
back. The plotters that inspired the gesture keep the offset in both axes, and
that is what people expect when they drag — the boat should stay where they put
it.

**Offset Vessel Center** is now a group over two inputs, **Ahead** and
**Abeam**, and a pan sets both. Each stays a percentage of the distance from the
centre of the screen to its edge.

Both axes are measured in the vessel's frame rather than the screen's, so the
offset rotates with the boat. That matters in north-up: a screen-fixed
look-ahead would show a vessel heading south the water it had already passed.

Per-axis clamps alone do not keep the vessel visible — 90% ahead combined with
90% abeam lands diagonally outside the viewport corner — so the resolved offset
is scaled back uniformly when it would push the vessel off screen. Offsets on a
single axis never reach that point and are unchanged.

The stored value carries over as the ahead offset and the new abeam offset
defaults to zero, so no existing view moves.

Closes #615


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Map centering offsets now support independent **Ahead** and **Abeam** positioning.
  - Follow mode now calculates offsets using the viewport size and map rotation, supporting diagonal and rotated views.
  - Settings added an **Abeam** offset input with validation, and it defaults to **0**.

- **Bug Fixes**
  - Improved offset math keeps the vessel correctly positioned on-screen, including corner and turn scenarios.
  - Panning now preserves both Ahead and Abeam components and returns consistent round-trip results.

- **Documentation**
  - Updated Map settings help to explain separate Ahead/Abeam behavior and follow-mode impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->