### PR TITLE
fix(charts): stop the In view filter looping on map view change

### DIFF
--- a/src/app/modules/skresources/components/charts/chartlist.spec.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.spec.ts
@@ -121,3 +121,105 @@ describe('ChartListComponent — list ordered by chart layer order (#550)', () =
     expect(idsOf(filteredSignalOf(comp)())).toEqual(['c', 'b', 'a', 'osm']);
   });
 });
+
+/**
+ * Two constructor effects — one on `selectedCharts`, one on `app.mapExtent()` —
+ * both end in `doFilter()`, which writes the `filteredList` signal and then reads
+ * it back (via `alignSelections()`). Tracked, that read made each effect a
+ * dependent of the other's write: with the "In view" filter on, a single map move
+ * ping-ponged them forever and Freeboard locked up on zoom/pan (#617).
+ *
+ * Both inputs must be present to reproduce it, so these tests use a real
+ * component fixture (`setInput` needs a `ComponentRef`) with the template
+ * overridden away — the loop is in the effects, not the view.
+ *
+ * `arrangeChartLayers` trips after a small number of calls so a regression fails
+ * as an assertion rather than running the vitest worker out of memory.
+ */
+describe('ChartListComponent — "In view" filter does not loop on map move (#617)', () => {
+  const RUNAWAY = 25;
+  let filterRuns: number;
+  let mapExtent: WritableSignal<number[]>;
+
+  const makeComponent = () => {
+    const fixture = TestBed.createComponent(ChartListComponent);
+    fixture.componentRef.setInput('selectedCharts', ['a']);
+    const comp = fixture.componentInstance;
+    (comp as unknown as { fullList: FBCharts }).fullList.push(
+      chart('a', 'Alpha'),
+      chart('b', 'Bravo')
+    );
+    fixture.detectChanges();
+    return { fixture, comp };
+  };
+
+  const setInViewOnly = (comp: ChartListComponent, on: boolean) =>
+    (
+      comp as unknown as { toggleInViewOnly: (c: boolean) => void }
+    ).toggleInViewOnly(on);
+
+  beforeEach(() => {
+    filterRuns = 0;
+    mapExtent = signal<number[]>([0, 0, 1, 1]);
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: SKResourceService,
+          useValue: {
+            arrangeChartLayers: (list: FBCharts) => {
+              if (++filterRuns > RUNAWAY) {
+                throw new Error('doFilter() ran away — effect feedback loop');
+              }
+              return [...list];
+            }
+          }
+        },
+        {
+          provide: SKWorkerService,
+          useValue: { resourceUpdate: signal({ path: '' }) }
+        },
+        {
+          provide: AppFacade,
+          useValue: {
+            mapExtent,
+            // true → initItems() bails out, leaving the seeded fullList alone
+            sIsFetching: signal(true),
+            debug: vi.fn(),
+            data: { chartBounds: { show: false, charts: [] } }
+          }
+        },
+        { provide: MatDialog, useValue: {} },
+        { provide: SKResourceGroupService, useValue: {} },
+        { provide: FBMapInteractService, useValue: {} }
+      ]
+    });
+    // The loop lives in the constructor effects; the view is not needed.
+    TestBed.overrideComponent(ChartListComponent, { set: { template: '' } });
+  });
+
+  it('re-filters once, not forever, when the map view changes', () => {
+    const { fixture, comp } = makeComponent();
+    // Charts carry no bounds, so they are treated as global and stay in view —
+    // this is about how often the filter runs, not what it keeps.
+    setInViewOnly(comp, true);
+    fixture.detectChanges();
+    filterRuns = 0;
+
+    mapExtent.set([1, 1, 2, 2]);
+    fixture.detectChanges();
+
+    expect(filterRuns).toBe(1);
+  });
+
+  it('does not re-filter on a map view change while the filter is off', () => {
+    const { fixture, comp } = makeComponent();
+    setInViewOnly(comp, false);
+    fixture.detectChanges();
+    filterRuns = 0;
+
+    mapExtent.set([1, 1, 2, 2]);
+    fixture.detectChanges();
+
+    expect(filterRuns).toBe(0);
+  });
+});

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -6,6 +6,7 @@ import {
   input,
   inject,
   output,
+  untracked,
   DestroyRef
 } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -82,9 +83,16 @@ export class ChartListComponent extends ResourceListBase {
   constructor(protected override skres: SKResourceService) {
     super('charts', skres);
     // selection.charts changed
+    //
+    // Both this effect and the map-view one below end in doFilter(), which
+    // writes the filteredList signal and then reads it back (alignSelections).
+    // Tracked, that read makes each effect a dependent of the other's write, so
+    // with the in-view filter on, one map move ping-pongs them forever (#617).
+    // Their triggers are the signals read outside untracked(); the rest is
+    // side effect.
     effect(() => {
       if (this.selectedCharts()) {
-        this.externalSelection();
+        untracked(() => this.externalSelection());
       }
     });
     // resources delta handler
@@ -97,7 +105,7 @@ export class ChartListComponent extends ResourceListBase {
     effect(() => {
       this.app.mapExtent();
       if (this.inViewOnly) {
-        this.doFilter();
+        untracked(() => this.doFilter());
       }
     });
   }


### PR DESCRIPTION
Closes #617 — with the chart list's "In view" filter on, panning or zooming the
map locked Freeboard up.

The cause is effect feedback, not the filter logic. Two constructor effects in
`ChartListComponent` both end in `doFilter()`, which writes the `filteredList`
signal and then reads it back via `alignSelections()`:

- `effect(selectedCharts)` → `externalSelection()` → `doFilter()`
- `effect(mapExtent)` → `doFilter()` — added with the filter in #352

Neither effect re-triggers itself, because each reads `filteredList` *after* its
own write, so the version it records is already current. That is why this survived
review. But each one's write invalidates the read the *other* effect recorded, so
once both are live a single `moveend` ping-pongs them without end. Reproduced in a
spec, it runs the JS heap out of memory.

Both effects now run their work inside `untracked()`, so each is triggered only by
the signal it reads outside that call, and the shared list state is a side effect
rather than a dependency. This also stops the `selectedCharts` effect re-running on
every pan and zoom — a second dependency that leaked in via `doFilter()`'s
`mapExtent` read.

Reproducing needs both the `selectedCharts` input bound and the filter on, so the
tests use a real component fixture with the template overridden away; the loop is
in the effects, not the view. The stubbed `arrangeChartLayers` trips after 25 calls
so a regression fails as an assertion instead of running the vitest worker out of
memory.

Verified against a running dev server: the chart list re-filters correctly while
panning and zooming, with no lockup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the “In view” chart filter could repeatedly run when the map moved.
  - Improved filtering behavior so map extent changes trigger only the expected updates.
  - Added regression coverage for both enabled and disabled “In view” filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->