### PR TITLE
docs(charts): update Chart Image Adjustment for the modeless palette

### DIFF
--- a/features/changelog.json
+++ b/features/changelog.json
@@ -13,6 +13,8 @@
   { "feature": "cursor-eta", "pr": 455, "kind": "new", "since": "v3.0.0", "date": "2026-07-03", "title": "feat(map): show live bearing, distance and ETA at cursor" },
   { "feature": "buddy-list", "pr": 484, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-07", "title": "feat(ais): add \"Buddies only\" option to the vessel filter" },
   { "feature": "chart-image-adjustment", "pr": 489, "kind": "new", "since": "v3.0.0", "date": "2026-07-07", "title": "feat(charts): add brightness/contrast adjustment for raster image layers" },
+  { "feature": "chart-image-adjustment", "pr": 497, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-10", "title": "feat(charts): make image adjustment a modeless draggable palette" },
+  { "feature": "chart-image-adjustment", "pr": 510, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-12", "title": "feat(charts): trim image adjustment palette and remember its position" },
   { "feature": "weather-overlays", "pr": 491, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-11", "title": "feat(weather): add tidal currents overlay with time-stepping controls" },
   { "feature": "notes", "pr": 485, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-07", "title": "feat(notes): size Note Details dialog to fit its content" },
   { "feature": "notes", "pr": 512, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-12", "title": "feat(notes): add option to open note details on single click" },

--- a/features/chart-image-adjustment.md
+++ b/features/chart-image-adjustment.md
@@ -4,7 +4,7 @@ title: Chart Image Adjustment
 category: Charts
 ---
 
-![Fig 1. The Brightness/Contrast dialog, opened from the tune icon in the chart list](chart-image-adjustment-1.jpg)
+![Fig 1. The Image Adjustment palette, opened from the tune icon in the chart list](chart-image-adjustment-1.jpg)
 
 Aerial and satellite chart imagery is usually exposed for the land, which
 can leave the water — where the hazards are — looking crushed and nearly
@@ -14,15 +14,23 @@ anchorage.
 
 **To adjust a chart's image**, open the chart list and tap the **tune**
 icon next to a chart (it appears alongside the existing opacity control,
-for image-based charts only). A dialog offers **Brightness** and
-**Contrast** sliders with a live preview on the chart as you drag them, a
-**RESET** button to put both back to neutral, and **SAVE** to keep your
-changes.
+for image-based charts only). The chart list closes and a compact **Image
+Adjustment** palette opens over the map, headed by the name of the chart
+layer you're working on.
 
-Your adjustment is saved with that chart, alongside its opacity, so it's
-still applied the next time you open Freeboard. Left untouched, a chart
-looks exactly as it always has — the neutral default makes no visible
-change.
+The palette is modeless — there is no backdrop, so panning and zooming stay
+available while you adjust. Drag it by its header to move it clear of the
+water you're studying; it reopens wherever you last left it, even after a
+reload.
+
+**Brightness** and **Contrast** run from 0% to 200%, with 100% being
+neutral, and the chart updates live as you drag. **RESET** returns both to
+neutral. **SAVE** keeps your changes; closing the palette with its **close**
+button instead discards them and puts the chart back as it was.
+
+A saved adjustment is stored with that chart, alongside its opacity, so it's
+still applied the next time you open Freeboard. Left untouched, a chart looks
+exactly as it always has — the neutral default makes no visible change.
 
 This applies to raster, tile, WMS, and WMTS image charts. Vector charts
 (like S-57) don't have an image to adjust, so the control doesn't appear


### PR DESCRIPTION
The `chart-image-adjustment` feature doc still described the centred modal dialog that shipped in #489, so the Feature Browser told users to expect a UI that no longer exists. The ledger also had no rows for the two reworks that replaced it (#497, #510), leaving the feature's history incomplete.

The doc now describes current state: opening the **tune** control closes the chart list, the palette is modeless and draggable with its position remembered across reloads, the sliders run 0–200% around a neutral 100%, and closing the palette discards rather than saves. Two `enhanced` ledger rows added, both released in v3.0.0.

The existing screenshot needed no recapture — it was committed later, in #537, and already shows the trimmed post-#510 palette. Only its caption changed ("dialog" → "palette").

The online help's chart-control entry under *Resources / Layers* was checked against the code and is still accurate — the icon, its tooltip, and what it does are unchanged by both PRs — so `src/assets/help/index.html` is untouched.

Both surfaces verified in a running server before opening.

@coderabbitai ignore