### PR TITLE
docs(weather): document customizable current-overlay arrows

### DIFF
--- a/features/changelog.json
+++ b/features/changelog.json
@@ -16,6 +16,7 @@
   { "feature": "chart-image-adjustment", "pr": 497, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-10", "title": "feat(charts): make image adjustment a modeless draggable palette" },
   { "feature": "chart-image-adjustment", "pr": 510, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-12", "title": "feat(charts): trim image adjustment palette and remember its position" },
   { "feature": "weather-overlays", "pr": 491, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-11", "title": "feat(weather): add tidal currents overlay with time-stepping controls" },
+  { "feature": "weather-overlays", "pr": 523, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-14", "title": "feat(weather): make current-overlay arrows customizable symbols" },
   { "feature": "notes", "pr": 485, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-07", "title": "feat(notes): size Note Details dialog to fit its content" },
   { "feature": "notes", "pr": 512, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-12", "title": "feat(notes): add option to open note details on single click" },
   { "feature": "feature-browser", "pr": 528, "kind": "new", "since": "v3.0.0", "date": "2026-07-16", "title": "feat(features): add a searchable \"What's New\" feature browser" },

--- a/features/custom-map-symbols.md
+++ b/features/custom-map-symbols.md
@@ -48,13 +48,15 @@ choice and won't swap your custom icon back in later.
 | AIS vessels | Yes |
 | Aids to navigation | Yes |
 | Route start / turn / end points | Yes |
+| Wind, ocean current and tidal current arrows | Yes |
 | Special waypoint markers (start pin, start boat, sightings, alarms) | No |
 | Shaded chart areas | No |
 | Dots for moored vessels | No |
 
 Icons that normally rotate to a heading or bearing — your vessel, AIS
-targets, aids to navigation, route turn points — keep rotating correctly even
-when you've replaced them with your own artwork.
+targets, aids to navigation, route turn points, and the wind and current
+direction arrows — keep rotating correctly even when you've replaced them with
+your own artwork.
 
 ## Built-in icon names you can replace
 
@@ -99,9 +101,21 @@ real-aton / virtual-aton
 
 **Route points:** `route-start`, `route-waypoint`, `route-end`
 
-Your own vessel, AIS, aids-to-navigation, and route icons apply everywhere at
-once — Freeboard picks these automatically rather than letting you choose
-them per marker, so one custom icon covers every marker of that kind.
+**Weather indicators** — the direction arrows on the wind, ocean current and
+tidal current overlays:
+
+```
+windIndicator-arrow    oceanCurrentIndicator-arrow    tidalCurrentIndicator-arrow
+```
+
+The two current arrows are tinted by Freeboard to show speed, so draw
+replacements for those with a plain white fill — a pre-coloured glyph comes out
+muddy. The wind arrow isn't tinted and renders in your own colours.
+
+Your own vessel, AIS, aids-to-navigation, route and weather-indicator icons
+apply everywhere at once — Freeboard picks these automatically rather than
+letting you choose them per marker, so one custom icon covers every marker of
+that kind.
 
 ## Keeping icons through GPX import and export
 

--- a/features/weather-overlays.md
+++ b/features/weather-overlays.md
@@ -40,5 +40,11 @@ resources list):
   to see how currents shift through the day, with **Play** to animate
   through time and **Now** to jump back to the current moment.
 
+Both current arrows can also be replaced with custom artwork through a symbol
+provider plugin, each under its own well-known id — `oceanCurrentIndicator-arrow`
+and `tidalCurrentIndicator-arrow` — so the two overlays stay distinguishable
+when shown together. Because Freeboard tints these arrows to encode speed, draw
+a replacement with a plain white fill; a pre-coloured glyph comes out muddy.
+
 All three overlays refresh automatically as you pan or zoom, and can be
 shown together or independently.


### PR DESCRIPTION
The ocean-current and tidal-current flow arrows became provider-overridable
symbols in #523, but neither doc said so: **Wind, Currents & Tides** described
only the wind arrow's override, and **Custom Map Symbols** listed no weather
indicators at all — not even `windIndicator-arrow`, overridable since #520.

Wind, Currents & Tides now names both current-arrow ids and the white-fill
requirement (Freeboard tints these arrows to encode speed, so a pre-coloured
glyph comes out muddy). Custom Map Symbols gains the arrows in its coverage
table and its rotation note, plus a **Weather indicators** block listing all
three ids in the replaceable-names reference.

The ledger records #523 against `weather-overlays` only. Custom Map Symbols is
catching up to current state — the symbols capability itself did not change,
the overlays opted into it.

Verified in a local build: both docs render correctly in the Feature Browser
and the #523 row appears in the Wind, Currents & Tides history table.

@coderabbitai ignore