### PR TITLE
docs(routes): document the long left-click vertex delete

### DIFF
--- a/features/changelog.json
+++ b/features/changelog.json
@@ -22,6 +22,7 @@
   { "feature": "feature-browser", "pr": 528, "kind": "new", "since": "v3.0.0", "date": "2026-07-16", "title": "feat(features): add a searchable \"What's New\" feature browser" },
   { "feature": "feature-browser", "pr": 530, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-17", "title": "feat(features): replace forced onboarding modals with a passive What's New indicator" },
   { "feature": "chart-zoom-limits", "kind": "new", "since": "v2.1.0", "date": "2023-07-06", "title": "limit zoom to selected maps" },
+  { "feature": "route-planning", "pr": 580, "kind": "enhanced", "date": "2026-07-25", "title": "feat(map): delete a route vertex with a long left-click, matching touch" },
   { "feature": "route-planning", "pr": 582, "kind": "enhanced", "date": "2026-07-25", "title": "feat(routes): unify the route draw and modify helper panels" },
   { "feature": "route-planning", "pr": 584, "kind": "enhanced", "date": "2026-07-25", "title": "feat(routes): add undo for route drawing and editing" },
   { "feature": "route-planning", "pr": 593, "kind": "enhanced", "date": "2026-07-25", "title": "feat(routes): add a Hide action to the route popover" },

--- a/features/route-planning.md
+++ b/features/route-planning.md
@@ -30,9 +30,12 @@ chart — it won't disappear on you.
 
 **Modifying a route** uses the same editing card as drawing, showing the
 running distance and the leg you're working on. Drag a point to move it,
-drag a leg to add a point, or Ctrl-Click (press-and-hold) a point to remove
-it. To **extend the route**, click open water past its end: the route grows
-by a new end point, the same way you drew it, without leaving Modify.
+drag a leg to add a point, or remove a point with Ctrl-Click or a
+press-and-hold. Both delete gestures work the same with a mouse, a
+touchscreen or a pen; a press that turns into a drag moves the point instead
+of deleting it. To **extend the route**, click open water past its end: the
+route grows by a new end point, the same way you drew it, without leaving
+Modify.
 **Undo** steps back through your edits one at a time. The card's commit
 action saves your changes — labelled **Save** for a route that isn't stored
 yet, **Finish** for one that is — and **Cancel** (or the ✕) discards them,


### PR DESCRIPTION
The route-planning doc described removing a point as "Ctrl-Click
(press-and-hold)", which reads as though press-and-hold were merely the touch
gloss of Ctrl-Click. Since #580 they are two independent gestures and both work
with any pointer, so the doc now says so — and notes that a press which turns
into a drag moves the point instead of deleting it, which is the reassurance a
mouse user needs before trusting the gesture.

#580 was also missing from the ledger: the #600 pass recorded its five siblings
(#582, #584, #593, #597, #598) but not this one, leaving a gap in the Feature
Browser's history for route planning. The row carries no `since` — the change is
unreleased, matching its siblings.

No help impact: `src/assets/help/index.html` has no passage covering the vertex
delete gestures (the `#menus` Draw Menu entry is control-level and stays correct).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified route editing instructions for adding and removing points across mouse, touchscreen, and pen input.
  - Explained that dragging a point moves it rather than deleting it.
  - Documented deleting a route point with a long left-click, including touch-compatible behavior.
  - Clarified how routes can be extended by clicking beyond their endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->