### PR TITLE
docs(features): document the newest-changes strip in the Feature Browser

### DIFF
--- a/features/changelog.json
+++ b/features/changelog.json
@@ -21,6 +21,7 @@
   { "feature": "notes", "pr": 512, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-12", "title": "feat(notes): add option to open note details on single click" },
   { "feature": "feature-browser", "pr": 528, "kind": "new", "since": "v3.0.0", "date": "2026-07-16", "title": "feat(features): add a searchable \"What's New\" feature browser" },
   { "feature": "feature-browser", "pr": 530, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-17", "title": "feat(features): replace forced onboarding modals with a passive What's New indicator" },
+  { "feature": "feature-browser", "pr": 604, "kind": "enhanced", "date": "2026-07-27", "title": "feat(features): show a feature's newest changes above its instructions" },
   { "feature": "chart-zoom-limits", "kind": "new", "since": "v2.1.0", "date": "2023-07-06", "title": "limit zoom to selected maps" },
   { "feature": "route-planning", "pr": 580, "kind": "enhanced", "date": "2026-07-25", "title": "feat(map): delete a route vertex with a long left-click, matching touch" },
   { "feature": "route-planning", "pr": 582, "kind": "enhanced", "date": "2026-07-25", "title": "feat(routes): unify the route draw and modify helper panels" },

--- a/features/feature-browser.md
+++ b/features/feature-browser.md
@@ -12,8 +12,11 @@ chart.
 
 Each entry shows a screenshot, a plain description of what the feature does
 and how to use it, and the release it last changed in — click a screenshot
-to view it larger. Search narrows the list by name, and you can sort the
-table by category, feature, status, or release.
+to view it larger. When a feature has changed in the current release, its
+newest changes are listed at the top of the entry so you don't have to hunt
+for them; the complete history sits in a table at the bottom. Search narrows
+the list by name, and you can sort the table by category, feature, status,
+or release.
 
 A small lightbulb button also appears on the left toolbar whenever there's
 something new or changed you haven't seen yet — click it to jump straight


### PR DESCRIPTION
The Feature Browser's own entry described a details pane that no longer matches
what it renders: since #604 an entry also carries a strip of the feature's newest
changes above the instruction body, and the doc mentioned neither that strip nor
the History table the `+N more` affordance jumps to.

The doc now describes both, in one paragraph — deliberately without a hand-written
"New in 3.1" section (that is exactly what #604 removed from `route-planning.md`,
and the strip generates it from the ledger instead) and without the three-item cap,
which is implementation detail a boater doesn't need.

The ledger gains the #604 row so the change appears in the release notes and in the
entry's own history. It is left unstamped, so a release fills `since`; until then
"Since" stays v3.0.0, the newest released row.

No online-help change: the two Feature Browser references there are pointers into
the browser and are unaffected by what its details pane renders.

@coderabbitai ignore