### PR TITLE
fix(plotterext): hide saved routes from the default unfiltered state

### DIFF
--- a/src/app/modules/plotterext/plotterext.route-hide.spec.ts
+++ b/src/app/modules/plotterext/plotterext.route-hide.spec.ts
@@ -1,0 +1,127 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MatDialog } from '@angular/material/dialog';
+import { SignalKClient } from 'signalk-client-angular';
+
+import { PlotterExtensionService } from './plotterext.service';
+import { RouteBufferRegistry } from './route-buffer.registry';
+import { AppFacade } from '../../app.facade';
+import { SKResourceService } from '../skresources/resources.service';
+import { MapService } from '../map/ol/lib/map.service';
+import { SKStreamFacade } from '../skstream/skstream.facade';
+import { FBRoute, FBRoutes } from '../../types/resources/freeboard';
+
+/**
+ * Regression coverage for #592: `route.hide` on a saved route must take the
+ * route off the chart in the default "show all" state, not only once the Route
+ * list has been filtered.
+ *
+ * The trap: while `selections.routes === null` (unfiltered) `selectionRemove`
+ * is a no-op and `refreshRoutes()` re-derives the full set, so hiding through
+ * the raw selection API left the route displayed while the registry deleted its
+ * mirror and emitted `route.hidden` — host and extension disagreeing.
+ * `hideRoute` must go through `SKResourceService.routeHide`, which materialises
+ * the shown routes into an explicit selection first.
+ *
+ * The SKResourceService stub is a bare prototype with a mock app (same approach
+ * as resources-route-hide.spec) so the genuine `routeHide` logic runs rather
+ * than a fake standing in for it.
+ */
+const route = (id: string): FBRoute => [id, {}, true] as unknown as FBRoute;
+
+const HREF = 'rte-2';
+
+describe('PlotterExtensionService.hideRoute (#592)', () => {
+  let service: PlotterExtensionService;
+  let skres: SKResourceService;
+  let registry: RouteBufferRegistry;
+
+  /** @param selections null = unfiltered ("show all"), the default state. */
+  const setup = (selections: string[] | null) => {
+    skres = Object.create(SKResourceService.prototype) as SKResourceService;
+    const routeCacheSignal = signal<FBRoutes>([
+      route('rte-1'),
+      route(HREF),
+      route('rte-3')
+    ]);
+    Object.assign(skres as unknown as Record<string, unknown>, {
+      app: {
+        config: { selections: { routes: selections } },
+        saveConfig: () => undefined
+      },
+      routeCacheSignal,
+      routes: routeCacheSignal.asReadonly()
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        PlotterExtensionService,
+        RouteBufferRegistry,
+        {
+          provide: AppFacade,
+          useValue: {
+            config: { plotterExtensions: { widgets: [] } },
+            debug: () => {}
+          }
+        },
+        { provide: SignalKClient, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: SKResourceService, useValue: skres },
+        { provide: MapService, useValue: {} },
+        {
+          provide: SKStreamFacade,
+          useValue: {
+            selfNightMode: signal(false),
+            refreshSelfNightMode: () => {}
+          }
+        }
+      ]
+    });
+    service = TestBed.inject(PlotterExtensionService);
+    registry = TestBed.inject(RouteBufferRegistry);
+    // Mirror the saved route as an extension would see it after route.show.
+    registry.show({ routeId: HREF, name: 'Route 2', points: [], href: HREF });
+  };
+
+  const cacheIds = () => skres.routes().map((r: FBRoute) => r[0]);
+  const selection = () =>
+    (
+      skres as unknown as {
+        app: { config: { selections: { routes: string[] | null } } };
+      }
+    ).app.config.selections.routes;
+
+  describe('from an unfiltered ("show all") collection', () => {
+    beforeEach(() => setup(null));
+
+    it('removes the route from the displayed set', () => {
+      service.hideRoute(HREF);
+      expect(cacheIds()).toEqual(['rte-1', 'rte-3']);
+    });
+
+    it('makes the hide survive a route refresh', () => {
+      service.hideRoute(HREF);
+      // "Show all" became an explicit whitelist of what remains shown, so the
+      // hidden route is not restored when the cache is next re-derived.
+      expect(selection()).toEqual(['rte-1', 'rte-3']);
+    });
+
+    it('drops the registry mirror as a hidden-but-saved route', () => {
+      service.hideRoute(HREF);
+      expect(registry.get(HREF)).toBeUndefined();
+    });
+  });
+
+  // The filtered path already worked, but via a server round-trip; assert it
+  // keeps working and now updates the displayed set locally.
+  describe('from an already-filtered collection', () => {
+    beforeEach(() => setup(['rte-1', HREF, 'rte-3']));
+
+    it('still removes the route from the selection and the displayed set', () => {
+      service.hideRoute(HREF);
+      expect(selection()).toEqual(['rte-1', 'rte-3']);
+      expect(cacheIds()).toEqual(['rte-1', 'rte-3']);
+    });
+  });
+});

--- a/src/app/modules/plotterext/plotterext.service.ts
+++ b/src/app/modules/plotterext/plotterext.service.ts
@@ -901,8 +901,10 @@ export class PlotterExtensionService {
       return;
     }
     if (buf.saved && buf.href) {
-      this.skres.selectionRemove('routes', buf.href);
-      this.skres.refreshRoutes();
+      // routeHide (not a bare selectionRemove) — while the routes collection is
+      // unfiltered ("show all", the default) selectionRemove is a no-op, so the
+      // route would stay on the chart while the registry reported it hidden.
+      this.skres.routeHide(buf.href);
       this.routeRegistry.delete(routeId, true);
     } else {
       this.routeRegistry.delete(routeId, false);


### PR DESCRIPTION
The plotter-extensions `route.hide` managed a saved route's visibility through the
raw selection API. While the routes collection is unfiltered — `selections.routes
=== null`, the default "show all" — `selectionRemove` is a no-op and
`refreshRoutes()` re-derives the full set, so the route stayed on the chart while
the registry deleted its mirror and emitted `route.hidden`. Host and extension
disagreed, and the hide silently did nothing for any user who had never touched the
Route list checkboxes.

Routes it through `SKResourceService.routeHide()` — the durable path added for the
route popover's Hide action — which materialises the currently-shown routes into an
explicit selection before removing, so the hide survives a refresh. The Route list
checkboxes follow automatically, since they sync off the route-cache signal that
`routeHide` updates.

`route.show` is left alone deliberately: `selectionAdd` is likewise a no-op while
unfiltered, but an unfiltered collection already displays every route, so the
outcome is correct either way and a `routeShow()` counterpart would be
behaviourally identical to what is there.

Verified end-to-end against a local Signal K server, driving `route.hide` over the
host API from the unfiltered state: the route left the chart, `selections.routes`
materialised from `null` to an explicit whitelist excluding it, and the Route list
checkbox cleared.

Closes #592


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hiding of saved routes so they remain hidden after refreshing route data.
  * Ensured hidden routes are removed from displayed route lists and route registries.
  * Preserved existing behavior for hiding unsaved routes.

* **Tests**
  * Added regression coverage for hiding routes in both unfiltered and filtered views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->