### PR TITLE
fix(map): hold the follow-vessel offset fixed to the screen, not the boat

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,10 +1,6 @@
 import { FBAppData, IAppConfig, TemperatureUnitDef } from './types';
 import { Convert } from './lib/convert';
-import {
-  clampCenterOffset,
-  legacyCenterOffset,
-  legacyPanBehavior
-} from './lib/follow-offset';
+import { legacyPanBehavior, normaliseCenterOffset } from './lib/follow-offset';
 import { SKVessel } from './modules';
 import { DefaultOptions } from './modules/map/ol/lib/charts/s57.service';
 
@@ -151,18 +147,18 @@ export function cleanConfig(
   if (typeof settings.map.popoverMulti === 'undefined') {
     settings.map.popoverMulti = false;
   }
-  if (typeof settings.map.centerOffset === 'undefined') {
-    settings.map.centerOffset = 0;
-  } else if (!Number.isInteger(settings.map.centerOffset)) {
-    // A fractional value is the superseded 0-0.7 preset; the setting now holds
-    // a whole percentage.
-    settings.map.centerOffset = legacyCenterOffset(settings.map.centerOffset);
-  } else {
-    settings.map.centerOffset = clampCenterOffset(settings.map.centerOffset);
-  }
-  settings.map.centerOffsetAbeam = clampCenterOffset(
-    settings.map.centerOffsetAbeam ?? 0
+  // Coerce every superseded shape — the vessel-frame {ahead, abeam} pair, an
+  // even older single along-course percentage, or the 0-0.7 fractional preset —
+  // to the screen-fixed {x, y} offset.
+  const legacyAbeam = (
+    settings.map as unknown as { centerOffsetAbeam?: number }
+  ).centerOffsetAbeam;
+  settings.map.centerOffset = normaliseCenterOffset(
+    settings.map.centerOffset,
+    legacyAbeam
   );
+  delete (settings.map as unknown as { centerOffsetAbeam?: number })
+    .centerOffsetAbeam;
   if (typeof settings.map.doubleClickZoom === 'undefined') {
     settings.map.doubleClickZoom = false;
   }
@@ -532,8 +528,7 @@ export function defaultConfig(): IAppConfig {
       labelsMinZoom: 8,
       doubleClickZoom: false, // true=zoom
       overZoomTiles: true, // keep tiles visible beyond chart max zoom
-      centerOffset: 0,
-      centerOffsetAbeam: 0,
+      centerOffset: { x: 0, y: 0 },
       s57Options: {
         graphicsStyle: 'Paper',
         boundaries: 'Plain',

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -11,10 +11,9 @@ import { Subject } from 'rxjs';
 import { InfoService, IndexedDB, AppInfoDef } from './lib/services';
 import { isTrackShown, toggleTrackSelection } from './lib/vessel-track';
 import {
-  CenterOffset,
-  centerOffsetFromPan,
   MapViewport,
-  mapCenterForOffset
+  mapCenterForOffset,
+  resolvePan
 } from './lib/follow-offset';
 
 import {
@@ -902,12 +901,6 @@ export class AppFacade extends InfoService {
     );
   }
 
-  private activeVesselCourse(): number | null {
-    return (
-      this.data.vessels.active.cogTrue ?? this.data.vessels.active.headingTrue
-    );
-  }
-
   /**
    * The viewport an offset is measured against, or null until the map has
    * reported an extent — the viewport signals hold [0, 0] until then, which
@@ -930,55 +923,49 @@ export class AppFacade extends InfoService {
     };
   }
 
-  private get centerOffset(): CenterOffset {
-    return {
-      ahead: this.config.map.centerOffset ?? 0,
-      abeam: this.config.map.centerOffsetAbeam ?? 0
-    };
-  }
-
   /** Calculate the position to center the map.
    * @param applyOffset false to centre the vessel exactly, ignoring the
    * configured vessel centre offset.
    */
   calcMapCenter(applyOffset = true): Position {
     const position = this.data.vessels.active.position;
-    const cog = this.activeVesselCourse();
-    const offset = this.centerOffset;
+    const offset = this.config.map.centerOffset;
     const viewport =
-      applyOffset && (offset.ahead || offset.abeam) ? this.mapViewport() : null;
-    if (cog === null || !viewport) {
+      applyOffset && (offset.x || offset.y) ? this.mapViewport() : null;
+    if (!viewport) {
       return position;
     }
-    return mapCenterForOffset(position, cog, viewport, offset);
+    return mapCenterForOffset(position, viewport, offset);
   }
 
   /**
-   * Adopt a chart pan as the vessel centre offset.
-   * @returns true when the setting changed and needs persisting.
+   * Resolve a settled follow-mode pan.
+   * @returns 'release' when the vessel was dragged off screen (the caller drops
+   * follow mode), 'adopted' when a new screen-fixed offset was stored, or
+   * 'unchanged' when nothing needs persisting.
    */
-  setCenterOffsetFromPan(mapCenter: Position): boolean {
-    const cog = this.activeVesselCourse();
+  applyPanGesture(mapCenter: Position): 'release' | 'adopted' | 'unchanged' {
     const viewport = this.mapViewport();
-    if (cog === null || !viewport) {
-      return false;
+    if (!viewport) {
+      return 'unchanged';
     }
-    const offset = centerOffsetFromPan(
+    const outcome = resolvePan(
       this.data.vessels.active.position,
       mapCenter,
-      cog,
       viewport
     );
-    const current = this.centerOffset;
-    if (
-      offset === null ||
-      (offset.ahead === current.ahead && offset.abeam === current.abeam)
-    ) {
-      return false;
+    if (outcome.action === 'release') {
+      return 'release';
     }
-    this.config.map.centerOffset = offset.ahead;
-    this.config.map.centerOffsetAbeam = offset.abeam;
-    return true;
+    if (outcome.action === 'ignore') {
+      return 'unchanged';
+    }
+    const current = this.config.map.centerOffset;
+    if (outcome.offset.x === current.x && outcome.offset.y === current.y) {
+      return 'unchanged';
+    }
+    this.config.map.centerOffset = outcome.offset;
+    return 'adopted';
   }
 
   /**

--- a/src/app/lib/follow-offset.spec.ts
+++ b/src/app/lib/follow-offset.spec.ts
@@ -1,50 +1,41 @@
 import { describe, it, expect } from 'vitest';
-import { getGreatCircleBearing } from 'geolib';
 import {
   CENTER_OFFSET_LIMIT,
-  centerOffsetFromPan,
   clampCenterOffset,
-  edgeDistanceInDirection,
   legacyCenterOffset,
   legacyPanBehavior,
   mapCenterForOffset,
-  MapViewport
+  MapViewport,
+  normaliseCenterOffset,
+  resolvePan
 } from './follow-offset';
-import { Convert } from './convert';
 import { GeoUtils } from './geoutils';
 import { Position } from '../types';
 
 const VESSEL: Position = [-80.5, 25.0];
-const NORTH = 0;
+const HALF = 2000; // metres from the viewport centre to the edge, both axes
 const EAST = Math.PI / 2;
-const SOUTH = Math.PI;
-const WEST = Math.PI * 1.5;
 
-/** A square north-up viewport 2km to every edge, so a percentage of the edge
- *  distance means the same thing in any direction. */
-const SQUARE: MapViewport = {
-  halfWidth: 2000,
-  halfHeight: 2000,
-  rotation: 0
-};
-
-/** Distance (m) and bearing (radians) from the vessel to a resolved map centre. */
-const fromVessel = (centre: Position) => ({
-  distance: GeoUtils.distanceTo(VESSEL, centre),
-  bearing: Convert.degreesToRadians(getGreatCircleBearing(VESSEL, centre) ?? 0)
+/** A viewport of the given rotation and half-extents. */
+const vp = (
+  rotation = 0,
+  halfWidth = HALF,
+  halfHeight = HALF
+): MapViewport => ({
+  halfWidth,
+  halfHeight,
+  rotation
 });
 
-/** A heading-up viewport on an easterly course, taller than it is wide: the
- *  course points up the screen, and the two axes have different edge distances. */
-const ROTATED: MapViewport = {
-  halfWidth: 800,
-  halfHeight: 2000,
-  rotation: -EAST
-};
+/** A point `metres` from the vessel on `bearing`, via the same geodesy the
+ *  production code uses, so fixtures are exact rather than flat-earth. */
+const dest = (bearing: number, metres: number): Position =>
+  GeoUtils.destCoordinate(VESSEL, bearing, metres);
 
-/** A map centre panned `distance` metres from the vessel on `bearing`. */
-const panTo = (bearing: number, distance: number) =>
-  GeoUtils.destCoordinate(VESSEL, bearing, distance);
+const expectPos = (actual: Position, expected: Position, precision = 6) => {
+  expect(actual[0]).toBeCloseTo(expected[0], precision);
+  expect(actual[1]).toBeCloseTo(expected[1], precision);
+};
 
 describe('clampCenterOffset', () => {
   it('keeps the vessel on screen by clamping to the limit', () => {
@@ -57,12 +48,13 @@ describe('clampCenterOffset', () => {
     expect(clampCenterOffset(-12.6)).toBe(-13);
   });
 
-  it('falls back to no offset for a non-numeric entry', () => {
-    expect(clampCenterOffset(NaN)).toBe(0);
+  it('normalises a negative rounding residue to 0, not -0', () => {
+    // The residue a pan leaves on the axis the user did not move along.
+    expect(Object.is(clampCenterOffset(-0.2), 0)).toBe(true);
   });
 
-  it('normalises the -0 that rounding a hair of negative produces', () => {
-    expect(clampCenterOffset(-0.4)).toBe(0);
+  it('falls back to no offset for a non-numeric entry', () => {
+    expect(clampCenterOffset(NaN)).toBe(0);
   });
 });
 
@@ -88,186 +80,132 @@ describe('legacyPanBehavior', () => {
   });
 });
 
-describe('edgeDistanceInDirection', () => {
-  it('reaches the top edge on a northerly course in north-up', () => {
-    expect(edgeDistanceInDirection(1000, 500, NORTH, 0)).toBe(500);
+describe('normaliseCenterOffset', () => {
+  it('defaults an unset offset to centred', () => {
+    expect(normaliseCenterOffset(undefined)).toEqual({ x: 0, y: 0 });
   });
 
-  it('reaches the side edge on an easterly course in north-up', () => {
-    expect(edgeDistanceInDirection(1000, 500, EAST, 0)).toBe(1000);
+  it('maps the vessel-frame {ahead, abeam} pair onto the screen axes', () => {
+    // ahead → y (up the screen), abeam → x (across it).
+    expect(normaliseCenterOffset(50, 30)).toEqual({ x: 30, y: 50 });
   });
 
-  it('follows the rotation in heading-up, where the course is always up', () => {
-    // Heading-up rotates the view by -course, so the course direction is the
-    // top of the screen whatever the compass bearing.
-    expect(edgeDistanceInDirection(1000, 500, EAST, -EAST)).toBe(500);
+  it('lifts an even older single along-course percentage onto the y axis', () => {
+    expect(normaliseCenterOffset(50)).toEqual({ x: 0, y: 50 });
+  });
+
+  it('converts the superseded fractional preset before lifting it', () => {
+    expect(normaliseCenterOffset(0.5)).toEqual({ x: 0, y: 50 });
+  });
+
+  it('clamps and rounds an {x, y} offset', () => {
+    expect(normaliseCenterOffset({ x: 200, y: -12.6 })).toEqual({
+      x: 90,
+      y: -13
+    });
   });
 });
 
 describe('mapCenterForOffset', () => {
-  it('places the map centre ahead of the vessel for a positive ahead offset', () => {
-    const { distance, bearing } = fromVessel(
-      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 50, abeam: 0 })
-    );
-    expect(distance).toBeCloseTo(1000, -1);
-    expect(bearing).toBeCloseTo(NORTH, 2);
-  });
-
-  it('places the map centre astern for a negative ahead offset', () => {
-    const { distance, bearing } = fromVessel(
-      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: -50, abeam: 0 })
-    );
-    expect(distance).toBeCloseTo(1000, -1);
-    expect(bearing).toBeCloseTo(SOUTH, 2);
-  });
-
-  it('places the map centre to starboard for a positive abeam offset', () => {
-    const { distance, bearing } = fromVessel(
-      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 0, abeam: 50 })
-    );
-    expect(distance).toBeCloseTo(1000, -1);
-    expect(bearing).toBeCloseTo(EAST, 2);
-  });
-
-  it('places the map centre to port for a negative abeam offset', () => {
-    const { bearing } = fromVessel(
-      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 0, abeam: -50 })
-    );
-    expect(bearing).toBeCloseTo(WEST, 2);
-  });
-
-  it('combines both axes into a diagonal offset', () => {
-    const { bearing } = fromVessel(
-      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 50, abeam: 50 })
-    );
-    // Equal parts ahead and to starboard puts the centre on the bow quarter.
-    expect(bearing).toBeCloseTo(Math.PI / 4, 2);
-  });
-
-  it('holds the offset in the vessel frame as the vessel turns', () => {
-    // The same "ahead" offset must point east once the vessel heads east, or a
-    // look-ahead would show the water already passed.
-    const { bearing } = fromVessel(
-      mapCenterForOffset(VESSEL, EAST, SQUARE, { ahead: 50, abeam: 0 })
-    );
-    expect(bearing).toBeCloseTo(EAST, 2);
-  });
-
   it('centres the vessel exactly when there is no offset', () => {
-    expect(
-      mapCenterForOffset(VESSEL, NORTH, SQUARE, { ahead: 0, abeam: 0 })
-    ).toEqual(VESSEL);
+    expect(mapCenterForOffset(VESSEL, vp(), { x: 0, y: 0 })).toEqual(VESSEL);
   });
 
-  it('holds a single-axis offset at the full limit without shrinking it', () => {
-    const { distance } = fromVessel(
-      mapCenterForOffset(VESSEL, NORTH, SQUARE, {
-        ahead: CENTER_OFFSET_LIMIT,
-        abeam: 0
-      })
-    );
-    expect(distance).toBeCloseTo(1800, -1);
+  it('places the centre up the screen for a positive y, north-up', () => {
+    // 50% of a 2000m half-viewport = 1000m up; north-up so up = north.
+    expectPos(mapCenterForOffset(VESSEL, vp(), { x: 0, y: 50 }), dest(0, 1000));
   });
 
-  it('shrinks a corner offset that would push the vessel off screen', () => {
-    // 90% ahead with 90% abeam lands diagonally outside the viewport corner,
-    // which neither per-axis clamp catches on its own.
-    const { distance, bearing } = fromVessel(
-      mapCenterForOffset(VESSEL, NORTH, SQUARE, {
-        ahead: CENTER_OFFSET_LIMIT,
-        abeam: CENTER_OFFSET_LIMIT
-      })
+  it('places the centre down the screen for a negative y', () => {
+    expectPos(
+      mapCenterForOffset(VESSEL, vp(), { x: 0, y: -50 }),
+      dest(Math.PI, 1000)
     );
-    const limit = (CENTER_OFFSET_LIMIT / 100) * 1.01;
-    expect(Math.abs(distance * Math.cos(bearing))).toBeLessThanOrEqual(
-      SQUARE.halfHeight * limit
+  });
+
+  it('places the centre to screen-right for a positive x, north-up', () => {
+    expectPos(
+      mapCenterForOffset(VESSEL, vp(), { x: 50, y: 0 }),
+      dest(EAST, 1000)
     );
-    expect(Math.abs(distance * Math.sin(bearing))).toBeLessThanOrEqual(
-      SQUARE.halfWidth * limit
+  });
+
+  it('follows the view rotation, not the course: up-screen is along-course in heading-up', () => {
+    // There is no course parameter: direction is fixed by the view rotation
+    // alone, so the offset can never rotate with COG. Heading-up rotates the
+    // view by -course, so a positive y points along the course (here east).
+    expectPos(
+      mapCenterForOffset(VESSEL, vp(-EAST), { x: 0, y: 50 }),
+      dest(EAST, 1000)
     );
-    // Still on the bow quarter — the shrink is uniform, not per axis.
-    expect(bearing).toBeCloseTo(Math.PI / 4, 2);
   });
 });
 
-describe('centerOffsetFromPan', () => {
-  it('reads a pan ahead of the vessel as a positive ahead offset', () => {
-    expect(
-      centerOffsetFromPan(VESSEL, panTo(NORTH, 1000), NORTH, SQUARE)
-    ).toEqual({ ahead: 50, abeam: 0 });
+describe('resolvePan', () => {
+  it('adopts an up-screen pan as a positive y offset, north-up', () => {
+    expect(resolvePan(VESSEL, dest(0, 1000), vp())).toEqual({
+      action: 'offset',
+      offset: { x: 0, y: 50 }
+    });
   });
 
-  it('reads a pan astern as a negative ahead offset', () => {
-    expect(
-      centerOffsetFromPan(VESSEL, panTo(SOUTH, 1000), NORTH, SQUARE)
-    ).toEqual({ ahead: -50, abeam: 0 });
+  it('adopts a down-screen pan as a negative y offset', () => {
+    expect(resolvePan(VESSEL, dest(Math.PI, 1000), vp())).toEqual({
+      action: 'offset',
+      offset: { x: 0, y: -50 }
+    });
   });
 
-  it('keeps the sideways part of a pan instead of discarding it', () => {
-    // The single-axis behaviour this replaces projected the pan onto the course
-    // and sprang the vessel back onto the course line (#615).
-    expect(
-      centerOffsetFromPan(VESSEL, panTo(EAST, 1000), NORTH, SQUARE)
-    ).toEqual({ ahead: 0, abeam: 50 });
+  it('keeps a sideways pan on the x axis instead of discarding it', () => {
+    expect(resolvePan(VESSEL, dest(EAST, 1000), vp())).toEqual({
+      action: 'offset',
+      offset: { x: 50, y: 0 }
+    });
   });
 
-  it('reads a pan to port as a negative abeam offset', () => {
-    expect(
-      centerOffsetFromPan(VESSEL, panTo(WEST, 1000), NORTH, SQUARE)
-    ).toEqual({ ahead: 0, abeam: -50 });
+  it('measures against the view rotation: an along-course pan is vertical in heading-up', () => {
+    expect(resolvePan(VESSEL, dest(EAST, 1000), vp(-EAST))).toEqual({
+      action: 'offset',
+      offset: { x: 0, y: 50 }
+    });
   });
 
-  it('resolves a diagonal pan into both axes', () => {
-    // 1000m on the bow quarter is ~707m on each axis, ~35% of a 2000m edge.
-    expect(
-      centerOffsetFromPan(VESSEL, panTo(Math.PI / 4, 1000), NORTH, SQUARE)
-    ).toEqual({ ahead: 35, abeam: 35 });
+  it('clamps an adopted offset that nears the edge but stays on screen', () => {
+    // 95% up the screen is still on screen; it sticks at the limit.
+    expect(resolvePan(VESSEL, dest(0, 1900), vp())).toEqual({
+      action: 'offset',
+      offset: { x: 0, y: CENTER_OFFSET_LIMIT }
+    });
   });
 
-  it('measures against the course, not the compass', () => {
-    expect(
-      centerOffsetFromPan(VESSEL, panTo(EAST, 1000), EAST, SQUARE)
-    ).toEqual({ ahead: 50, abeam: 0 });
+  it('releases follow mode when the pan drags the vessel past the top edge', () => {
+    // 105% up = off screen: drop follow rather than clamp the vessel back on.
+    expect(resolvePan(VESSEL, dest(0, 2100), vp())).toEqual({
+      action: 'release'
+    });
   });
 
-  it('clamps a pan that would push the vessel off screen', () => {
-    expect(
-      centerOffsetFromPan(VESSEL, panTo(NORTH, 4000), NORTH, SQUARE)?.ahead
-    ).toBe(CENTER_OFFSET_LIMIT);
+  it('releases follow mode when the pan drags the vessel past a side edge', () => {
+    expect(resolvePan(VESSEL, dest(EAST, 2100), vp())).toEqual({
+      action: 'release'
+    });
   });
 
-  it('leaves the setting alone when the vessel has no course', () => {
-    expect(
-      centerOffsetFromPan(VESSEL, panTo(NORTH, 1000), null, SQUARE)
-    ).toBeNull();
+  it('ignores a pan when the viewport edge distances are unusable', () => {
+    expect(resolvePan(VESSEL, dest(0, 1000), vp(0, 0, HALF))).toEqual({
+      action: 'ignore'
+    });
+    expect(resolvePan(VESSEL, dest(0, 1000), vp(0, HALF, NaN))).toEqual({
+      action: 'ignore'
+    });
   });
 
-  it('round-trips: applying a captured offset restores the panned-to centre', () => {
-    const panned = panTo(Math.PI / 4, 1000);
-    const offset = centerOffsetFromPan(VESSEL, panned, NORTH, SQUARE);
-    const centre = mapCenterForOffset(VESSEL, NORTH, SQUARE, offset!);
-    expect(centre[0]).toBeCloseTo(panned[0], 3);
-    expect(centre[1]).toBeCloseTo(panned[1], 3);
-  });
-
-  it('round-trips through a rotated, non-square viewport', () => {
-    // Heading-up on an easterly course, narrow screen: the two axes have
-    // different edge distances and neither aligns with north.
-    const panned = panTo(EAST + Math.PI / 5, 600);
-    const offset = centerOffsetFromPan(VESSEL, panned, EAST, ROTATED);
-    const centre = mapCenterForOffset(VESSEL, EAST, ROTATED, offset!);
-    expect(centre[0]).toBeCloseTo(panned[0], 3);
-    expect(centre[1]).toBeCloseTo(panned[1], 3);
-  });
-
-  it('constrains a pan that drags the vessel off a rotated viewport', () => {
-    // Dragged well beyond the narrow edge: the stored pair must be the one the
-    // renderer actually uses, or the vessel springs back from the drop point.
-    const panned = panTo(EAST + Math.PI / 4, 4000);
-    const offset = centerOffsetFromPan(VESSEL, panned, EAST, ROTATED)!;
-    const centre = mapCenterForOffset(VESSEL, EAST, ROTATED, offset);
-    const rendered = centerOffsetFromPan(VESSEL, centre, EAST, ROTATED)!;
-    expect(rendered.ahead).toBeCloseTo(offset.ahead, 0);
-    expect(rendered.abeam).toBeCloseTo(offset.abeam, 0);
+  it('round-trips an adopted offset through mapCenterForOffset', () => {
+    const offset = { x: 40, y: -25 };
+    const centre = mapCenterForOffset(VESSEL, vp(), offset);
+    expect(resolvePan(VESSEL, centre, vp())).toEqual({
+      action: 'offset',
+      offset
+    });
   });
 });

--- a/src/app/lib/follow-offset.ts
+++ b/src/app/lib/follow-offset.ts
@@ -1,21 +1,20 @@
 import { getGreatCircleBearing } from 'geolib';
 import { Convert } from './convert';
 import { GeoUtils } from './geoutils';
-import { MapPanBehavior, Position } from '../types';
+import { MapCenterOffset, MapPanBehavior, Position } from '../types';
 
 /**
- * Where the map centre sits relative to the vessel, as whole percentages of the
- * distance from the viewport centre to the screen edge. The offset is held in
- * the vessel's frame rather than the screen's, so it rotates with the boat —
- * a look-ahead has to stay ahead in north-up too, or a vessel heading south
- * would be shown the water it has already passed.
+ * The vessel centre offset is fixed in the *screen's* frame — `x` across the
+ * screen, `y` up it — each a whole percentage of the distance from the viewport
+ * centre to that edge. Because it is held in screen space the vessel keeps the
+ * on-screen spot it was panned to whatever its course does. Anchoring it to the
+ * boat's heading instead swings the chart about whenever the course is unknown
+ * or noisy (at rest, or barely moving) — which is exactly when you pan to look
+ * around. Positive `y` puts the map centre above the vessel (look ahead),
+ * positive `x` to its right.
  */
-export interface CenterOffset {
-  ahead: number; // along the course; negative places the centre astern
-  abeam: number; // to starboard of the course; negative places it to port
-}
 
-/** The viewport the offset is measured against. */
+/** The viewport an offset is measured against. */
 export interface MapViewport {
   halfWidth: number; // metres from the centre to the side edge
   halfHeight: number; // metres from the centre to the top edge
@@ -25,7 +24,7 @@ export interface MapViewport {
 /** Neither axis may exceed this share of the distance to the screen edge. */
 export const CENTER_OFFSET_LIMIT = 90;
 
-/** Round and clamp an entered or panned-to offset to a usable percentage. */
+/** Round and clamp an entered or panned-to offset axis to a usable percentage. */
 export function clampCenterOffset(value: number): number {
   if (!Number.isFinite(value)) {
     return 0;
@@ -57,188 +56,99 @@ export function legacyPanBehavior(lockMoveMap?: boolean): MapPanBehavior {
   return lockMoveMap ? 'offset' : 'exit';
 }
 
+/**
+ * Coerce any stored offset shape to the current screen-fixed `{x, y}` form:
+ * - unset → centred;
+ * - the `{ahead, abeam}` pair from the vessel-frame offset maps ahead→y, abeam→x;
+ * - a bare number is the oldest single along-course value (a 0–0.7 fractional
+ *   preset, otherwise a whole percentage) and lands on `y`, where it pointed in
+ *   heading-up;
+ * - an `{x, y}` offset is clamped.
+ * @param value the stored `centerOffset`
+ * @param abeam the stored `centerOffsetAbeam`, if the vessel-frame pair was used
+ */
+export function normaliseCenterOffset(
+  value: unknown,
+  abeam?: unknown
+): MapCenterOffset {
+  if (typeof value === 'number') {
+    return {
+      x: typeof abeam === 'number' ? clampCenterOffset(abeam) : 0,
+      y: Number.isInteger(value)
+        ? clampCenterOffset(value)
+        : legacyCenterOffset(value)
+    };
+  }
+  if (value && typeof value === 'object') {
+    const offset = value as Partial<MapCenterOffset>;
+    return {
+      x: clampCenterOffset(offset.x ?? 0),
+      y: clampCenterOffset(offset.y ?? 0)
+    };
+  }
+  return { x: 0, y: 0 };
+}
+
 const TWO_PI = Math.PI * 2;
-const QUARTER_TURN = Math.PI / 2;
 
 /** Normalise an angle to `[0, 2π)`. */
 const normalise = (radians: number): number =>
   ((radians % TWO_PI) + TWO_PI) % TWO_PI;
 
 /**
- * Geodetic distance from the viewport centre to the screen edge in the given
- * direction. This correctly handles any map rotation mode (north-up or
- * heading-up) and any screen aspect ratio.
- *
- * In OL, a CW bearing β has projected-space direction (sin β, cos β). With OL
- * view rotation rot (CCW), the screen-space components are:
- *   sx = sin(β + rot)  (rightward)   sy = cos(β + rot)  (upward)
- * The edge of the viewport rectangle lies at min(hw/|sx|, hh/|sy|).
- * @param halfWidth geodetic distance from the centre to the side edge
- * @param halfHeight geodetic distance from the centre to the top edge
- * @param bearing direction of interest in radians
- * @param rotation OL view rotation in radians
+ * Screen axes map to world bearings through the OL view rotation alone: a world
+ * bearing β projects to screen `(sin(β + rot), cos(β + rot))` = (right, up), so
+ * screen-up is world bearing `-rot` and screen-right is `π/2 - rot`. Both
+ * functions below share this — and neither takes the vessel's course, which is
+ * what keeps the offset fixed to the screen rather than the boat.
  */
-export function edgeDistanceInDirection(
-  halfWidth: number,
-  halfHeight: number,
-  bearing: number,
-  rotation: number
-): number {
-  const sx = Math.abs(Math.sin(bearing + rotation));
-  const sy = Math.abs(Math.cos(bearing + rotation));
-  return Math.min(
-    sx > 1e-10 ? halfWidth / sx : Infinity,
-    sy > 1e-10 ? halfHeight / sy : Infinity
-  );
-}
-
-/** The two axis offsets in metres, measured in the vessel's frame. */
-function offsetComponents(
-  course: number,
-  viewport: MapViewport,
-  offset: CenterOffset
-): { ahead: number; abeam: number } {
-  const { halfWidth, halfHeight, rotation } = viewport;
-  return {
-    ahead:
-      edgeDistanceInDirection(halfWidth, halfHeight, course, rotation) *
-      (offset.ahead / 100),
-    abeam:
-      edgeDistanceInDirection(
-        halfWidth,
-        halfHeight,
-        course + QUARTER_TURN,
-        rotation
-      ) *
-      (offset.abeam / 100)
-  };
-}
 
 /**
- * Shrink factor keeping the vessel on screen. Each axis is clamped against the
- * edge distance in its *own* direction, which is not enough once both are in
- * play: 90% ahead combined with 90% abeam lands diagonally outside the corner.
- * Offsets on a single axis are always within bounds, so this returns 1 for them
- * and only bites on a genuine corner offset.
- */
-function onScreenScale(
-  bearing: number,
-  distance: number,
-  viewport: MapViewport
-): number {
-  const { halfWidth, halfHeight, rotation } = viewport;
-  const fx =
-    halfWidth > 0
-      ? Math.abs(distance * Math.sin(bearing + rotation)) / halfWidth
-      : 0;
-  const fy =
-    halfHeight > 0
-      ? Math.abs(distance * Math.cos(bearing + rotation)) / halfHeight
-      : 0;
-  const excess = Math.max(fx, fy) / (CENTER_OFFSET_LIMIT / 100);
-  return excess > 1 ? 1 / excess : 1;
-}
-
-/**
- * Scale an offset pair back until the vessel is inside the viewport, so that a
- * stored offset is the one actually rendered. Panning the vessel clean off the
- * screen otherwise stores a pair the renderer then shrinks, and the vessel
- * springs back from where it was dropped.
- * @param offset the offset percentages to constrain
- * @param course vessel COG (or heading) in radians
- * @param viewport the current map viewport
- */
-export function constrainCenterOffset(
-  offset: CenterOffset,
-  course: number,
-  viewport: MapViewport
-): CenterOffset {
-  const { ahead, abeam } = offsetComponents(course, viewport, offset);
-  const distance = Math.hypot(ahead, abeam);
-  if (!distance || !Number.isFinite(distance)) {
-    return offset;
-  }
-  const scale = onScreenScale(
-    normalise(course + Math.atan2(abeam, ahead)),
-    distance,
-    viewport
-  );
-  return scale >= 1
-    ? offset
-    : {
-        ahead: clampCenterOffset(offset.ahead * scale),
-        abeam: clampCenterOffset(offset.abeam * scale)
-      };
-}
-
-/**
- * Resolve the configured offset to a map centre for the vessel's current
- * position and course.
+ * Resolve the configured offset to a map centre. `x`/`y` are shares of the
+ * viewport half-width / half-height, i.e. on-screen metres right and up; these
+ * combine into a world bearing through the view rotation, so the result never
+ * depends on the vessel's course.
  * @param vessel vessel position `[lon, lat]`
- * @param course vessel COG (or heading) in radians
  * @param viewport the current map viewport
  * @param offset the configured offset percentages
  */
 export function mapCenterForOffset(
   vessel: Position,
-  course: number,
   viewport: MapViewport,
-  offset: CenterOffset
+  offset: MapCenterOffset
 ): Position {
-  const { ahead, abeam } = offsetComponents(course, viewport, offset);
-  const distance = Math.hypot(ahead, abeam);
+  const right = (offset.x / 100) * viewport.halfWidth;
+  const up = (offset.y / 100) * viewport.halfHeight;
+  const distance = Math.hypot(right, up);
   if (!distance || !Number.isFinite(distance)) {
     return vessel;
   }
-  // atan2 carries the sign of both axes, so an astern or to-port offset needs
-  // no special case — it simply points the other way.
-  const bearing = normalise(course + Math.atan2(abeam, ahead));
+  // atan2 carries the sign of both axes, so a below-screen or to-the-left offset
+  // needs no special case — it simply points the other way.
   return GeoUtils.destCoordinate(
     vessel,
-    bearing,
-    distance * onScreenScale(bearing, distance, viewport)
+    normalise(-viewport.rotation + Math.atan2(right, up)),
+    distance
   );
 }
 
 /**
- * Derive the offset from a chart pan, by resolving the vessel → map-centre
- * displacement into its along-course and abeam components so the vessel stays
- * where the user dragged it.
- *
- * Returns null when the vessel has no course to measure against, in which case
- * the pan leaves the configured offset alone.
- * @param vessel vessel position `[lon, lat]`
- * @param mapCenter map centre the user panned to `[lon, lat]`
- * @param course vessel COG (or heading) in radians; null when not under way
- * @param viewport the current map viewport
+ * Raw pan offset in screen-edge percentages (`x` right, `y` up), before
+ * clamping — the inverse projection of {@link mapCenterForOffset}. `|value| > 100`
+ * on an axis means the pan dragged the vessel past that edge, i.e. off screen.
+ * Null when the viewport edge distances are unusable.
  */
-export function centerOffsetFromPan(
+function panScreenFraction(
   vessel: Position,
   mapCenter: Position,
-  course: number | null,
   viewport: MapViewport
-): CenterOffset | null {
-  if (course === null) {
-    return null;
-  }
+): MapCenterOffset | null {
   const { halfWidth, halfHeight, rotation } = viewport;
-  const aheadEdge = edgeDistanceInDirection(
-    halfWidth,
-    halfHeight,
-    course,
-    rotation
-  );
-  const abeamEdge = edgeDistanceInDirection(
-    halfWidth,
-    halfHeight,
-    course + QUARTER_TURN,
-    rotation
-  );
   if (
-    !aheadEdge ||
-    !abeamEdge ||
-    !Number.isFinite(aheadEdge) ||
-    !Number.isFinite(abeamEdge)
+    !halfWidth ||
+    !halfHeight ||
+    !Number.isFinite(halfWidth) ||
+    !Number.isFinite(halfHeight)
   ) {
     return null;
   }
@@ -247,15 +157,42 @@ export function centerOffsetFromPan(
   const bearing = Convert.degreesToRadians(
     getGreatCircleBearing(vessel, mapCenter) ?? 0
   );
-  const delta = bearing - course;
-  return constrainCenterOffset(
-    {
-      ahead: clampCenterOffset(
-        ((distance * Math.cos(delta)) / aheadEdge) * 100
-      ),
-      abeam: clampCenterOffset(((distance * Math.sin(delta)) / abeamEdge) * 100)
-    },
-    course,
-    viewport
-  );
+  const screenAngle = bearing + rotation;
+  return {
+    x: ((distance * Math.sin(screenAngle)) / halfWidth) * 100,
+    y: ((distance * Math.cos(screenAngle)) / halfHeight) * 100
+  };
+}
+
+/** How a settled follow-mode pan is interpreted. */
+export type PanResolution =
+  | { action: 'offset'; offset: MapCenterOffset }
+  | { action: 'release' }
+  | { action: 'ignore' };
+
+/**
+ * Resolve a settled follow-mode pan. A pan that leaves the vessel on screen is
+ * adopted as the screen-fixed centre offset (both axes kept, so a diagonal pan
+ * sticks); a pan that drags the vessel past a viewport edge releases follow mode
+ * rather than clamping the vessel back on; an unmeasurable view is ignored.
+ * @param vessel vessel position `[lon, lat]`
+ * @param mapCenter map centre the user panned to `[lon, lat]`
+ * @param viewport the current map viewport
+ */
+export function resolvePan(
+  vessel: Position,
+  mapCenter: Position,
+  viewport: MapViewport
+): PanResolution {
+  const raw = panScreenFraction(vessel, mapCenter, viewport);
+  if (raw === null) {
+    return { action: 'ignore' };
+  }
+  if (Math.abs(raw.x) > 100 || Math.abs(raw.y) > 100) {
+    return { action: 'release' };
+  }
+  return {
+    action: 'offset',
+    offset: { x: clampCenterOffset(raw.x), y: clampCenterOffset(raw.y) }
+  };
 }

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -682,7 +682,12 @@ export class FBMapComponent implements OnInit, OnDestroy {
       // The pan IS the offset gesture, so it also ends the post-tap grace.
       this.userPanned = false;
       this.stopOffsetGrace();
-      if (this.app.setCenterOffsetFromPan(e.lonlat as Position)) {
+      const outcome = this.app.applyPanGesture(e.lonlat as Position);
+      if (outcome === 'release') {
+        // Panned the vessel clean off screen: stop following and leave the
+        // chart where it is, rather than clamping the vessel back on screen.
+        this.exitMovingMap.emit(true);
+      } else if (outcome === 'adopted') {
         this.app.saveConfigDebounced();
       }
     }

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -486,29 +486,29 @@
                     </div>
                     <div class="setting-field-group">
                       <mat-form-field floatLabel="always">
-                        <mat-label>Ahead</mat-label>
+                        <mat-label>Vertical</mat-label>
                         <input
                           matInput
                           type="number"
-                          #centerOffset="ngModel"
+                          #centerOffsetY="ngModel"
                           [min]="-centerOffsetLimit"
                           [max]="centerOffsetLimit"
-                          [(ngModel)]="facade.settings.map.centerOffset"
-                          (change)="parseCenterOffset(centerOffset)"
-                          matTooltip="How far ahead of the vessel to centre the map, as a percentage of the distance to the screen edge. Use a negative value to look behind."
+                          [(ngModel)]="facade.settings.map.centerOffset.y"
+                          (change)="parseCenterOffset(centerOffsetY)"
+                          matTooltip="Where the vessel sits up or down the screen, as a percentage of the distance to the edge. Positive looks ahead (vessel lower); negative looks behind."
                         />
                       </mat-form-field>
                       <mat-form-field floatLabel="always">
-                        <mat-label>Abeam</mat-label>
+                        <mat-label>Horizontal</mat-label>
                         <input
                           matInput
                           type="number"
-                          #centerOffsetAbeam="ngModel"
+                          #centerOffsetX="ngModel"
                           [min]="-centerOffsetLimit"
                           [max]="centerOffsetLimit"
-                          [(ngModel)]="facade.settings.map.centerOffsetAbeam"
-                          (change)="parseCenterOffset(centerOffsetAbeam)"
-                          matTooltip="How far to one side of the vessel to centre the map, as a percentage of the distance to the screen edge. Positive is to starboard, negative to port."
+                          [(ngModel)]="facade.settings.map.centerOffset.x"
+                          (change)="parseCenterOffset(centerOffsetX)"
+                          matTooltip="Where the vessel sits left or right of centre, as a percentage of the distance to the edge. Positive shifts the map right (vessel left)."
                         />
                       </mat-form-field>
                     </div>

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -34,6 +34,15 @@ export type WindIndicator = 'arrow' | 'barb';
 // returns to it on the next position update).
 export type MapPanBehavior = 'offset' | 'exit' | 'none';
 
+// Screen-fixed offset of the map centre from the vessel: each axis is a whole
+// percentage of the distance from the viewport centre to that edge. `x` is
+// across the screen (positive = right), `y` up it (positive = above the vessel,
+// i.e. look ahead). Fixed to the screen, so it does not rotate with the course.
+export interface MapCenterOffset {
+  x: number;
+  y: number;
+}
+
 export interface SKApiResponse {
   state: 'FAILED' | 'COMPLETED' | 'PENDING';
   statusCode: number;
@@ -135,8 +144,7 @@ export interface IAppConfig {
     labelsMinZoom: number;
     doubleClickZoom: boolean; // true=zoom
     overZoomTiles: boolean; // keep tiles visible beyond chart max zoom
-    centerOffset: number; // whole % of the distance to the screen edge that the map centre sits ahead of the vessel (negative = astern)
-    centerOffsetAbeam: number; // as above, to starboard of the vessel's course (negative = to port)
+    centerOffset: MapCenterOffset; // screen-fixed map-centre offset from the vessel
     s57Options: Options; // S57 chart Options
     popoverMulti: boolean; // close popovers using cose button
   };


### PR DESCRIPTION
## Why

#616 made the follow-vessel offset two-axis (ahead + abeam), which is a real
improvement — but it holds the offset in the **vessel's frame**, so it rotates
with the course. The rationale there was that a look-ahead should stay ahead. That
holds underway, but it breaks down exactly when you most often pan to look at
something: **at rest or barely moving, the course is unknown or noisy**, so the
chart swings around the boat as COG jitters (or the offset is suppressed entirely
when there is no course, and follow snaps the vessel back to centre). AvNav and
similar plotters keep the panned offset fixed to the screen for this reason.

Worth noting: in heading-up the two models agree — "up the screen" is along the
course either way — so this only changes behaviour in north-up / low-speed, which
is where the vessel-frame version misbehaves.

## What changes

- The offset is measured in the **screen's frame** (`x` across, `y` up — each a
  percentage of the viewport half-extent) and resolved through the view rotation
  alone, so it never depends on the vessel's course. The boat holds the on-screen
  spot you panned it to whether stationary, drifting, or under way.
- Because the axes are independent screen fractions, a per-axis clamp always keeps
  the vessel on screen, so the corner-scaling machinery (`constrainCenterOffset` /
  `onScreenScale`) is no longer needed and is removed.
- **Panning the vessel off screen releases follow mode** (leaving the chart where
  you left it) rather than clamping it back on.

## Notes

- Config becomes `centerOffset: { x, y }`. The vessel-frame `centerOffset` /
  `centerOffsetAbeam` pair migrates (ahead → y, abeam → x), as do the older
  single-value and 0–0.7 fractional shapes. The two settings fields are now
  **Vertical** / **Horizontal**.
- No version change.

## Testing

- [x] `npm run test:ci` green (full suite); `follow-offset` unit tests cover the
  course-independent screen-frame resolution, the 2D pan round-trip, near-edge
  clamping, off-screen release, and the migration.
- [x] `npm run build:all` clean (AOT template typecheck of the new bindings).
- [x] Interactive: exercised on a live Signal K server — the offset holds its
  on-screen position at rest (the case #616 mishandles) and under way, and follow
  releases when the vessel is panned off screen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map vessel-center offsets now use screen-based vertical and horizontal positioning (x/y percentages).
  * Updated map settings let you configure vertical and horizontal offset percentages instead of ahead/abeam values.
  * While in follow mode, panning now adopts a valid clamped offset or automatically exits follow when the vessel would move out of view.
* **Bug Fixes**
  * Improved migration and coercion of older offset settings to the new x/y format for consistent map positioning.
  * Correct handling of normalized zero values to avoid “negative zero” behavior.
* **Tests**
  * Refreshed unit tests to cover the new offset normalization and pan-follow resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->