### PR TITLE
fix(course): convert Arrival Circle field to/from kilometers correctly

### DIFF
--- a/src/app/modules/course/course-settings.spec.ts
+++ b/src/app/modules/course/course-settings.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import { ChangeDetectorRef } from '@angular/core';
+import { beforeEach, describe, it, expect } from 'vitest';
+import { of } from 'rxjs';
+import {
+  MatBottomSheetRef,
+  MAT_BOTTOM_SHEET_DATA
+} from '@angular/material/bottom-sheet';
+
+import { CourseSettingsModal } from './course-settings';
+import { CourseService } from './course.service';
+import { SignalKClient } from 'signalk-client-angular';
+import { AppFacade } from 'src/app/app.facade';
+import { SKStreamFacade } from '../skstream/skstream.facade';
+import { DistanceUnitDef } from 'src/app/types';
+
+/**
+ * Harness for the Arrival Circle field's unit conversion (#639). arrivalCircle
+ * is always stored/streamed in meters (SignalK spec); the dialog must convert
+ * to/from the user's Distance preference on both the display path (ngOnInit)
+ * and the save path (onFormChange).
+ */
+function setup(distanceUnit: DistanceUnitDef, arrivalCircleMeters: number) {
+  const app = {
+    config: {
+      units: { distance: distanceUnit },
+      course: { arrivalCircle: arrivalCircleMeters }
+    },
+    skApiVersion: 2
+  };
+  TestBed.configureTestingModule({
+    providers: [
+      CourseSettingsModal,
+      { provide: AppFacade, useValue: app },
+      { provide: SKStreamFacade, useValue: { delta$: () => of() } },
+      {
+        provide: SignalKClient,
+        useValue: { api: { get: () => of({}), putWithContext: () => of({}) } }
+      },
+      {
+        provide: CourseService,
+        useValue: {
+          courseData: () => ({ arrivalCircle: arrivalCircleMeters })
+        }
+      },
+      {
+        provide: ChangeDetectorRef,
+        useValue: { detectChanges: () => undefined }
+      },
+      { provide: MatBottomSheetRef, useValue: { dismiss: () => undefined } },
+      { provide: MAT_BOTTOM_SHEET_DATA, useValue: { title: 'Course Settings' } }
+    ]
+  });
+  return TestBed.inject(CourseSettingsModal);
+}
+
+describe('CourseSettingsModal Arrival Circle unit conversion (#639)', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('converts meters to km for display when Distance preference is kilometer', () => {
+    const modal = setup('kilometer', 100);
+    modal.ngOnInit();
+    expect(modal.frmArrivalCircle).toBeCloseTo(0.1, 6); // 100 m -> 0.1 km, not 100
+  });
+
+  it('converts meters to nm for display when Distance preference is naut-mile', () => {
+    const modal = setup('naut-mile', 1852);
+    modal.ngOnInit();
+    expect(modal.frmArrivalCircle).toBeCloseTo(1, 6); // 1852 m -> 1 nm
+  });
+
+  it('converts km input back to meters on save when Distance preference is kilometer', () => {
+    const modal = setup('kilometer', 100);
+    modal.ngOnInit();
+    modal.onFormChange({ target: { id: 'arrivalCircle', value: '1' } });
+    expect(modal.app.config.course.arrivalCircle).toBeCloseTo(1000, 6); // 1 km -> 1000 m, not 1
+  });
+
+  it('converts nm input back to meters on save when Distance preference is naut-mile', () => {
+    const modal = setup('naut-mile', 1852);
+    modal.ngOnInit();
+    modal.onFormChange({ target: { id: 'arrivalCircle', value: '1' } });
+    expect(modal.app.config.course.arrivalCircle).toBeCloseTo(1852, 6); // 1 nm -> 1852 m
+  });
+});

--- a/src/app/modules/course/course-settings.spec.ts
+++ b/src/app/modules/course/course-settings.spec.ts
@@ -82,4 +82,11 @@ describe('CourseSettingsModal Arrival Circle unit conversion (#639)', () => {
     modal.onFormChange({ target: { id: 'arrivalCircle', value: '1' } });
     expect(modal.app.config.course.arrivalCircle).toBeCloseTo(1852, 6); // 1 nm -> 1852 m
   });
+
+  it('leaves the stored value untouched for non-finite input', () => {
+    const modal = setup('kilometer', 100);
+    modal.ngOnInit();
+    modal.onFormChange({ target: { id: 'arrivalCircle', value: '1e999' } }); // -> Infinity
+    expect(modal.app.config.course.arrivalCircle).toBe(100);
+  });
 });

--- a/src/app/modules/course/course-settings.ts
+++ b/src/app/modules/course/course-settings.ts
@@ -221,7 +221,11 @@ export class CourseSettingsModal implements OnInit {
         : this.course.courseData().arrivalCircle;
     this.frmArrivalCircle =
       this.app.config.units.distance === 'kilometer'
-        ? this.frmArrivalCircle
+        ? Number(
+            Convert.transform(this.frmArrivalCircle, 'm', 'kilometer').toFixed(
+              1
+            )
+          )
         : Number(
             Convert.transform(this.frmArrivalCircle, 'm', 'naut-mile').toFixed(
               1
@@ -284,10 +288,10 @@ export class CourseSettingsModal implements OnInit {
       if (e.target.value !== '' && e.target.value !== null) {
         let d =
           this.app.config.units.distance === 'kilometer'
-            ? Number(e.target.value)
+            ? Number(e.target.value) * 1000
             : Convert.nauticalMilesToKm(Number(e.target.value)) * 1000;
         d = d <= 0 ? null : d;
-        this.app.config.course.arrivalCircle = Number(e.target.value);
+        this.app.config.course.arrivalCircle = d;
 
         this.signalk.api
           .putWithContext(

--- a/src/app/modules/course/course-settings.ts
+++ b/src/app/modules/course/course-settings.ts
@@ -286,10 +286,14 @@ export class CourseSettingsModal implements OnInit {
     }
     if (e.target && e.target.id === 'arrivalCircle') {
       if (e.target.value !== '' && e.target.value !== null) {
+        const value = Number(e.target.value);
+        if (!Number.isFinite(value)) {
+          return;
+        }
         let d =
           this.app.config.units.distance === 'kilometer'
-            ? Number(e.target.value) * 1000
-            : Convert.nauticalMilesToKm(Number(e.target.value)) * 1000;
+            ? value * 1000
+            : Convert.nauticalMilesToKm(value) * 1000;
         d = d <= 0 ? null : d;
         this.app.config.course.arrivalCircle = d;
 


### PR DESCRIPTION
## Summary

The Arrival Circle field in Course Settings only converted meters <-> nautical miles for display and save. When the Distance preference was Kilometer, the raw meters value was shown/saved unconverted while still labeled "km" — e.g. a 100 m arrival circle displayed as "100 km", and typing "1" (intending 1 km) set a 1 meter arrival circle.

This also fixes the cached `app.config.course.arrivalCircle` value, which was set from the raw display-unit input instead of the converted meters value — the same value used elsewhere (`activateRoute`, `setDestination`) where it's expected to be in meters.

## Test plan

- [x] Added `course-settings.spec.ts` covering display (m->km, m->nm) and save (km->m, nm->m) conversion; verified it fails on pre-fix code and passes after.
- [x] `npm run test:ci` — all 443 tests pass.
- [x] `npm run build:web` — builds clean.

Closes #639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Arrival Circle distances now display correctly according to the selected unit preference.
  * Saved kilometer and nautical mile values are consistently converted to meters.
  * Non-positive distance values continue to be cleared appropriately.

* **Tests**
  * Added coverage for kilometer and nautical mile conversions during display and saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->