### PR TITLE
fix(map): keep the follow offset fixed on screen while zooming

### DIFF
--- a/features/changelog.json
+++ b/features/changelog.json
@@ -43,6 +43,7 @@
   { "feature": "follow-vessel", "pr": 601, "kind": "enhanced", "since": "v3.1.0-beta.0", "date": "2026-07-26", "title": "feat(map): single center/follow button and pan to set follow offset" },
   { "feature": "follow-vessel", "pr": 616, "kind": "enhanced", "since": "v3.1.0-beta.0", "date": "2026-07-27", "title": "feat(map): offset the vessel abeam as well as ahead when following" },
   { "feature": "follow-vessel", "pr": 638, "kind": "enhanced", "since": "v3.1.0-beta.1", "date": "2026-07-28", "title": "fix(map): hold the follow-vessel offset fixed to the screen, not the boat" },
+  { "feature": "follow-vessel", "pr": 642, "kind": "enhanced", "date": "2026-07-29", "title": "fix(map): keep the follow offset fixed on screen while zooming" },
   { "feature": "radar-overlay", "kind": "new", "since": "v2.19.7", "date": "2026-01-18", "title": "Initial RADAR API support" },
   { "feature": "radar-overlay", "kind": "enhanced", "since": "v2.24.0", "date": "2026-06-19", "title": "Radar control panel with overlay toggle, opacity and radar controls" },
   { "feature": "radar-overlay", "pr": 573, "kind": "enhanced", "since": "v3.1.0-beta.0", "date": "2026-07-25", "title": "feat(radar): Support Radar API 3.4.0 in the radar overlay (with pre-3.4.0 fallback)" },

--- a/features/follow-vessel.md
+++ b/features/follow-vessel.md
@@ -41,7 +41,8 @@ Both are measured against the **screen**, not your course — the offset holds t
 you set it to whether you're underway, drifting, or sitting still, instead of swinging
 around as your heading jitters at low speed or with no course at all. In heading-up mode
 this comes to the same thing as ahead/abeam, since "up the screen" already tracks your
-course; the difference only shows in north-up.
+course; the difference only shows in north-up. Zooming keeps the boat on that same spot
+too, scaling the chart around it rather than nudging the boat back toward center.
 
 ## Setting the offset by panning
 

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -13,6 +13,7 @@ import { isTrackShown, toggleTrackSelection } from './lib/vessel-track';
 import {
   MapViewport,
   mapCenterForOffset,
+  mapCenterForZoomShift,
   resolvePan
 } from './lib/follow-offset';
 
@@ -926,8 +927,11 @@ export class AppFacade extends InfoService {
   /** Calculate the position to center the map.
    * @param applyOffset false to centre the vessel exactly, ignoring the
    * configured vessel centre offset.
+   * @param zoomShift zoom levels about to be applied; when non-zero the centre is
+   * computed for the post-zoom viewport so the offset stays fixed on screen
+   * through the zoom rather than snapping back after it.
    */
-  calcMapCenter(applyOffset = true): Position {
+  calcMapCenter(applyOffset = true, zoomShift = 0): Position {
     const position = this.data.vessels.active.position;
     const offset = this.config.map.centerOffset;
     const viewport =
@@ -935,7 +939,9 @@ export class AppFacade extends InfoService {
     if (!viewport) {
       return position;
     }
-    return mapCenterForOffset(position, viewport, offset);
+    return zoomShift
+      ? mapCenterForZoomShift(position, viewport, offset, zoomShift)
+      : mapCenterForOffset(position, viewport, offset);
   }
 
   /**

--- a/src/app/lib/follow-offset.spec.ts
+++ b/src/app/lib/follow-offset.spec.ts
@@ -5,6 +5,7 @@ import {
   legacyCenterOffset,
   legacyPanBehavior,
   mapCenterForOffset,
+  mapCenterForZoomShift,
   MapViewport,
   normaliseCenterOffset,
   resolvePan
@@ -138,6 +139,60 @@ describe('mapCenterForOffset', () => {
       mapCenterForOffset(VESSEL, vp(-EAST), { x: 0, y: 50 }),
       dest(EAST, 1000)
     );
+  });
+});
+
+describe('mapCenterForZoomShift', () => {
+  it('is the plain offset centre when the zoom does not change', () => {
+    const offset = { x: 40, y: -25 };
+    expect(mapCenterForZoomShift(VESSEL, vp(), offset, 0)).toEqual(
+      mapCenterForOffset(VESSEL, vp(), offset)
+    );
+  });
+
+  it('halves the offset ground distance when zooming in one level', () => {
+    // 50% of a 2000m half-viewport is 1000m up; one level in halves the
+    // resolution, so the same screen offset now spans 500m.
+    expectPos(
+      mapCenterForZoomShift(VESSEL, vp(), { x: 0, y: 50 }, 1),
+      dest(0, 500)
+    );
+  });
+
+  it('doubles the offset ground distance when zooming out one level', () => {
+    expectPos(
+      mapCenterForZoomShift(VESSEL, vp(), { x: 0, y: 50 }, -1),
+      dest(0, 2000)
+    );
+  });
+
+  it('holds the vessel on the same on-screen spot through a zoom in', () => {
+    const offset = { x: 40, y: -25 };
+    const centre = mapCenterForZoomShift(VESSEL, vp(), offset, 1);
+    // The post-zoom viewport is half the size; the vessel must still sit at the
+    // configured offset within it.
+    expect(resolvePan(VESSEL, centre, vp(0, HALF / 2, HALF / 2))).toEqual({
+      action: 'offset',
+      offset
+    });
+  });
+
+  it('holds the vessel on the same on-screen spot through a zoom out', () => {
+    const offset = { x: 40, y: -25 };
+    const centre = mapCenterForZoomShift(VESSEL, vp(), offset, -1);
+    expect(resolvePan(VESSEL, centre, vp(0, HALF * 2, HALF * 2))).toEqual({
+      action: 'offset',
+      offset
+    });
+  });
+
+  it('preserves the offset through a zoom in a rotated (heading-up) view', () => {
+    const offset = { x: 40, y: -25 };
+    const centre = mapCenterForZoomShift(VESSEL, vp(-EAST), offset, 1);
+    expect(resolvePan(VESSEL, centre, vp(-EAST, HALF / 2, HALF / 2))).toEqual({
+      action: 'offset',
+      offset
+    });
   });
 });
 

--- a/src/app/lib/follow-offset.ts
+++ b/src/app/lib/follow-offset.ts
@@ -133,6 +133,35 @@ export function mapCenterForOffset(
 }
 
 /**
+ * The map centre that keeps a screen-fixed offset constant across a zoom of
+ * `zoomShift` levels (positive in, negative out). The view resolution changes by
+ * a factor of two per level, so the offset spans half the ground distance one
+ * level in and twice one level out; scaling the viewport by that factor before
+ * projecting the offset lands the vessel back on the same on-screen spot.
+ * @param vessel vessel position `[lon, lat]`
+ * @param viewport the current (pre-zoom) map viewport
+ * @param offset the configured offset percentages
+ * @param zoomShift zoom levels applied, e.g. `+1` for a single zoom-in step
+ */
+export function mapCenterForZoomShift(
+  vessel: Position,
+  viewport: MapViewport,
+  offset: MapCenterOffset,
+  zoomShift: number
+): Position {
+  const scale = 2 ** -zoomShift;
+  return mapCenterForOffset(
+    vessel,
+    {
+      ...viewport,
+      halfWidth: viewport.halfWidth * scale,
+      halfHeight: viewport.halfHeight * scale
+    },
+    offset
+  );
+}
+
+/**
  * Raw pan offset in screen-edge percentages (`x` right, `y` up), before
  * clamping — the inverse projection of {@link mapCenterForOffset}. `|value| > 100`
  * on an axis means the pan dragged the vessel past that edge, i.e. off screen.

--- a/src/app/lib/zoom-keys.spec.ts
+++ b/src/app/lib/zoom-keys.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { zoomKeyDirection } from './zoom-keys';
+
+/**
+ * The +/- keyboard-zoom guard: fires only for the bare +/- keys, never under a
+ * platform modifier (the browser's own page zoom should win) and never while a
+ * text-editing element has focus.
+ */
+describe('zoomKeyDirection', () => {
+  const ev = (o: Partial<Record<string, unknown>>): KeyboardEvent =>
+    ({
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      key: '',
+      target: null,
+      ...o
+    }) as unknown as KeyboardEvent;
+
+  it('maps + to zoom in and - to zoom out', () => {
+    expect(zoomKeyDirection(ev({ key: '+' }))).toBe('in');
+    expect(zoomKeyDirection(ev({ key: '-' }))).toBe('out');
+  });
+
+  it('ignores any other key', () => {
+    expect(zoomKeyDirection(ev({ key: '=' }))).toBeNull();
+    expect(zoomKeyDirection(ev({ key: 'a' }))).toBeNull();
+    expect(zoomKeyDirection(ev({ key: 'ArrowUp' }))).toBeNull();
+  });
+
+  it('leaves a platform-modifier chord to the browser', () => {
+    expect(zoomKeyDirection(ev({ key: '+', ctrlKey: true }))).toBeNull();
+    expect(zoomKeyDirection(ev({ key: '-', metaKey: true }))).toBeNull();
+    expect(zoomKeyDirection(ev({ key: '+', altKey: true }))).toBeNull();
+  });
+
+  it('is ignored while a text-editing target has focus', () => {
+    for (const tagName of ['INPUT', 'TEXTAREA', 'SELECT']) {
+      expect(
+        zoomKeyDirection(ev({ key: '+', target: { tagName } }))
+      ).toBeNull();
+    }
+    expect(
+      zoomKeyDirection(ev({ key: '-', target: { isContentEditable: true } }))
+    ).toBeNull();
+  });
+});

--- a/src/app/lib/zoom-keys.ts
+++ b/src/app/lib/zoom-keys.ts
@@ -1,0 +1,30 @@
+/**
+ * The zoom step a keydown requests — `'in'` for `+`, `'out'` for `-`, or `null`
+ * for anything else. Mirrors OpenLayers' KeyboardZoom key set (`+` / `-`) so
+ * routing these keys through the app's own zoom leaves *which* keys zoom
+ * unchanged. A platform-modifier chord (Ctrl/Cmd/Alt) is left alone so the
+ * browser's own page zoom still wins, as is a text-editing target so typing `-`
+ * in a field doesn't move the map.
+ */
+export function zoomKeyDirection(e: KeyboardEvent): 'in' | 'out' | null {
+  if (e.ctrlKey || e.metaKey || e.altKey) {
+    return null;
+  }
+  const el = e.target as HTMLElement | null;
+  const tag = el?.tagName;
+  if (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    !!el?.isContentEditable
+  ) {
+    return null;
+  }
+  if (e.key === '+') {
+    return 'in';
+  }
+  if (e.key === '-') {
+    return 'out';
+  }
+  return null;
+}

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -19,6 +19,7 @@
   (mapPointerDrag)="onMapPointerDrag()"
   (mapContextMenu)="onMapContextMenu($event)"
   (contextmenu)="onContextMenu($event)"
+  (keydown)="onZoomKeydown($event)"
   olView
   [zoom]="mapZoomLevel()"
   [center]="mapCenterPositon()"

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -2059,15 +2059,26 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   // handle map zoom controls
   protected zoomMap(zoomIn: boolean) {
-    if (zoomIn) {
-      if (this.app.config.map.zoomLevel < this.app.MAP_ZOOM_EXTENT.max) {
-        ++this.app.config.map.zoomLevel;
-      }
-    } else {
-      if (this.app.config.map.zoomLevel > this.app.MAP_ZOOM_EXTENT.min) {
-        --this.app.config.map.zoomLevel;
+    const { min, max } = this.app.MAP_ZOOM_EXTENT;
+    const current = this.app.config.map.zoomLevel;
+    const next = zoomIn
+      ? Math.min(current + 1, max)
+      : Math.max(current - 1, min);
+    if (next === current) {
+      return;
+    }
+    // Following with a screen offset: recompute the centre for the new zoom and
+    // set it in the same update as the zoom, so the vessel keeps its on-screen
+    // spot instead of zooming about the chart centre and snapping the offset
+    // back on the next position fix.
+    if (this.movingMap && !this.offsetSuppressed && !this.userPanned) {
+      const offset = this.app.config.map.centerOffset;
+      if (offset.x || offset.y) {
+        this.mapCenterPositon.set(this.app.calcMapCenter(true, next - current));
       }
     }
+    this.mapZoomLevel.set(next);
+    this.app.config.map.zoomLevel = next;
   }
 
   // orient map heading up / north up

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -49,6 +49,7 @@ import { Feature as GeoJsonFeature } from 'geojson';
 
 import { Convert, TARGET_UNIT } from 'src/app/lib/convert';
 import { GeoUtils, Angle } from 'src/app/lib/geoutils';
+import { zoomKeyDirection } from 'src/app/lib/zoom-keys';
 import { computeCursorEta, CursorEtaInfo } from './cursor-eta';
 import { CursorPin, tapFadeMs, TAP_MAX_DURATION } from './cursor-marker';
 import {
@@ -622,7 +623,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
       { name: 'dragpan' },
       { name: 'dragzoom' },
       { name: 'keyboardpan' },
-      { name: 'keyboardzoom' },
+      // keyboardzoom is handled by onZoomKeydown so +/- preserves the follow
+      // offset, the same as the on-screen zoom buttons.
       { name: 'mousewheelzoom' },
       { name: 'pinchzoom' }
     ];
@@ -2056,6 +2058,18 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   // ****** MAP control functions *******
+
+  // Bound to the map element's keydown (so it only fires when the map has focus,
+  // as OL's keyboardzoom did): route +/- through the same offset-preserving zoom
+  // as the on-screen buttons instead of OL zooming about the chart centre.
+  protected onZoomKeydown(e: KeyboardEvent) {
+    const direction = zoomKeyDirection(e);
+    if (!direction) {
+      return;
+    }
+    e.preventDefault();
+    this.zoomMap(direction === 'in');
+  }
 
   // handle map zoom controls
   protected zoomMap(zoomIn: boolean) {


### PR DESCRIPTION
Following with a screen-fixed vessel offset (#638), the zoom controls changed only the zoom level: OpenLayers rescaled the view about the chart centre, so the vessel drifted off its on-screen spot and the offset was only restored on the next position fix — a two-step jerk on every zoom.

Recompute the map centre for the target zoom and apply it in the same update as the zoom, so the vessel keeps its on-screen position throughout. One zoom level changes the view resolution by a factor of two, so a screen-fixed offset spans half the ground distance zooming in and twice zooming out; scaling the viewport by that factor before projecting the offset lands the vessel back on the same spot (new pure helper `mapCenterForZoomShift`).

This covers both centre-anchored discrete-zoom paths — the on-screen **+ / −** buttons and **keyboard `+` / `-`** (routed through the same path in place of OL's `KeyboardZoom`, which zoomed about the centre). Cursor-anchored gestures (mouse-wheel, pinch, double-click) are intentionally left as-is: preserving the offset there would override their zoom-toward-cursor anchor. Centred follow (no offset) and mid-pan are untouched.

Unit tests assert the recomputed centre holds the vessel at the same screen offset across a zoom in and out (including a rotated view) and cover the keyboard-zoom key guard. The button behaviour was verified by hand on a live instance; keyboard `+` / `-` was verified end-to-end against a deployed build (headless browser, real key events) — each press moves the zoom by exactly one level through the same path, with no double-handling from the removed OL interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
