### PR TITLE
fix(map): make route vertex editing work on touch devices

### DIFF
--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.spec.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.spec.ts
@@ -1,5 +1,9 @@
 import { expect, describe, it } from 'vitest';
-import { vertexDeleteCondition } from './interaction-modify.component';
+import { Collection } from 'ol';
+import {
+  PointerAwareModify,
+  vertexDeleteCondition
+} from './interaction-modify.component';
 import { vertexDeleted } from '../vertex-delete';
 
 // Minimal stand-in for the OL map: only get/set of the delete-on-release flag
@@ -72,5 +76,58 @@ describe('vertexDeleteCondition', () => {
     const map = fakeMap(false);
     vertexDeleteCondition(ev('click', { map }));
     expect(vertexDeleted(map)).toBe(false);
+  });
+});
+
+// #643: a fingertip lands further from a vertex than OL's 10px default allows,
+// so the press grabbed the segment and inserted a point instead of the vertex.
+// Whether a given press *snaps* can only be observed against a rendered map, so
+// these assert the tolerance the interaction will apply — including that the
+// field OL keeps it in still exists, which is what makes the switch work at all.
+describe('PointerAwareModify vertex tolerance', () => {
+  const toleranceOf = (m: PointerAwareModify) =>
+    (m as unknown as { pixelTolerance_: number }).pixelTolerance_;
+
+  function modify() {
+    return new PointerAwareModify({
+      features: new Collection(),
+      pixelTolerance: 10
+    });
+  }
+
+  // Interacting view => OL skips the hover re-snap, keeping the event harmless.
+  function pointerEv(pointerType?: string) {
+    return {
+      type: 'pointerdown',
+      originalEvent: pointerType ? { pointerType } : {},
+      map: { getView: () => ({ getInteracting: () => true }) }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  }
+
+  it('stores the constructed tolerance where OL can read it', () => {
+    // Canary: an OL upgrade that renames the field would otherwise leave every
+    // pointer silently stuck on the mouse radius.
+    expect(toleranceOf(modify())).toBe(10);
+  });
+
+  it('widens the tolerance to the touch radius for a touch pointer', () => {
+    const m = modify();
+    m.handleEvent(pointerEv('touch'));
+    expect(toleranceOf(m)).toBe(15);
+  });
+
+  it('keeps the mouse radius for a mouse pointer', () => {
+    const m = modify();
+    m.handleEvent(pointerEv('mouse'));
+    expect(toleranceOf(m)).toBe(10);
+  });
+
+  it('leaves the tolerance alone for an event carrying no pointer type', () => {
+    // A wheel or key event mid-gesture must not reset a touch gesture's radius.
+    const m = modify();
+    m.handleEvent(pointerEv('touch'));
+    m.handleEvent(pointerEv());
+    expect(toleranceOf(m)).toBe(15);
   });
 });

--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
@@ -11,6 +11,7 @@ import { Geometry } from 'ol/geom';
 import { Modify } from 'ol/interaction';
 import { ModifyEvent } from 'ol/interaction/Modify';
 import { MapComponent } from '../map.component';
+import { hitToleranceForPointer } from '../util';
 import { markVertexDeleted } from '../vertex-delete';
 
 /**
@@ -52,6 +53,48 @@ export const vertexDeleteCondition = (e: MapBrowserEvent<any>): boolean => {
   return false;
 };
 
+/** OpenLayers' own default `pixelTolerance`, kept for mouse pointers. */
+const MOUSE_VERTEX_TOLERANCE = 10;
+/** Touch radius, matching the tolerance the rest of the map uses for a finger. */
+const TOUCH_VERTEX_TOLERANCE = 15;
+
+/**
+ * `Modify` whose vertex tolerance follows the pointer in use (#643).
+ *
+ * One `pixelTolerance` for every pointer type is too tight for a finger: a press
+ * landing more than 10px from the vertex it aims at grabs the *segment* instead,
+ * which inserts a point. So a tap leaves a stray vertex behind, and a tap-hold
+ * removes that freshly inserted point rather than the vertex under the finger —
+ * the delete appears to do nothing.
+ *
+ * Both radii match `hitToleranceForPointer`, which keeps this aligned with the
+ * route-extend hit test — that guard must stay >= this tolerance or a single
+ * click can both insert a vertex and append an end point (#598).
+ *
+ * OL takes `pixelTolerance` only as a constructor option, so switching it per
+ * gesture means writing the field it is stored in. `interaction-modify.component.spec`
+ * asserts that field exists, so an OL upgrade that renames it fails the suite
+ * rather than silently reverting every pointer to the mouse radius.
+ */
+export class PointerAwareModify extends Modify {
+  override handleEvent(
+    event: MapBrowserEvent<KeyboardEvent | PointerEvent | WheelEvent>
+  ): boolean {
+    const pointerType = (event.originalEvent as PointerEvent)?.pointerType;
+    // Events carrying no pointer type (wheel, keyboard) must leave the tolerance
+    // as the gesture in progress set it.
+    if (pointerType) {
+      (this as unknown as { pixelTolerance_: number }).pixelTolerance_ =
+        hitToleranceForPointer(
+          pointerType,
+          MOUSE_VERTEX_TOLERANCE,
+          TOUCH_VERTEX_TOLERANCE
+        );
+    }
+    return super.handleEvent(event);
+  }
+}
+
 @Component({
   selector: 'ol-map > ol-modify',
   template: '<ng-content></ng-content>',
@@ -90,9 +133,10 @@ export class InteractionModifyComponent {
 
   addModifyInteraction() {
     if (undefined !== this.map) {
-      this.interaction = new Modify({
+      this.interaction = new PointerAwareModify({
         features: this.features,
-        deleteCondition: vertexDeleteCondition
+        deleteCondition: vertexDeleteCondition,
+        pixelTolerance: MOUSE_VERTEX_TOLERANCE
       });
       this.interaction.on('change', this.emitChangeEvent);
       this.interaction.on('modifystart', this.emitModifyStartEvent);

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -27,6 +27,7 @@ import { FeatureLike } from 'ol/Feature';
 import { Extent, getWidth } from 'ol/extent';
 import { hitToleranceForPointer, worldCopyOffset } from './util';
 import {
+  clearHeldVertexOnRelease,
   clearVertexDeleted,
   clearVertexDeletedOnDrag,
   startPointerGesture,
@@ -334,8 +335,9 @@ export class MapComponent implements OnInit, OnDestroy {
       this._pointerDown.update(() => e);
     });
   };
-  private pointerUpHandler = (event) => {
+  private pointerUpHandler = (event: PointerEvent) => {
     this.clearTouchTimer();
+    clearHeldVertexOnRelease(this.map, event);
   };
   private rightClickHandler = (event: MouseEvent) => {
     this.clearTouchTimer();

--- a/src/app/modules/map/ol/lib/vertex-delete.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.spec.ts
@@ -3,6 +3,7 @@ import { Map } from 'ol';
 import { Collection } from 'ol';
 import { Modify } from 'ol/interaction';
 import {
+  clearHeldVertexOnRelease,
   clearVertexDeleted,
   clearVertexDeletedOnDrag,
   markVertexDeleted,
@@ -75,6 +76,50 @@ describe('tryDeleteHeldVertexOnHold', () => {
     const map = fakeMap([]);
     expect(tryDeleteHeldVertexOnHold(map as Map, src('mouse'))).toBe(false);
     expect(map.get('vertexDeleteOnRelease')).toBeUndefined();
+  });
+});
+
+// #643: OL retires the grabbed-vertex dot only from a pointermove that lands
+// clear of the line. Touch emits none once the finger lifts, so the dot stayed
+// lit on a vertex nothing was holding, reading as a selection that could not be
+// dismissed. Re-arming the interaction is what drops it (OL clears the dot in
+// `setActive(false)`), so that toggle is the observable contract here.
+describe('clearHeldVertexOnRelease', () => {
+  function releaseOn(map: Map, pointerType: string) {
+    clearHeldVertexOnRelease(map, { pointerType } as PointerEvent);
+  }
+
+  it('drops the dot when a touch gesture ends', () => {
+    const modify = activeModify();
+    const setActive = vi.spyOn(modify, 'setActive');
+    const map = fakeMap([modify]);
+
+    releaseOn(map as Map, 'touch');
+    expect(setActive.mock.calls.map(([a]) => a)).toEqual([false, true]);
+  });
+
+  it('leaves a mouse release alone — moving the cursor away clears it', () => {
+    const modify = activeModify();
+    const setActive = vi.spyOn(modify, 'setActive');
+
+    releaseOn(fakeMap([modify]) as Map, 'mouse');
+    expect(setActive).not.toHaveBeenCalled();
+  });
+
+  it('leaves the dot when this release still has a vertex to delete', () => {
+    // A tap-hold whose immediate remove was refused deletes via deleteCondition
+    // on this release, which needs the dot — and this runs first.
+    const modify = activeModify();
+    const setActive = vi.spyOn(modify, 'setActive');
+    const map = fakeMap([modify]);
+    map.set('vertexDeleteOnRelease', true);
+
+    releaseOn(map as Map, 'touch');
+    expect(setActive).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no Modify is active', () => {
+    expect(() => releaseOn(fakeMap([]) as Map, 'touch')).not.toThrow();
   });
 });
 

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -78,6 +78,43 @@ export function clearVertexDeletedOnDrag(map: Pick<Map, 'get' | 'set'>): void {
   }
 }
 
+/** The Modify interaction currently editing, if any. */
+function activeModify(map: Map): Modify | undefined {
+  return map
+    .getInteractions()
+    .getArray()
+    .find((i) => i instanceof Modify && i.getActive()) as Modify | undefined;
+}
+
+/**
+ * Drop the "grabbed vertex" dot when a touch gesture ends (#643).
+ *
+ * OpenLayers retires that dot only from a `pointermove` landing clear of the
+ * line, so a mouse drops it the moment the cursor moves away. Touch emits no
+ * move after the finger lifts, leaving the dot lit on a vertex nothing is
+ * holding — and it reads as a selection the user cannot dismiss, because the tap
+ * that would clear it on a desktop instead extends the route (#549).
+ *
+ * A release with a delete still outstanding is left alone: `deleteCondition`
+ * needs the dot to remove the vertex on this very release, and this runs first
+ * (a viewport listener precedes OL's document-level `pointerup`).
+ *
+ * `setActive(false)` is OL's own documented way to drop the dot; re-arming
+ * immediately keeps the interaction ready for the next gesture, and the release
+ * still reaches `handleUpEvent`, so an edit this gesture made is unaffected.
+ */
+export function clearHeldVertexOnRelease(map: Map, src: PointerEvent): void {
+  if (src.pointerType !== 'touch' || map.get('vertexDeleteOnRelease')) {
+    return;
+  }
+  const modify = activeModify(map);
+  if (!modify) {
+    return;
+  }
+  modify.setActive(false);
+  modify.setActive(true);
+}
+
 /**
  * On a long press during route editing, remove the grabbed vertex.
  *
@@ -90,10 +127,7 @@ export function clearVertexDeletedOnDrag(map: Pick<Map, 'get' | 'set'>): void {
  * caller should not also open the context menu), `false` when there was none.
  */
 export function tryDeleteHeldVertexOnHold(map: Map, src: MouseEvent): boolean {
-  const modify = map
-    .getInteractions()
-    .getArray()
-    .find((i) => i instanceof Modify && i.getActive()) as Modify | undefined;
+  const modify = activeModify(map);
   if (!modify) {
     return false;
   }


### PR DESCRIPTION
Route vertex editing was effectively mouse-only. Two independent defects, both
predating #636 (which the issue suspected, but which touched neither `Modify`
nor any tolerance).

**A press that missed by more than 10px silently did nothing.** OL's `Modify`
applies one `pixelTolerance` — its 10px default — to every pointer type. A
fingertip routinely lands further out, and a press that misses the vertex grabs
the *segment* instead, which inserts a point. So a tap left a stray vertex
behind, and a tap-hold then removed that freshly inserted point rather than the
vertex under the finger: the route came out unchanged and the delete looked
broken. It also explains why an undo appeared to "fix" the gesture — the undo
was removing the stray point an earlier tap had inserted. The tolerance now
follows the pointer through the map's existing `hitToleranceForPointer`, so a
finger gets 15px and the mouse keeps 10.

**The grabbed-vertex dot never cleared.** OL retires it only on a `pointermove`
landing clear of the line, so a mouse drops it as soon as the cursor moves away
— but touch emits no move once the finger lifts, leaving the dot lit on a vertex
nothing was holding. It read as a selection that could not be dismissed, because
the tap that clears it on a desktop instead extends the route (#549). A touch
release now drops it, unless that release still has a vertex to delete.

Both radii remain equal to the route-extend hit test, preserving the #598
invariant that a single click cannot both insert a vertex and append an end
point. Confirmed on an iPhone; mouse behaviour is unchanged.

Closes #643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map vertex selection accuracy across mouse and touch input.
  * Touch interactions now use a wider hit area for easier vertex selection.
  * Fixed held-vertex deletion cleanup when releasing touch gestures.
  * Prevented unintended cleanup while a vertex is being deleted.

* **Tests**
  * Added coverage for pointer-specific hit tolerance and touch release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->