### PR TITLE
fix(map): let touch tap-hold delete a route vertex

### DIFF
--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -30,6 +30,7 @@ import {
   clearHeldVertexOnRelease,
   clearVertexDeleted,
   clearVertexDeletedOnDrag,
+  isTouchContextMenuWhileEditing,
   startPointerGesture,
   tryDeleteHeldVertexOnHold
 } from './vertex-delete';
@@ -264,10 +265,17 @@ export class MapComponent implements OnInit, OnDestroy {
   private touchTimer: any;
   private evCache: { [id: number]: MouseEvent } = {};
   private touchStartXY: { x: number; y: number } | null = null;
+  // The pointer type that opened the current gesture. A native `contextmenu`
+  // event carries no pointer type of its own, so it is read from here to tell a
+  // touch long-press apart from a mouse right-click.
+  private lastPointerType: string | undefined;
   private clearTouchTimer = () => {
     clearTimeout(this.touchTimer);
     this.evCache = {};
     this.touchStartXY = null;
+    // Reset with the rest of the gesture state so a later pointer-less
+    // `contextmenu` (the keyboard menu key) can't read a stale touch value.
+    this.lastPointerType = undefined;
   };
   /** Cancel the long-press only once the pointer has moved beyond a small
    *  tolerance. A press inevitably jitters a few pixels (and a press on a
@@ -313,6 +321,7 @@ export class MapComponent implements OnInit, OnDestroy {
     // the setTimeout that patches into the zone) would run outside it.
     this.ngZone.run(() => {
       this.evCache[event.pointerId] = event;
+      this.lastPointerType = event.pointerType;
       this.map.set('vertexDeleteOnRelease', false);
       startPointerGesture(this.map);
       this.touchStartXY = { x: event.clientX, y: event.clientY };
@@ -340,6 +349,16 @@ export class MapComponent implements OnInit, OnDestroy {
     clearHeldVertexOnRelease(this.map, event);
   };
   private rightClickHandler = (event: MouseEvent) => {
+    // A finger long-press makes the WebView fire a native `contextmenu` at the OS
+    // long-press timeout, well before the vertex-delete hold completes. Clearing
+    // the hold timer here would cancel the delete, so ignore that event while
+    // editing and let the hold run its course.
+    if (
+      isTouchContextMenuWhileEditing(this.map, event.type, this.lastPointerType)
+    ) {
+      event.preventDefault();
+      return;
+    }
     this.clearTouchTimer();
     this.emitRightClickEvent(event);
   };

--- a/src/app/modules/map/ol/lib/vertex-delete.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.spec.ts
@@ -6,6 +6,7 @@ import {
   clearHeldVertexOnRelease,
   clearVertexDeleted,
   clearVertexDeletedOnDrag,
+  isTouchContextMenuWhileEditing,
   markVertexDeleted,
   startPointerGesture,
   tryDeleteHeldVertexOnHold,
@@ -76,6 +77,48 @@ describe('tryDeleteHeldVertexOnHold', () => {
     const map = fakeMap([]);
     expect(tryDeleteHeldVertexOnHold(map as Map, src('mouse'))).toBe(false);
     expect(map.get('vertexDeleteOnRelease')).toBeUndefined();
+  });
+});
+
+// A touch long-press makes the Android WebView emit a *native* `contextmenu` at
+// ~500ms (the OS long-press timeout), a full second before the 1500ms
+// vertex-delete hold timer. Left to run, its handler clears that timer and the
+// delete never fires. While editing, that native touch contextmenu must be
+// ignored so the hold timer survives; every other case keeps working.
+describe('isTouchContextMenuWhileEditing', () => {
+  it('is true for a native touch contextmenu while a Modify is active', () => {
+    const map = fakeMap([activeModify()]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'contextmenu', 'touch')
+    ).toBe(true);
+  });
+
+  it('is false when no Modify is active — the not-editing menu is unchanged', () => {
+    const map = fakeMap([]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'contextmenu', 'touch')
+    ).toBe(false);
+  });
+
+  it('is false for a mouse contextmenu — a real right-click still opens the menu', () => {
+    const map = fakeMap([activeModify()]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'contextmenu', 'mouse')
+    ).toBe(false);
+  });
+
+  it("is false for touchHold's own pointerdown source, not a native contextmenu", () => {
+    const map = fakeMap([activeModify()]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'pointerdown', 'touch')
+    ).toBe(false);
+  });
+
+  it('is false for a contextmenu with no pointer type — the keyboard menu key', () => {
+    const map = fakeMap([activeModify()]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'contextmenu', undefined)
+    ).toBe(false);
   });
 });
 

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -87,6 +87,33 @@ function activeModify(map: Map): Modify | undefined {
 }
 
 /**
+ * Whether a `contextmenu` is the touch long-press artifact that must be ignored
+ * for the vertex-delete hold to survive.
+ *
+ * A finger long-press on the map makes the browser/WebView emit a **native**
+ * `contextmenu` at the OS long-press timeout (~500 ms) — a full second before the
+ * 1500 ms vertex-delete hold timer. Handled normally it clears that timer, so the
+ * delete never fires and the grabbed vertex is only ever dragged. While a route is
+ * being edited that native touch event is redundant with the hold timer and must
+ * be dropped. A mouse right-click (a deliberate action) and a touch long-press
+ * when not editing (opens the chart menu) both stay as they were.
+ *
+ * `eventType` separates the native DOM `contextmenu` from the synthetic
+ * pointer-down source that `touchHold` replays into this same handler.
+ */
+export function isTouchContextMenuWhileEditing(
+  map: Map,
+  eventType: string,
+  pointerType: string | undefined
+): boolean {
+  return (
+    eventType === 'contextmenu' &&
+    pointerType === 'touch' &&
+    !!activeModify(map)
+  );
+}
+
+/**
  * Drop the "grabbed vertex" dot when a touch gesture ends (#643).
  *
  * OpenLayers retires that dot only from a `pointermove` landing clear of the


### PR DESCRIPTION
On touch devices, long-pressing a route vertex in edit mode never deleted it — the vertex only moved.

## Why

A finger long-press makes the browser/WebView emit a **native `contextmenu`** at the OS long-press timeout (~500 ms) — a full second before the 1500 ms vertex-delete hold timer. Its handler (`rightClickHandler`) called `clearTouchTimer()`, so `touchHold` → `tryDeleteHeldVertexOnHold` never ran and the grabbed vertex was only ever dragged. The code assumed OL emits no `contextmenu` for touch — true for OL's synthetic events, but not for the one the WebView raises itself.

## How

While a route is being edited, ignore that native touch `contextmenu` (a small `isTouchContextMenuWhileEditing` predicate) so the hold timer survives. A mouse right-click and a touch long-press when *not* editing are untouched — the not-editing chart menu and measure paths are unchanged. Builds on #644.

The delete currently commits on finger-lift (the existing `vertexDeleteOnRelease` fallback); a follow-up will move it to the hold timeout with haptic + visual feedback.

## Test plan

- [x] `npm run test:ci` green; added unit tests for the predicate (native touch contextmenu while editing → ignored; mouse, not-editing, and the synthetic `touchHold` source → not ignored).
- [x] Verified on an Android WebView (marine plotter): tap-hold now deletes the grabbed vertex.
- [x] Not-editing chart context menu still opens on touch long-press.
- [x] Mouse right-click context menu unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch-based vertex editing by filtering native context menus triggered during long-press gestures.
  * Preserved existing right-click behavior for mouse interactions and touch actions outside active editing.
  * Prevented unintended context menus from interrupting vertex deletion gestures.

* **Tests**
  * Added coverage for touch and mouse context-menu scenarios during and outside route editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->