### PR TITLE
feat(map): show labels on note markers

### DIFF
--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -508,7 +508,13 @@
 
   <!-- Notes (display-filtered by plotter extensions) -->
   @if (showNoteslayer()) {
-    <fb-notes [notes]="plotterExt.visibleNotes()" [zIndex]="450"> </fb-notes>
+    <fb-notes
+      [notes]="plotterExt.visibleNotes()"
+      [labelMinZoom]="this.app.config.map.labelsMinZoom"
+      [mapZoom]="mapZoomLevel()"
+      [zIndex]="450"
+    >
+    </fb-notes>
   }
 
   <!-- Distance & Bearing to -->

--- a/src/app/modules/map/ol/lib/resources/layer-notes.component.spec.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-notes.component.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import VectorSource from 'ol/source/Vector';
+import Feature from 'ol/Feature';
+import { Style, Icon } from 'ol/style';
+import { FreeboardNoteLayerComponent } from './layer-notes.component';
+import { FBNotes } from 'src/app/types';
+
+/**
+ * `buildStyle()` applies a note's name as its label when the feature is built,
+ * for both the symbol and fallback-diamond styles. `updateLabels()` — inherited
+ * from FBFeatureLayerComponent and driven by the `labelMinZoom` / `mapZoom`
+ * inputs — then refreshes existing features when the zoom threshold is crossed.
+ *
+ * These are the pieces that have to keep agreeing for a label to appear: the id
+ * prefix `updateLabels()` matches on, the feature name both paths read, and the
+ * Text each style carries. This spec pins that contract so it can't silently
+ * drift apart again.
+ *
+ * Only plain instance fields are touched, so exercise the layer on a bare
+ * prototype instance — no Angular DI needed (same approach as the AIS filter
+ * spec alongside).
+ */
+function layer(fields: {
+  mapZoom: number;
+  labelMinZoom: number;
+  /** omit the symbol to exercise the fallback-diamond style */
+  symbol?: boolean;
+}) {
+  const c = Object.create(
+    FreeboardNoteLayerComponent.prototype
+  ) as FreeboardNoteLayerComponent;
+  Object.assign(c, {
+    source: new VectorSource(),
+    labelPrefixes: ['note'],
+    theme: { labelText: { color: '#000000' } },
+    mapImages: {
+      getSymbol: () =>
+        fields.symbol === false ? undefined : new Icon({ src: 'note.png' })
+    },
+    ...fields
+  });
+  return c as unknown as FreeboardNoteLayerComponent & {
+    source: VectorSource;
+    parseFBNotes: (n: FBNotes) => void;
+    updateLabels: () => void;
+  };
+}
+
+const notes = [
+  [
+    'abc123',
+    {
+      name: 'Cape Fear',
+      position: { latitude: 33.87, longitude: -78.0 },
+      properties: { skIcon: 'anchorage' }
+    }
+  ]
+] as unknown as FBNotes;
+
+function labelOf(source: VectorSource): string {
+  const f = source.getFeatures()[0] as Feature;
+  return ((f.getStyle() as Style).getText()?.getText() as string) ?? '';
+}
+
+describe('notes layer labels', () => {
+  it('labels a note with its name at or above the label zoom threshold', () => {
+    const c = layer({ mapZoom: 12, labelMinZoom: 10 });
+    c.parseFBNotes(notes);
+    c.updateLabels();
+    expect(labelOf(c.source)).toBe('Cape Fear');
+  });
+
+  it('clears the label below the threshold', () => {
+    const c = layer({ mapZoom: 8, labelMinZoom: 10 });
+    c.parseFBNotes(notes);
+    c.updateLabels();
+    expect(labelOf(c.source)).toBe('');
+  });
+
+  it('gives every note feature the id prefix updateLabels() matches on', () => {
+    const c = layer({ mapZoom: 12, labelMinZoom: 10 });
+    c.parseFBNotes(notes);
+    expect(c.source.getFeatures()[0].getId()).toBe('note.abc123');
+  });
+
+  it('labels a note whose icon could not be resolved', () => {
+    // The fallback diamond carries no other identification, so losing the
+    // label there leaves an anonymous marker.
+    const c = layer({ mapZoom: 12, labelMinZoom: 10, symbol: false });
+    c.parseFBNotes(notes);
+    expect(labelOf(c.source)).toBe('Cape Fear');
+  });
+
+  it('labels rebuilt features without waiting for updateLabels()', () => {
+    // Notes are re-fetched as the map moves, and ngOnChanges rebuilds every
+    // feature after super.ngOnChanges() has already run updateLabels(). A
+    // label applied only there goes out with the features it was applied to,
+    // so the freshly built feature has to carry its label immediately.
+    const c = layer({ mapZoom: 12, labelMinZoom: 10 });
+    c.parseFBNotes(notes);
+    expect(labelOf(c.source)).toBe('Cape Fear');
+  });
+});

--- a/src/app/modules/map/ol/lib/resources/layer-notes.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-notes.component.ts
@@ -74,27 +74,44 @@ export class FreeboardNoteLayerComponent extends FBFeatureLayerComponent {
   buildStyle(note: SKNote | NoteResource): Style {
     const icon = this.mapImages.getSymbol(note.properties?.skIcon ?? 'default');
     if (icon) {
-      return new Style({
-        image: icon,
-        text: new Text({
-          text: '',
-          offsetX: 0,
-          offsetY: -12
-        })
-      });
+      // Label here rather than leaving it to updateLabels(): notes are
+      // re-fetched as the map moves, and ngOnChanges rebuilds every feature
+      // after super.ngOnChanges() has run, so a label applied there is
+      // discarded with the features it was applied to.
+      return this.setTextLabel(
+        new Style({
+          image: icon,
+          text: new Text({
+            text: '',
+            offsetX: 0,
+            offsetY: -12
+          })
+        }),
+        note.name
+      );
     } else {
-      return new Style({
-        image: new RegularShape({
-          points: 4,
-          radius: 10,
-          fill: new Fill({ color: 'gold' }),
-          stroke: new Stroke({
-            color: 'black',
-            width: 1
+      // A note whose icon could not be resolved still needs its label: the
+      // fallback diamond carries no other identification.
+      return this.setTextLabel(
+        new Style({
+          image: new RegularShape({
+            points: 4,
+            radius: 10,
+            fill: new Fill({ color: 'gold' }),
+            stroke: new Stroke({
+              color: 'black',
+              width: 1
+            }),
+            rotation: (Math.PI / 180) * 45
           }),
-          rotation: (Math.PI / 180) * 45
-        })
-      });
+          text: new Text({
+            text: '',
+            offsetX: 0,
+            offsetY: -12
+          })
+        }),
+        note.name
+      );
     }
   }
 }


### PR DESCRIPTION
## What problem does this solve?

Note markers never display their name labels, at any zoom.

## How does it work?

Two things prevent it.

`<fb-notes>` is the only resource layer in `fb-map.component.html` not given the
`[labelMinZoom]` / `[mapZoom]` inputs, so the `ngOnChanges` branches that drive
`updateLabels()` in `FBFeatureLayerComponent` never fire.

Binding those alone isn't enough: `ngOnChanges` calls `super.ngOnChanges()` first and
*then* rebuilds every feature from the incoming notes, and unlike the sibling layers
the notes layer's `buildStyle()` doesn't apply the label. Notes are re-fetched as the
map moves, so a label applied by `updateLabels()` is discarded along with the features
it was applied to. This applies it in `buildStyle()`, as `fb-waypoints` does.

## How was this tested?

New spec for the notes layer's labelling contract — the id prefix `updateLabels()`
matches on, the feature name it reads, and the Text placeholder it writes into —
including that a rebuilt feature carries its label without waiting for
`updateLabels()`. That case fails before this change and passes after.

Also verified on a live Signal K server: built from this branch and installed over a
stock 3.0.1 install. Same chart, same view — a tide-station note published by a
plotter extension:

**Before** (stock 3.0.1 — icon renders, no label)

![before](https://raw.githubusercontent.com/dgshue/freeboard-sk/pr-assets/note-labels-before.png)

**After** (this PR — label renders)

![after](https://raw.githubusercontent.com/dgshue/freeboard-sk/pr-assets/note-labels-after.png)

Note: `test:ci` on current `master` already fails 8 tests in `whats-new.spec.ts` and
`plotterext.embedding-host.spec.ts`. Unrelated to this change and unaffected by it —
verified by running both specs on a clean `master` checkout.

## Checklist

- [x] One logical change; version numbers untouched.
- [x] Skimmed [`DEV-LESSONS-LEARNED.md`](../docs/freeboard/DEV-LESSONS-LEARNED.md) for traps relevant to this change.
- [x] Tests added/updated for new behaviour and `npm run test:ci` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map notes now display labels based on the configured zoom level.
  * Note labels update appropriately as the map zoom changes.
  * Labels appear for notes with icons and for notes using the fallback marker.

* **Bug Fixes**
  * Preserved note labels when map features are rebuilt or refreshed.
  * Improved label visibility when notes do not have an associated icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->