### PR TITLE
fix(map): delete a route vertex at the hold timeout, with a progress indicator and haptic

### DIFF
--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.spec.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.spec.ts
@@ -6,10 +6,9 @@ import {
 } from './interaction-modify.component';
 import { vertexDeleted } from '../vertex-delete';
 
-// Minimal stand-in for the OL map: only get/set of the delete-on-release flag
-// are read by the condition.
-function fakeMap(vertexDeleteOnRelease = false) {
-  const store: Record<string, unknown> = { vertexDeleteOnRelease };
+// Minimal stand-in for the OL map: get/set back the vertexDeletedInGesture flag.
+function fakeMap() {
+  const store: Record<string, unknown> = {};
   return {
     get: (k: string) => store[k],
     set: (k: string, v: unknown) => {
@@ -46,26 +45,12 @@ describe('vertexDeleteCondition', () => {
     expect(vertexDeleteCondition(ev('click', { ctrlKey: false }))).toBe(false);
   });
 
-  it('deletes on release when tap-hold flagged vertexDeleteOnRelease, and clears the flag', () => {
-    const map = fakeMap(true);
-    expect(vertexDeleteCondition(ev('pointerup', { map }))).toBe(true);
-    expect(map.get('vertexDeleteOnRelease')).toBe(false);
+  it('does not delete on a plain release — touch tap-hold deletes mid-hold, not here', () => {
+    expect(vertexDeleteCondition(ev('pointerup'))).toBe(false);
   });
 
-  it('does not delete on release when the tap-hold flag is not set', () => {
-    expect(
-      vertexDeleteCondition(ev('pointerup', { map: fakeMap(false) }))
-    ).toBe(false);
-  });
-
-  // #608: the release that deletes also produces a click, which the route
-  // extend handler would read as open water once the line has snapped away.
-  it('flags vertexDeletedInGesture when a tap-hold release deletes', () => {
-    const map = fakeMap(true);
-    vertexDeleteCondition(ev('pointerup', { map }));
-    expect(vertexDeleted(map)).toBe(true);
-  });
-
+  // #608: the click a Ctrl-Click delete produces would be read as open water
+  // once the line has snapped away, so the gesture is flagged to suppress it.
   it('flags vertexDeletedInGesture when Ctrl-Click deletes', () => {
     const map = fakeMap();
     vertexDeleteCondition(ev('click', { ctrlKey: true, map }));
@@ -73,7 +58,7 @@ describe('vertexDeleteCondition', () => {
   });
 
   it('leaves vertexDeletedInGesture unset when nothing is deleted', () => {
-    const map = fakeMap(false);
+    const map = fakeMap();
     vertexDeleteCondition(ev('click', { map }));
     expect(vertexDeleted(map)).toBe(false);
   });

--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
@@ -19,7 +19,7 @@ import { markVertexDeleted } from '../vertex-delete';
  *
  * This is the **Ctrl-Click** (mouse) path — a primary-button click, so OpenLayers
  * re-snaps the grabbed vertex to the point under the cursor before this runs. The
- * **Tap-hold** (touch/pen) path no longer goes through `deleteCondition`: it
+ * **Tap-hold** (touch/pen) path does not go through `deleteCondition`: it
  * removes the vertex directly, mid-hold, from the hold timer (see
  * `tryDeleteHeldVertexOnHold`).
  *

--- a/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
+++ b/src/app/modules/map/ol/lib/interactions/interaction-modify.component.ts
@@ -17,34 +17,22 @@ import { markVertexDeleted } from '../vertex-delete';
 /**
  * Decides whether a map event should delete the grabbed route vertex.
  *
- * Two delete gestures are supported, matching the on-screen instructions
- * ("Ctrl-Click or Tap-hold to remove point from a line"):
- * - **Ctrl-Click** (mouse) — a primary-button click, so OpenLayers re-snaps the
- *   grabbed vertex to the point under the cursor before this runs.
- * - **Tap-hold** (touch/pen) — map.component flags `vertexDeleteOnRelease`, which
- *   we consume on the following release. OL 10 emits no `contextmenu` for touch,
- *   so this is the only touch delete path.
+ * This is the **Ctrl-Click** (mouse) path — a primary-button click, so OpenLayers
+ * re-snaps the grabbed vertex to the point under the cursor before this runs. The
+ * **Tap-hold** (touch/pen) path no longer goes through `deleteCondition`: it
+ * removes the vertex directly, mid-hold, from the hold timer (see
+ * `tryDeleteHeldVertexOnHold`).
  *
  * A mouse right-click (`contextmenu`) is deliberately **not** a delete gesture: it
  * never re-snaps the grabbed vertex (its pointerdown is not a primary action), so
  * it would delete whatever vertex was last touched rather than the one clicked
  * (#575); and Freeboard already uses right-click for the map context menu.
  *
- * Either gesture flags `VERTEX_DELETED_IN_GESTURE` so the click the same release
+ * A delete flags `VERTEX_DELETED_IN_GESTURE` so the click the same release
  * produces is not also read as a route extension (#608).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const vertexDeleteCondition = (e: MapBrowserEvent<any>): boolean => {
-  if (
-    (e.type === 'pointerup' ||
-      e.type === 'singleclick' ||
-      e.type === 'click') &&
-    e.map.get('vertexDeleteOnRelease')
-  ) {
-    e.map.set('vertexDeleteOnRelease', false);
-    markVertexDeleted(e.map);
-    return true;
-  }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (e.type === 'click' && (e.originalEvent as any).ctrlKey) {
     markVertexDeleted(e.map);

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -30,10 +30,16 @@ import {
   clearHeldVertexOnRelease,
   clearVertexDeleted,
   clearVertexDeletedOnDrag,
+  hasGrabbedVertex,
   isTouchContextMenuWhileEditing,
   startPointerGesture,
   tryDeleteHeldVertexOnHold
 } from './vertex-delete';
+import {
+  completeVertexDeleteIndicator,
+  hideVertexDeleteIndicator,
+  showVertexDeleteIndicator
+} from './vertex-delete-indicator';
 
 export interface FBMapEvent extends MapEvent {
   lonlat: Coordinate;
@@ -262,7 +268,24 @@ export class MapComponent implements OnInit, OnDestroy {
   // Only arrow function works with addEventListener
 
   // Long Press Detection (iOS & Android)
-  private touchTimer: any;
+  // A deliberate hold deletes a grabbed vertex; a shorter hold in open water
+  // opens the chart context menu.
+  private readonly MODIFY_HOLD_MS = 1500;
+  private readonly MENU_HOLD_MS = 500;
+  // The delete-progress indicator is shown from the native long-press
+  // `contextmenu` (which fires with the OS long-press buzz), so the bar starts
+  // with that buzz. This fallback covers devices that emit no such event; it is
+  // long enough that a quick tap or the start of a vertex drag never flashes it.
+  private readonly INDICATOR_FALLBACK_MS = 650;
+  // A short double pulse confirming the vertex delete completed — distinct from
+  // the single OS long-press buzz. A no-op where web-page vibration is
+  // unsupported or suppressed (iOS Safari; some WebView-based browsers), which
+  // is harmless: the indicator turning red is the primary completion cue.
+  private readonly VERTEX_DELETE_HAPTIC = [45, 40, 60];
+  private touchTimer: ReturnType<typeof setTimeout>;
+  private indicatorTimer: ReturnType<typeof setTimeout>;
+  private indicatorShown = false;
+  private pointerDownTime = 0;
   private evCache: { [id: number]: MouseEvent } = {};
   private touchStartXY: { x: number; y: number } | null = null;
   // The pointer type that opened the current gesture. A native `contextmenu`
@@ -271,6 +294,13 @@ export class MapComponent implements OnInit, OnDestroy {
   private lastPointerType: string | undefined;
   private clearTouchTimer = () => {
     clearTimeout(this.touchTimer);
+    clearTimeout(this.indicatorTimer);
+    if (this.indicatorShown) {
+      // Hold cancelled (finger lifted early or moved off) — a completed delete
+      // clears this flag first, so this only fires when nothing was deleted.
+      hideVertexDeleteIndicator();
+      this.indicatorShown = false;
+    }
     this.evCache = {};
     this.touchStartXY = null;
     // Reset with the rest of the gesture state so a later pointer-less
@@ -305,12 +335,44 @@ export class MapComponent implements OnInit, OnDestroy {
     }
     const src = Object.values(this.evCache)[0];
     // During route editing a long hold removes the grabbed vertex; otherwise it
-    // opens the chart context menu.
-    if (tryDeleteHeldVertexOnHold(this.map)) {
+    // opens the chart context menu (null result = no active edit).
+    const removed = tryDeleteHeldVertexOnHold(this.map);
+    if (removed !== null) {
+      // Confirm only a real removal — OpenLayers can refuse (e.g. a two-point
+      // line), and a buzz + red trash on nothing deleted would be a lie.
+      if (removed) {
+        navigator.vibrate?.(this.VERTEX_DELETE_HAPTIC);
+        completeVertexDeleteIndicator();
+      } else {
+        hideVertexDeleteIndicator();
+      }
+      this.indicatorShown = false;
       return;
     }
     this.mapContextMenu.emit(src as any);
     this.rightClickHandler(src);
+  };
+  // Show the delete-progress indicator over a grabbed vertex, its bar timed to
+  // fill for the remainder of the hold. Triggered by the native long-press
+  // `contextmenu` (in step with the OS buzz), with a fallback timer; the guard
+  // keeps those two triggers from showing it twice.
+  private showDeleteIndicator = () => {
+    if (
+      this.indicatorShown ||
+      !this.map ||
+      !this.touchStartXY ||
+      !hasGrabbedVertex(this.map)
+    ) {
+      return;
+    }
+    const remaining =
+      this.MODIFY_HOLD_MS - (performance.now() - this.pointerDownTime);
+    showVertexDeleteIndicator(
+      this.touchStartXY.x,
+      this.touchStartXY.y,
+      Math.max(0, remaining)
+    );
+    this.indicatorShown = true;
   };
   private pointerDownHandler = (event) => {
     // Re-enter the Angular zone: schedules the long-press timer in-zone (so the
@@ -321,6 +383,7 @@ export class MapComponent implements OnInit, OnDestroy {
     this.ngZone.run(() => {
       this.evCache[event.pointerId] = event;
       this.lastPointerType = event.pointerType;
+      this.pointerDownTime = performance.now();
       startPointerGesture(this.map);
       this.touchStartXY = { x: event.clientX, y: event.clientY };
       // A vertex delete during Modify needs a deliberate long hold (1500 ms) so a
@@ -330,7 +393,16 @@ export class MapComponent implements OnInit, OnDestroy {
         .getInteractions()
         .getArray()
         .some((i) => i instanceof Modify && i.getActive());
-      this.touchTimer = setTimeout(this.touchHold, modifying ? 1500 : 500);
+      this.touchTimer = setTimeout(
+        this.touchHold,
+        modifying ? this.MODIFY_HOLD_MS : this.MENU_HOLD_MS
+      );
+      if (modifying) {
+        this.indicatorTimer = setTimeout(
+          this.showDeleteIndicator,
+          this.INDICATOR_FALLBACK_MS
+        );
+      }
       const rawCoord = this.map.getEventCoordinate(event);
       const c = toLonLat(rawCoord);
       const e = Object.assign(event, {
@@ -350,10 +422,12 @@ export class MapComponent implements OnInit, OnDestroy {
     // A finger long-press makes the WebView fire a native `contextmenu` at the OS
     // long-press timeout, well before the vertex-delete hold completes. Clearing
     // the hold timer here would cancel the delete, so ignore that event while
-    // editing and let the hold run its course.
+    // editing and let the hold run its course. This fires with the OS long-press
+    // buzz, so it is also where the delete-progress indicator starts.
     if (
       isTouchContextMenuWhileEditing(this.map, event.type, this.lastPointerType)
     ) {
+      this.showDeleteIndicator();
       event.preventDefault();
       return;
     }

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -293,7 +293,6 @@ export class MapComponent implements OnInit, OnDestroy {
       ) > 15
     ) {
       this.clearTouchTimer();
-      this.map.set('vertexDeleteOnRelease', false);
     }
   };
   private touchHold = () => {
@@ -307,7 +306,7 @@ export class MapComponent implements OnInit, OnDestroy {
     const src = Object.values(this.evCache)[0];
     // During route editing a long hold removes the grabbed vertex; otherwise it
     // opens the chart context menu.
-    if (tryDeleteHeldVertexOnHold(this.map, src)) {
+    if (tryDeleteHeldVertexOnHold(this.map)) {
       return;
     }
     this.mapContextMenu.emit(src as any);
@@ -322,7 +321,6 @@ export class MapComponent implements OnInit, OnDestroy {
     this.ngZone.run(() => {
       this.evCache[event.pointerId] = event;
       this.lastPointerType = event.pointerType;
-      this.map.set('vertexDeleteOnRelease', false);
       startPointerGesture(this.map);
       this.touchStartXY = { x: event.clientX, y: event.clientY };
       // A vertex delete during Modify needs a deliberate long hold (1500 ms) so a

--- a/src/app/modules/map/ol/lib/map.component.ts
+++ b/src/app/modules/map/ol/lib/map.component.ts
@@ -30,6 +30,7 @@ import {
   clearHeldVertexOnRelease,
   clearVertexDeleted,
   clearVertexDeletedOnDrag,
+  isTouchContextMenuWhileEditing,
   startPointerGesture,
   tryDeleteHeldVertexOnHold
 } from './vertex-delete';
@@ -264,10 +265,17 @@ export class MapComponent implements OnInit, OnDestroy {
   private touchTimer: any;
   private evCache: { [id: number]: MouseEvent } = {};
   private touchStartXY: { x: number; y: number } | null = null;
+  // The pointer type that opened the current gesture. A native `contextmenu`
+  // event carries no pointer type of its own, so it is read from here to tell a
+  // touch long-press apart from a mouse right-click.
+  private lastPointerType: string | undefined;
   private clearTouchTimer = () => {
     clearTimeout(this.touchTimer);
     this.evCache = {};
     this.touchStartXY = null;
+    // Reset with the rest of the gesture state so a later pointer-less
+    // `contextmenu` (the keyboard menu key) can't read a stale touch value.
+    this.lastPointerType = undefined;
   };
   /** Cancel the long-press only once the pointer has moved beyond a small
    *  tolerance. A press inevitably jitters a few pixels (and a press on a
@@ -313,6 +321,7 @@ export class MapComponent implements OnInit, OnDestroy {
     // the setTimeout that patches into the zone) would run outside it.
     this.ngZone.run(() => {
       this.evCache[event.pointerId] = event;
+      this.lastPointerType = event.pointerType;
       this.map.set('vertexDeleteOnRelease', false);
       startPointerGesture(this.map);
       this.touchStartXY = { x: event.clientX, y: event.clientY };
@@ -340,6 +349,16 @@ export class MapComponent implements OnInit, OnDestroy {
     clearHeldVertexOnRelease(this.map, event);
   };
   private rightClickHandler = (event: MouseEvent) => {
+    // A finger long-press makes the WebView fire a native `contextmenu` at the OS
+    // long-press timeout, well before the vertex-delete hold completes. Clearing
+    // the hold timer here would cancel the delete, so ignore that event while
+    // editing and let the hold run its course.
+    if (
+      isTouchContextMenuWhileEditing(this.map, event.type, this.lastPointerType)
+    ) {
+      event.preventDefault();
+      return;
+    }
     this.clearTouchTimer();
     this.emitRightClickEvent(event);
   };

--- a/src/app/modules/map/ol/lib/vertex-delete-indicator.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete-indicator.spec.ts
@@ -1,0 +1,54 @@
+import { expect, describe, it, beforeEach } from 'vitest';
+import {
+  completeVertexDeleteIndicator,
+  hideVertexDeleteIndicator,
+  showVertexDeleteIndicator
+} from './vertex-delete-indicator';
+
+const EL = '#fb-vertex-delete-indicator';
+
+describe('vertex delete indicator', () => {
+  beforeEach(() => {
+    hideVertexDeleteIndicator();
+  });
+
+  it('shows a positioned indicator with a fill timed to the hold and a trash icon', () => {
+    showVertexDeleteIndicator(120, 80, 1320);
+    const el = document.querySelector(EL) as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.style.left).toBe('120px');
+    expect(el.style.top).toBe('80px');
+    expect(el.querySelector('.fb-vdi-icon')).not.toBeNull();
+    const fill = el.querySelector('.fb-vdi-fill') as HTMLElement;
+    expect(fill.style.animationDuration).toBe('1320ms');
+  });
+
+  it('replaces an indicator already showing rather than stacking', () => {
+    showVertexDeleteIndicator(0, 0, 1000);
+    showVertexDeleteIndicator(0, 0, 1000);
+    expect(document.querySelectorAll(EL).length).toBe(1);
+  });
+
+  it('turns red on completion', () => {
+    showVertexDeleteIndicator(0, 0, 1000);
+    completeVertexDeleteIndicator();
+    expect(document.querySelector(EL)?.classList.contains('fb-vdi-done')).toBe(
+      true
+    );
+  });
+
+  it('removes the indicator when hidden', () => {
+    showVertexDeleteIndicator(0, 0, 1000);
+    hideVertexDeleteIndicator();
+    expect(document.querySelector(EL)).toBeNull();
+  });
+
+  it('injects its stylesheet only once', () => {
+    showVertexDeleteIndicator(0, 0, 1000);
+    hideVertexDeleteIndicator();
+    showVertexDeleteIndicator(0, 0, 1000);
+    expect(
+      document.querySelectorAll('#fb-vertex-delete-indicator-style').length
+    ).toBe(1);
+  });
+});

--- a/src/app/modules/map/ol/lib/vertex-delete-indicator.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete-indicator.ts
@@ -1,0 +1,119 @@
+// A transient on-screen indicator for the tap-hold vertex delete: a short
+// progress bar that fills over the hold with a trash icon beside it, sitting
+// just above the finger (which covers the grabbed vertex). It confirms "keep
+// holding to delete", then turns red the instant the delete lands.
+//
+// Built as plain DOM rather than an Angular component: it is tied to a raw
+// pointer gesture, positioned in screen space, and created/destroyed entirely
+// within MapComponent's gesture lifecycle — an overlay element sidesteps the
+// cross-component wiring and change-detection zone juggling a component needs
+// for something this short-lived.
+
+const STYLE_ID = 'fb-vertex-delete-indicator-style';
+const EL_ID = 'fb-vertex-delete-indicator';
+
+const CSS = `
+#${EL_ID} {
+  position: fixed;
+  transform: translate(-50%, calc(-100% - 22px));
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 9px;
+  border-radius: 9px;
+  background: rgba(28, 28, 30, 0.92);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+}
+#${EL_ID} .fb-vdi-track {
+  width: 78px;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.28);
+  overflow: hidden;
+}
+#${EL_ID} .fb-vdi-fill {
+  width: 100%;
+  height: 100%;
+  border-radius: 3px;
+  background: #ffffff;
+  transform-origin: left center;
+  transform: scaleX(0);
+  animation-name: fb-vdi-grow;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+@keyframes fb-vdi-grow {
+  to { transform: scaleX(1); }
+}
+#${EL_ID} .fb-vdi-icon {
+  width: 20px;
+  height: 20px;
+  fill: #b7b7bb;
+  flex: 0 0 auto;
+  transition: fill 90ms linear;
+}
+#${EL_ID}.fb-vdi-done .fb-vdi-fill {
+  animation: none;
+  transform: scaleX(1);
+  background: #ff4d4f;
+}
+#${EL_ID}.fb-vdi-done .fb-vdi-icon {
+  fill: #ff4d4f;
+}
+`;
+
+// A standard trash-can glyph.
+const TRASH_SVG =
+  '<svg class="fb-vdi-icon" viewBox="0 0 24 24" aria-hidden="true">' +
+  '<path d="M9 3v1H4v2h16V4h-5V3H9zM6 8v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V8H6zm3 2h2v9H9v-9zm4 0h2v9h-2v-9z"/>' +
+  '</svg>';
+
+function ensureStyle(): void {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = CSS;
+  document.head.appendChild(style);
+}
+
+/**
+ * Show the indicator above (`x`, `y`) — the press point — with the bar filling
+ * over `durationMs`. Replaces any indicator already showing.
+ */
+export function showVertexDeleteIndicator(
+  x: number,
+  y: number,
+  durationMs: number
+): void {
+  ensureStyle();
+  hideVertexDeleteIndicator();
+  const el = document.createElement('div');
+  el.id = EL_ID;
+  el.innerHTML = `<div class="fb-vdi-track"><div class="fb-vdi-fill"></div></div>${TRASH_SVG}`;
+  el.style.left = `${x}px`;
+  el.style.top = `${y}px`;
+  const fill = el.querySelector('.fb-vdi-fill') as HTMLElement | null;
+  if (fill) {
+    fill.style.animationDuration = `${durationMs}ms`;
+  }
+  document.body.appendChild(el);
+}
+
+/** Turn the indicator red to confirm the delete landed, then retire it. */
+export function completeVertexDeleteIndicator(): void {
+  const el = document.getElementById(EL_ID);
+  if (!el) {
+    return;
+  }
+  el.classList.add('fb-vdi-done');
+  setTimeout(() => el.remove(), 240);
+}
+
+/** Remove the indicator immediately (hold cancelled). */
+export function hideVertexDeleteIndicator(): void {
+  document.getElementById(EL_ID)?.remove();
+}

--- a/src/app/modules/map/ol/lib/vertex-delete.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.spec.ts
@@ -2,10 +2,12 @@ import { expect, describe, it, vi } from 'vitest';
 import { Map } from 'ol';
 import { Collection } from 'ol';
 import { Modify } from 'ol/interaction';
+import MapBrowserEventType from 'ol/MapBrowserEventType';
 import {
   clearHeldVertexOnRelease,
   clearVertexDeleted,
   clearVertexDeletedOnDrag,
+  hasGrabbedVertex,
   isTouchContextMenuWhileEditing,
   markVertexDeleted,
   startPointerGesture,
@@ -35,7 +37,7 @@ function activeModify(removePointResult = true): Modify {
 }
 
 describe('tryDeleteHeldVertexOnHold', () => {
-  it('removes the grabbed vertex mid-hold when a Modify is active', () => {
+  it('removes the grabbed vertex mid-hold and reports the removal when a Modify is active', () => {
     const modify = activeModify();
     const map = fakeMap([modify]);
 
@@ -43,34 +45,90 @@ describe('tryDeleteHeldVertexOnHold', () => {
     expect(modify.removePoint).toHaveBeenCalled();
   });
 
-  it("nulls the interaction's latched drag event so removePoint() is not refused", () => {
+  it('nulls the latched drag event BEFORE removePoint runs, so it is not refused', () => {
     // A finger jitter past OL's 1px tolerance leaves lastPointerEvent_ a
-    // POINTERDRAG, which removePoint() refuses; the helper clears it first.
-    const modify = activeModify();
+    // POINTERDRAG, which removePoint() refuses. The nulling must happen *before*
+    // the call — assert the state removePoint actually observes, not the state
+    // afterward (which a no-op mock leaves identical either way).
+    const modify = new Modify({ features: new Collection() });
+    vi.spyOn(modify, 'getActive').mockReturnValue(true);
+    let seenAtRemove: unknown = 'unset';
+    vi.spyOn(modify, 'removePoint').mockImplementation(() => {
+      seenAtRemove = (modify as unknown as { lastPointerEvent_: unknown })
+        .lastPointerEvent_;
+      return true;
+    });
     (modify as unknown as { lastPointerEvent_: unknown }).lastPointerEvent_ = {
       type: 'pointerdrag'
     };
     tryDeleteHeldVertexOnHold(fakeMap([modify]) as Map);
-    expect(
-      (modify as unknown as { lastPointerEvent_: unknown }).lastPointerEvent_
-    ).toBeNull();
+    expect(seenAtRemove).toBeNull();
   });
 
-  it('does not mark a delete when removePoint refuses (nothing grabbed)', () => {
+  it('reports false (nothing removed) when removePoint refuses, and marks no delete', () => {
     const map = fakeMap([activeModify(false)]);
-    tryDeleteHeldVertexOnHold(map as Map);
+    expect(tryDeleteHeldVertexOnHold(map as Map)).toBe(false);
     expect(vertexDeleted(map)).toBe(false);
   });
 
-  it('does nothing (opens context menu instead) when no Modify is active', () => {
+  it('returns null (caller opens the context menu) when no Modify is active', () => {
     const map = fakeMap([]);
-    expect(tryDeleteHeldVertexOnHold(map as Map)).toBe(false);
+    expect(tryDeleteHeldVertexOnHold(map as Map)).toBeNull();
   });
 
   it('relies on an OpenLayers field name that still exists (rename guard)', () => {
     expect(
       'lastPointerEvent_' in new Modify({ features: new Collection() })
     ).toBe(true);
+  });
+
+  it('removePoint removes only when the last event is not a drag — the OL guard the nudge defeats', () => {
+    // Behavioral canary beyond a rename: since the delete has no fallback, if a
+    // future OpenLayers changes *when* removePoint refuses, fail here rather than
+    // let the touch delete silently die. `removeVertex_` runs only past the guard.
+    const modify = new Modify({ features: new Collection() });
+    const removeVertex = vi
+      .spyOn(
+        modify as unknown as { removeVertex_: () => boolean },
+        'removeVertex_'
+      )
+      .mockReturnValue(false);
+
+    (modify as unknown as { lastPointerEvent_: unknown }).lastPointerEvent_ = {
+      type: MapBrowserEventType.POINTERDRAG
+    };
+    modify.removePoint();
+    expect(removeVertex).not.toHaveBeenCalled();
+
+    removeVertex.mockClear();
+    (modify as unknown as { lastPointerEvent_: unknown }).lastPointerEvent_ =
+      null;
+    modify.removePoint();
+    expect(removeVertex).toHaveBeenCalled();
+  });
+});
+
+describe('hasGrabbedVertex', () => {
+  it('is true when the active edit has a vertex grabbed under the pointer', () => {
+    const modify = activeModify();
+    (modify as unknown as { vertexFeature_: unknown }).vertexFeature_ = {};
+    expect(hasGrabbedVertex(fakeMap([modify]) as Map)).toBe(true);
+  });
+
+  it('is false when nothing is grabbed', () => {
+    const modify = activeModify();
+    (modify as unknown as { vertexFeature_: unknown }).vertexFeature_ = null;
+    expect(hasGrabbedVertex(fakeMap([modify]) as Map)).toBe(false);
+  });
+
+  it('is false when no Modify is active', () => {
+    expect(hasGrabbedVertex(fakeMap([]) as Map)).toBe(false);
+  });
+
+  it('relies on an OpenLayers field name that still exists (rename guard)', () => {
+    expect('vertexFeature_' in new Modify({ features: new Collection() })).toBe(
+      true
+    );
   });
 });
 

--- a/src/app/modules/map/ol/lib/vertex-delete.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.spec.ts
@@ -34,49 +34,43 @@ function activeModify(removePointResult = true): Modify {
   return modify;
 }
 
-function src(pointerType: string): MouseEvent {
-  return {
-    clientX: 10,
-    clientY: 20,
-    pointerType,
-    pointerId: 1
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any;
-}
-
 describe('tryDeleteHeldVertexOnHold', () => {
-  it('deletes the grabbed vertex on a long MOUSE hold — #578 parity with touch', () => {
+  it('removes the grabbed vertex mid-hold when a Modify is active', () => {
     const modify = activeModify();
     const map = fakeMap([modify]);
 
-    expect(tryDeleteHeldVertexOnHold(map as Map, src('mouse'))).toBe(true);
+    expect(tryDeleteHeldVertexOnHold(map as Map)).toBe(true);
     expect(modify.removePoint).toHaveBeenCalled();
   });
 
-  it('still deletes on a long touch hold', () => {
+  it("nulls the interaction's latched drag event so removePoint() is not refused", () => {
+    // A finger jitter past OL's 1px tolerance leaves lastPointerEvent_ a
+    // POINTERDRAG, which removePoint() refuses; the helper clears it first.
     const modify = activeModify();
-    const map = fakeMap([modify]);
-
-    expect(tryDeleteHeldVertexOnHold(map as Map, src('touch'))).toBe(true);
-    expect(modify.removePoint).toHaveBeenCalled();
+    (modify as unknown as { lastPointerEvent_: unknown }).lastPointerEvent_ = {
+      type: 'pointerdrag'
+    };
+    tryDeleteHeldVertexOnHold(fakeMap([modify]) as Map);
+    expect(
+      (modify as unknown as { lastPointerEvent_: unknown }).lastPointerEvent_
+    ).toBeNull();
   });
 
-  it('clears vertexDeleteOnRelease once the vertex is removed', () => {
-    const map = fakeMap([activeModify(true)]);
-    tryDeleteHeldVertexOnHold(map as Map, src('mouse'));
-    expect(map.get('vertexDeleteOnRelease')).toBe(false);
-  });
-
-  it('leaves vertexDeleteOnRelease set as a fallback when the immediate remove is refused', () => {
+  it('does not mark a delete when removePoint refuses (nothing grabbed)', () => {
     const map = fakeMap([activeModify(false)]);
-    tryDeleteHeldVertexOnHold(map as Map, src('mouse'));
-    expect(map.get('vertexDeleteOnRelease')).toBe(true);
+    tryDeleteHeldVertexOnHold(map as Map);
+    expect(vertexDeleted(map)).toBe(false);
   });
 
   it('does nothing (opens context menu instead) when no Modify is active', () => {
     const map = fakeMap([]);
-    expect(tryDeleteHeldVertexOnHold(map as Map, src('mouse'))).toBe(false);
-    expect(map.get('vertexDeleteOnRelease')).toBeUndefined();
+    expect(tryDeleteHeldVertexOnHold(map as Map)).toBe(false);
+  });
+
+  it('relies on an OpenLayers field name that still exists (rename guard)', () => {
+    expect(
+      'lastPointerEvent_' in new Modify({ features: new Collection() })
+    ).toBe(true);
   });
 });
 
@@ -149,18 +143,6 @@ describe('clearHeldVertexOnRelease', () => {
     expect(setActive).not.toHaveBeenCalled();
   });
 
-  it('leaves the dot when this release still has a vertex to delete', () => {
-    // A tap-hold whose immediate remove was refused deletes via deleteCondition
-    // on this release, which needs the dot — and this runs first.
-    const modify = activeModify();
-    const setActive = vi.spyOn(modify, 'setActive');
-    const map = fakeMap([modify]);
-    map.set('vertexDeleteOnRelease', true);
-
-    releaseOn(map as Map, 'touch');
-    expect(setActive).not.toHaveBeenCalled();
-  });
-
   it('does nothing when no Modify is active', () => {
     expect(() => releaseOn(fakeMap([]) as Map, 'touch')).not.toThrow();
   });
@@ -195,7 +177,7 @@ describe('vertexDeleted marker', () => {
     // marker must survive the whole gesture for that click to be suppressed.
     const map = fakeMap([activeModify(true)]);
     startPointerGesture(map);
-    tryDeleteHeldVertexOnHold(map as Map, src('mouse'));
+    tryDeleteHeldVertexOnHold(map as Map);
     expect(vertexDeleted(map)).toBe(true);
   });
 

--- a/src/app/modules/map/ol/lib/vertex-delete.spec.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.spec.ts
@@ -6,6 +6,7 @@ import {
   clearHeldVertexOnRelease,
   clearVertexDeleted,
   clearVertexDeletedOnDrag,
+  isTouchContextMenuWhileEditing,
   markVertexDeleted,
   startPointerGesture,
   tryDeleteHeldVertexOnHold,
@@ -76,6 +77,48 @@ describe('tryDeleteHeldVertexOnHold', () => {
     const map = fakeMap([]);
     expect(tryDeleteHeldVertexOnHold(map as Map, src('mouse'))).toBe(false);
     expect(map.get('vertexDeleteOnRelease')).toBeUndefined();
+  });
+});
+
+// A touch long-press makes the Android WebView emit a *native* `contextmenu` at
+// ~500ms (the OS long-press timeout), a full second before the 1500ms
+// vertex-delete hold timer. Left to run, its handler clears that timer and the
+// delete never fires. While editing, that native touch contextmenu must be
+// ignored so the hold timer survives; every other case keeps working.
+describe('isTouchContextMenuWhileEditing', () => {
+  it('is true for a native touch contextmenu while a Modify is active', () => {
+    const map = fakeMap([activeModify()]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'contextmenu', 'touch')
+    ).toBe(true);
+  });
+
+  it('is false when no Modify is active — the not-editing menu is unchanged', () => {
+    const map = fakeMap([]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'contextmenu', 'touch')
+    ).toBe(false);
+  });
+
+  it('is false for a mouse contextmenu — a real right-click still opens the menu', () => {
+    const map = fakeMap([activeModify()]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'contextmenu', 'mouse')
+    ).toBe(false);
+  });
+
+  it("is false for touchHold's own pointerdown source, not a native contextmenu", () => {
+    const map = fakeMap([activeModify()]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'pointerdown', 'touch')
+    ).toBe(false);
+  });
+
+  it('is false for a contextmenu with no pointer type — the keyboard menu key', () => {
+    const map = fakeMap([activeModify()]);
+    expect(
+      isTouchContextMenuWhileEditing(map as Map, 'contextmenu', undefined)
+    ).toBe(false);
   });
 });
 

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -87,6 +87,23 @@ function activeModify(map: Map): Modify | undefined {
 }
 
 /**
+ * Whether the active edit has a vertex grabbed under the pointer — the point a
+ * long hold would delete. OpenLayers sets `vertexFeature_` (the grabbed dot) on
+ * pointerdown when the press lands on a vertex, and a stationary tap-hold never
+ * clears it, so it reads true for the whole hold. Used to show the delete
+ * indicator and fire its haptic only for a real delete, not an open-water hold.
+ * `vertex-delete.spec` asserts the field still exists so an OpenLayers rename is
+ * caught by the suite.
+ */
+export function hasGrabbedVertex(map: Map): boolean {
+  const modify = activeModify(map);
+  if (!modify) {
+    return false;
+  }
+  return !!(modify as unknown as { vertexFeature_?: unknown }).vertexFeature_;
+}
+
+/**
  * Whether a `contextmenu` is the touch long-press artifact that must be ignored
  * for the vertex-delete hold to survive.
  *
@@ -156,18 +173,23 @@ export function clearHeldVertexOnRelease(map: Map, src: PointerEvent): void {
  * which no consumer reads. `vertex-delete.spec` asserts the field still exists so
  * an OpenLayers rename fails the suite rather than silently disabling the delete.
  *
- * Returns `true` when a Modify interaction was active (delete attempted, so the
- * caller should not also open the context menu), `false` when there was none.
+ * Returns `null` when no Modify interaction was active (so the caller opens the
+ * context menu instead); otherwise whether a vertex was actually **removed** —
+ * `true` only when `removePoint()` succeeded. `removePoint()` can refuse while a
+ * vertex is grabbed (OpenLayers keeps the endpoints of a two-point line), so the
+ * caller must confirm the delete (haptic, red indicator) on this result, not on
+ * merely having grabbed a vertex.
  */
-export function tryDeleteHeldVertexOnHold(map: Map): boolean {
+export function tryDeleteHeldVertexOnHold(map: Map): boolean | null {
   const modify = activeModify(map);
   if (!modify) {
-    return false;
+    return null;
   }
   (modify as unknown as { lastPointerEvent_: unknown }).lastPointerEvent_ =
     null;
-  if (modify.removePoint()) {
+  const removed = modify.removePoint();
+  if (removed) {
     markVertexDeleted(map);
   }
-  return true;
+  return removed;
 }

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -87,6 +87,33 @@ function activeModify(map: Map): Modify | undefined {
 }
 
 /**
+ * Whether a `contextmenu` is the touch long-press artifact that must be ignored
+ * for the vertex-delete hold to survive.
+ *
+ * A finger long-press on the map makes the browser/WebView emit a **native**
+ * `contextmenu` at the OS long-press timeout (~500 ms) — a full second before the
+ * 1500 ms vertex-delete hold timer. Handled normally it clears that timer, so the
+ * delete never fires and the grabbed vertex is only ever dragged. While a route is
+ * being edited that native touch event is redundant with the hold timer and must
+ * be dropped. A mouse right-click (a deliberate action) and a touch long-press
+ * when not editing (opens the chart menu) both stay as they were.
+ *
+ * `eventType` separates the native DOM `contextmenu` from the synthetic
+ * pointer-down source that `touchHold` replays into this same handler.
+ */
+export function isTouchContextMenuWhileEditing(
+  map: Map,
+  eventType: string,
+  pointerType: string | undefined
+): boolean {
+  return (
+    eventType === 'contextmenu' &&
+    pointerType === 'touch' &&
+    !!activeModify(map)
+  );
+}
+
+/**
  * Drop the "grabbed vertex" dot when a touch gesture ends (#643).
  *
  * OpenLayers retires that dot only from a `pointermove` landing clear of the

--- a/src/app/modules/map/ol/lib/vertex-delete.ts
+++ b/src/app/modules/map/ol/lib/vertex-delete.ts
@@ -122,16 +122,12 @@ export function isTouchContextMenuWhileEditing(
  * holding — and it reads as a selection the user cannot dismiss, because the tap
  * that would clear it on a desktop instead extends the route (#549).
  *
- * A release with a delete still outstanding is left alone: `deleteCondition`
- * needs the dot to remove the vertex on this very release, and this runs first
- * (a viewport listener precedes OL's document-level `pointerup`).
- *
  * `setActive(false)` is OL's own documented way to drop the dot; re-arming
  * immediately keeps the interaction ready for the next gesture, and the release
  * still reaches `handleUpEvent`, so an edit this gesture made is unaffected.
  */
 export function clearHeldVertexOnRelease(map: Map, src: PointerEvent): void {
-  if (src.pointerType !== 'touch' || map.get('vertexDeleteOnRelease')) {
+  if (src.pointerType !== 'touch') {
     return;
   }
   const modify = activeModify(map);
@@ -143,43 +139,35 @@ export function clearHeldVertexOnRelease(map: Map, src: PointerEvent): void {
 }
 
 /**
- * On a long press during route editing, remove the grabbed vertex.
+ * On a long press during route editing, remove the grabbed vertex immediately —
+ * mid-hold, while the pointer is still down, the way touch plotters work.
  *
  * Runs for **any** pointer — a long left-click gives mouse users parity with the
  * touch/pen tap-hold (alongside Ctrl-Click). A press that is really the start of a
  * drag cannot reach here: the Modify hold timer is 1500 ms and `clearTimerIfMoved`
  * disarms it once the pointer moves past its tolerance.
  *
+ * `removePoint()` refuses when the interaction's last event was a POINTERDRAG, and
+ * a finger always jitters past OpenLayers' 1 px move tolerance during the hold,
+ * latching `MapBrowserEventHandler.dragging_` (which `isMoving_` short-circuits
+ * on) for the rest of the gesture. Clearing the interaction's `lastPointerEvent_`
+ * lets `removePoint()` run — it removes the grabbed vertex from `dragSegments_`
+ * and carries the (now null) event only into its MODIFYSTART/MODIFYEND events,
+ * which no consumer reads. `vertex-delete.spec` asserts the field still exists so
+ * an OpenLayers rename fails the suite rather than silently disabling the delete.
+ *
  * Returns `true` when a Modify interaction was active (delete attempted, so the
  * caller should not also open the context menu), `false` when there was none.
  */
-export function tryDeleteHeldVertexOnHold(map: Map, src: MouseEvent): boolean {
+export function tryDeleteHeldVertexOnHold(map: Map): boolean {
   const modify = activeModify(map);
   if (!modify) {
     return false;
   }
-  // Flag a delete-on-release as the reliable fallback, then try to remove the
-  // grabbed vertex immediately (mid-hold, the way touch plotters work).
-  // removePoint() refuses if the last event was a drag, so replay a pointermove at
-  // the press point to clear that state first.
-  map.set('vertexDeleteOnRelease', true);
-  try {
-    map.getViewport().dispatchEvent(
-      new PointerEvent('pointermove', {
-        clientX: src.clientX,
-        clientY: src.clientY,
-        bubbles: true,
-        cancelable: true,
-        pointerId: (src as PointerEvent).pointerId ?? 1,
-        pointerType: (src as PointerEvent).pointerType ?? 'touch'
-      })
-    );
-    if (modify.removePoint()) {
-      map.set('vertexDeleteOnRelease', false);
-      markVertexDeleted(map);
-    }
-  } catch {
-    // Fall back to delete-on-release via the deleteCondition flag.
+  (modify as unknown as { lastPointerEvent_: unknown }).lastPointerEvent_ =
+    null;
+  if (modify.removePoint()) {
+    markVertexDeleted(map);
   }
   return true;
 }


### PR DESCRIPTION
> **Stacked on #646.** This branch is based on #646's touch fix, so its first commit (`fix(map): let touch tap-hold delete a route vertex`) also appears here and will drop out of the diff once #646 merges. The two commits to review are the last two — `delete a held route vertex at the hold timeout` and `confirm a tap-hold delete with a progress indicator and haptic`. Best reviewed (or merged) after #646.

## Why

After #646 a touch tap-hold deletes a route vertex, but only commits on finger-**lift**, and with no on-screen feedback — the finger covers the grabbed vertex, so there's nothing to tell the user a delete is underway, how long to hold, or that it landed. This makes the delete land **at the hold timeout while the finger is still down** and shows what's happening.

## How

- **Delete at the timeout.** `removePoint()` refuses when the interaction's last event was a `POINTERDRAG`, and a finger always jitters past OpenLayers' 1&nbsp;px move tolerance during the hold — latching `dragging_`, which `isMoving_` short-circuits on. Clearing the interaction's `lastPointerEvent_` lets `removePoint()` run mid-hold. With the delete now immediate, the delete-on-release fallback is removed: `vertexDeleteOnRelease` and `vertexDeleteCondition`'s release branch go (Ctrl-Click stays), and `clearHeldVertexOnRelease` simply drops the grabbed dot on any touch release. Two specs guard the OL internal it now depends on — a rename guard and a **behavioural** guard that `removePoint()` still refuses a drag — since there is no fallback.

- **Feedback.** A small progress bar with a trash icon appears just above the press point, starting with the native long-press buzz (triggered from the same `contextmenu` event) and filling for the rest of the hold. The icon turns red and a short `vibrate` double-pulse fires **only when a vertex is actually removed** — OpenLayers keeps a two-point line's endpoints, so the cue is gated on the real removal, not merely on having grabbed a vertex. A no-op where web-page vibration is suppressed (some WebViews); the red indicator is the primary cue there. The indicator is a plain-DOM overlay: tied to a raw pointer gesture, positioned in screen space, and created/destroyed within the gesture lifecycle.

Note: the fallback-removal edits touch code from #644 (`clearHeldVertexOnRelease`, `vertexDeleteCondition`) — @joelkoz, flagging since it just merged.

## Test plan

- [x] `npm run test:ci` green — new specs cover the mid-hold nudge, its OL-internal rename + behavioural canaries, `hasGrabbedVertex`, and the indicator module (show / complete / hide / replace / style-once).
- [x] Verified on Android (WebView + Chrome): the vertex deletes at the timeout with the finger still down; the bar fills and turns red; the completion buzz fires on browsers that allow web vibration and degrades cleanly to the red cue where a WebView suppresses it.
- [x] Not-editing chart context menu, mouse right-click / Ctrl-Click delete, and vertex move/add are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual progress indicator for tap-and-hold vertex deletion.
  * Improved touch long-press deletion handling, including native touch context-menu events.
  * Added completion feedback when a vertex is successfully deleted.

* **Bug Fixes**
  * Prevented plain pointer release and right-click actions from unintentionally deleting vertices.
  * Improved gesture cleanup and prevented duplicate deletion indicators.
  * Ensured vertices are removed reliably during active route editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->