### PR TITLE
fix(resources): prevent resource list effects from looping via alignSelections()

### DIFF
--- a/src/app/modules/skresources/components/resource-list-baseclass.spec.ts
+++ b/src/app/modules/skresources/components/resource-list-baseclass.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import { effect, signal } from '@angular/core';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { ResourceListBase } from './resource-list-baseclass';
+import type { SKResourceService } from '../resources.service';
+
+/**
+ * `doFilter()` writes the `filteredList` signal and then recomputes the select
+ * all/some/none flags from it via `alignSelections()`. When that read back was
+ * tracked, any effect ending in `doFilter()` became a dependent of its own
+ * write. One such effect is harmless — it records the version it just produced
+ * — but two are not: each one's write invalidates the version the other
+ * recorded, so they re-trigger each other until the heap is exhausted. That was
+ * #617, where the chart list's "In view" filter locked Freeboard up on any pan
+ * or zoom.
+ *
+ * Seven components extend this base class, so the guard belongs here rather
+ * than in each subclass's effects (#623). These tests stand up a minimal
+ * subclass with two effects that both call `doFilter()` *without* an
+ * `untracked()` wrapper — the mistake the base class has to survive — and
+ * assert the filter settles.
+ *
+ * `doFilter()` trips after a small number of calls so a regression fails as an
+ * assertion rather than taking the vitest worker down with an out-of-memory
+ * crash.
+ */
+const RUNAWAY = 25;
+
+type Entry = [string, { name: string }, boolean];
+
+const entry = (id: string, checked: boolean): Entry => [
+  id,
+  { name: id },
+  checked
+];
+
+class TestList extends ResourceListBase {
+  filterRuns = 0;
+  readonly triggerA = signal(0);
+  readonly triggerB = signal(0);
+
+  constructor() {
+    super('routes', {} as SKResourceService);
+    // Deliberately untracked-free: the base class must make these safe.
+    effect(() => {
+      this.triggerA();
+      this.doFilter();
+    });
+    effect(() => {
+      this.triggerB();
+      this.doFilter();
+    });
+  }
+
+  seed(entries: Entry[]) {
+    this.fullList.push(...entries);
+  }
+
+  checkAll() {
+    this.fullList.forEach((e) => (e[2] = true));
+  }
+
+  get list(): Entry[] {
+    return this.filteredList();
+  }
+
+  get flags() {
+    return { all: this.allSel, some: this.someSel };
+  }
+
+  protected override doFilter() {
+    if (++this.filterRuns > RUNAWAY) {
+      throw new Error('doFilter() ran away — alignSelections() feedback loop');
+    }
+    super.doFilter();
+  }
+}
+
+describe('ResourceListBase — alignSelections() takes no reactive dependency (#623)', () => {
+  let comp: TestList;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    comp = TestBed.runInInjectionContext(() => new TestList());
+    comp.seed([entry('a', true), entry('b', false)]);
+  });
+
+  it('settles after both effects have run once', () => {
+    TestBed.tick();
+
+    expect(comp.filterRuns).toBe(2);
+  });
+
+  it('re-filters once when a single effect is triggered', () => {
+    TestBed.tick();
+    comp.filterRuns = 0;
+
+    comp.triggerA.set(1);
+    TestBed.tick();
+
+    expect(comp.filterRuns).toBe(1);
+  });
+
+  it('re-filters once per effect when both are triggered', () => {
+    TestBed.tick();
+    comp.filterRuns = 0;
+
+    comp.triggerA.set(1);
+    comp.triggerB.set(1);
+    TestBed.tick();
+
+    expect(comp.filterRuns).toBe(2);
+  });
+
+  it('still derives the select all/some/none flags from the filtered list', () => {
+    TestBed.tick();
+
+    // One of two entries selected → "some".
+    expect(comp.list.map((e) => e[0])).toEqual(['a', 'b']);
+    expect(comp.flags).toEqual({ all: false, some: true });
+  });
+
+  it('reports all-selected once every entry is checked', () => {
+    TestBed.tick();
+    expect(comp.flags).toEqual({ all: false, some: true });
+
+    comp.checkAll();
+    comp.triggerA.set(1);
+    TestBed.tick();
+
+    expect(comp.flags).toEqual({ all: true, some: false });
+  });
+});

--- a/src/app/modules/skresources/components/resource-list-baseclass.spec.ts
+++ b/src/app/modules/skresources/components/resource-list-baseclass.spec.ts
@@ -7,19 +7,15 @@ import type { SKResourceService } from '../resources.service';
 
 /**
  * `doFilter()` writes the `filteredList` signal and then recomputes the select
- * all/some/none flags from it via `alignSelections()`. When that read back was
- * tracked, any effect ending in `doFilter()` became a dependent of its own
- * write. One such effect is harmless — it records the version it just produced
- * — but two are not: each one's write invalidates the version the other
- * recorded, so they re-trigger each other until the heap is exhausted. That was
- * #617, where the chart list's "In view" filter locked Freeboard up on any pan
- * or zoom.
+ * all/some/none flags from it via `alignSelections()`. A tracked read there
+ * would make any effect ending in `doFilter()` a dependent of its own write:
+ * one such effect is harmless, but two re-trigger each other until the heap is
+ * exhausted (#617).
  *
- * Seven components extend this base class, so the guard belongs here rather
- * than in each subclass's effects (#623). These tests stand up a minimal
- * subclass with two effects that both call `doFilter()` *without* an
- * `untracked()` wrapper — the mistake the base class has to survive — and
- * assert the filter settles.
+ * These tests stand up a minimal subclass with two effects that both call
+ * `doFilter()` *without* an `untracked()` wrapper — the mistake the base class
+ * has to survive — and assert that filtering settles and the selection flags
+ * stay correct.
  *
  * `doFilter()` trips after a small number of calls so a regression fails as an
  * assertion rather than taking the vitest worker down with an out-of-memory

--- a/src/app/modules/skresources/components/resource-list-baseclass.ts
+++ b/src/app/modules/skresources/components/resource-list-baseclass.ts
@@ -1,4 +1,4 @@
-import { signal } from '@angular/core';
+import { signal, untracked } from '@angular/core';
 import { FBResource } from 'src/app/types';
 import { SKResourceService, SKSelection } from '../resources.service';
 
@@ -53,11 +53,18 @@ export class ResourceListBase {
 
   /**
    * Align select all / some / none checkbox with entry selections
+   *
+   * The list is read non-reactively. Callers invoke this immediately after
+   * writing filteredList, so the value is already in hand — but a tracked read
+   * would also make whatever effect is on the stack a dependent of that write.
+   * Two such effects then re-trigger each other until the heap is exhausted —
+   * the chart list lockup of #617. Reading here with untracked() keeps that
+   * trap out of every subclass (#623).
    */
   protected alignSelections() {
     let c = false;
     let u = false;
-    this.filteredList().forEach((i: FBResource) => {
+    untracked(() => this.filteredList()).forEach((i: FBResource) => {
       c = i[2] ? true : c;
       u = !i[2] ? true : u;
     });

--- a/src/app/modules/skresources/components/resource-list-baseclass.ts
+++ b/src/app/modules/skresources/components/resource-list-baseclass.ts
@@ -55,11 +55,10 @@ export class ResourceListBase {
    * Align select all / some / none checkbox with entry selections
    *
    * The list is read non-reactively. Callers invoke this immediately after
-   * writing filteredList, so the value is already in hand — but a tracked read
-   * would also make whatever effect is on the stack a dependent of that write.
-   * Two such effects then re-trigger each other until the heap is exhausted —
-   * the chart list lockup of #617. Reading here with untracked() keeps that
-   * trap out of every subclass (#623).
+   * writing filteredList, so the value is already in hand — and a tracked read
+   * would make any effect on the call stack a dependent of that write. Two such
+   * effects then re-trigger each other until the heap is exhausted, so
+   * untracked() is load bearing here (#617).
    */
   protected alignSelections() {
     let c = false;


### PR DESCRIPTION
`ResourceListBase.doFilter()` writes the `filteredList` signal and then recomputes
the select all/some/none flags from it via `alignSelections()`. That read back was
**tracked**, so any effect ending in `doFilter()` became a dependent of its own
write.

A single such effect is harmless — it records the version it just produced, so it
never re-triggers itself. Two are not: each one's write invalidates the version the
other recorded, and they ping-pong until the JS heap is exhausted. That is #617,
where the chart list's "In view" filter locked Freeboard up on any pan or zoom.

#622 fixed that at the chart-list effects. Seven components extend
`ResourceListBase`, though, and the shape is present in all of them — the next
effect anyone adds to any list re-opens the trap, and it presents as a browser
lockup with nothing pointing at this file. So the guard belongs in the base class:
`alignSelections()` now reads the list with `untracked()`.

The reactive read served no purpose. `alignSelections()` is only ever called
immediately after the caller has just set the list; being a dependency of whatever
effect happens to be on the stack was incidental. Confirmed no subclass wants it to
re-run reactively — the one override (`AisListComponent`) calls `super` and then
reads `app.config.selections.aisTargetTypes`, a plain array. Fixing it in
`alignSelections()` rather than `doFilter()` matters because `ChartListComponent`
has its own `doFilter()` override that also writes-then-aligns; only the base method
covers every caller.

The existing `untracked()` wrappers in `chartlist.ts` and `routelist.ts` become
belt-and-braces rather than load bearing. They are left in place — removing them
would be a second logical change.

## Test

New `resource-list-baseclass.spec.ts` stands up a minimal `ResourceListBase`
subclass with two effects that both call `doFilter()` **deliberately without** an
`untracked()` wrapper — the mistake the base class has to survive — and asserts the
filter settles. `doFilter()` trips after 25 runs so a regression fails as an
assertion rather than taking the vitest worker down with an OOM crash.

- Fix reverted: 5/5 fail with `doFilter() ran away — alignSelections() feedback loop`
- Fix in place: 5/5 pass
- Full suite: 54 files / 479 tests passed; `build:web` and Prettier clean

Closes #623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved selection filtering stability to prevent repeated reactive updates and feedback loops.
  - Preserved accurate “select all” and partial-selection states when lists are filtered.

- **Tests**
  - Added comprehensive coverage for initial filtering, repeated triggers, simultaneous updates, filtered results, and selection-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->