### PR TITLE
docs(contributing): keep individual commits instead of squashing before review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,9 +148,17 @@ continue that. The bar below is what "done correctly" means here.
   shared Signal K `plugin-ci` workflow (`build:all` + `test:ci`) across a
   Linux/macOS/Windows + arm matrix; it must be green.
 - **Never change version numbers.** Maintainers own versioning and publish releases.
-- **Branch from latest `master`; rebase, never merge.** Clean up commit history
-  before opening (no "fix typo"/"oops" commits — amend into the relevant commit).
-  When updating with upstream: `git fetch && git rebase origin/master`, force-push.
+- **Branch from latest `master`; rebase, never merge.** When updating with upstream:
+  `git fetch && git rebase origin/master`, force-push. That rebase is the *only*
+  routine reason to force-push a PR branch.
+- **Keep the individual commits — never squash the branch.** Don't flatten the work
+  into a single commit before opening, and don't amend review fixes into earlier
+  commits afterwards — push those as new commits with a plain `git push`. Maintainers
+  squash when they merge, so pre-squashing gains nothing, and it costs the two things
+  the history is there for: CodeRabbit re-reviewing incrementally instead of in full
+  (re-reviews are rate-limited), and a reviewer's "changes since last review" view.
+  Write each commit message to explain *why*; on a contributor PR that sequence is
+  frequently the only record of how the design moved.
 - **CodeRabbit reviews PRs automatically — give every finding an explicit
   disposition.** Either fix it, or reply on that thread saying why it doesn't apply.
   **Don't leave a finding silently unanswered**, and don't treat a PR as ready for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,15 @@ Before you open a PR (full detail in [`AGENTS.md`](AGENTS.md)):
    npm run build:all
    npm run test:ci      # runs tests once and exits (not `npm test`, which watches)
    ```
-5. Commit with `type(scope): subject` messages (imperative, present tense). Keep
-   history clean — amend fixups rather than chaining "oops" commits.
+5. Commit with `type(scope): subject` messages (imperative, present tense).
+   **Keep your individual commits — don't squash the branch into one before you
+   open the PR.** Each commit should be a meaningful step, and its message should
+   say *why*, not just *what*: that sequence is how a reviewer follows your
+   reasoning, and on a contributor PR it is often the only place the reasoning is
+   written down at all. Maintainers squash when they merge, so flattening the
+   branch yourself gains nothing — and it costs a maintainer the ability to
+   reconcile what changed against what was reviewed. Keep every commit, including
+   the small ones; don't tidy them away.
 6. Push and open the PR.
    - **The title becomes a line in the release notes / App Store Changelog** — make
      it descriptive and user-facing.
@@ -78,7 +85,16 @@ Before you open a PR (full detail in [`AGENTS.md`](AGENTS.md)):
    unanswered thread doesn't tell a maintainer whether you disagreed or never saw
    it. Rebutting is fine — being silent isn't. A PR is ready for maintainer review
    once a CodeRabbit review has completed and every finding is disposed of.
-   If changes are requested, rebase and force-push to update the PR:
+   Push your fixes as **new commits** with a plain `git push` — **don't
+   force-push.** New commits keep CodeRabbit's re-review incremental and leave
+   reviewers a working "changes since last review" view; a force-push destroys
+   both, and re-reviews are rate-limited.
+   ```sh
+   git commit -m "fix(map): guard against a null layer on teardown"
+   git push
+   ```
+   The one routine reason to force-push is rebasing onto a moved `master` — that
+   preserves your commits rather than collapsing them:
    ```sh
    git fetch origin && git rebase origin/master
    git push -f

--- a/docs/freeboard/DEV-LESSONS-LEARNED.md
+++ b/docs/freeboard/DEV-LESSONS-LEARNED.md
@@ -567,7 +567,10 @@ head branch — so if `master` moved after you branched, CR (and CI) reason abou
 stale tree and may flag issues already fixed elsewhere.
 
 **What to do instead.** Rebase onto current `master` before relying on a re-review
-(`git fetch && git rebase origin/master`, force-push).
+(`git fetch && git rebase origin/master`, force-push). This rebase is the one
+routine exception to the no-force-push rule in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md) — it preserves your individual commits.
+The review fixes themselves go in as new commits and a plain `git push`.
 
 ### Waiting on a CodeRabbit review — poll the review endpoints, not its prose
 


### PR DESCRIPTION
The contributor docs currently push authors in the opposite direction from what
review actually needs: `CONTRIBUTING.md` asked for history to be flattened before
opening, and told contributors to force-push when addressing review feedback.

Both discard the commit sequence, which is what a maintainer uses to reconcile
what changed against what was already reviewed — and on a contributor PR that
sequence is often the only record of *why* the design moved. A force-push also
downgrades CodeRabbit from an incremental re-review to a full one, and re-reviews
are rate-limited.

PRs here are squash-merged, so a pre-flattened branch buys nothing anyway.

- `CONTRIBUTING.md` — keep individual commits, don't squash before opening; push
  review fixes as new commits with a plain `git push`.
- `AGENTS.md` — same rule for AI assistants, split out as its own bullet.
- `DEV-LESSONS-LEARNED.md` — its rebase-and-force-push advice now names itself as
  the one exception, so it no longer reads as contradicting `CONTRIBUTING.md`.

Rebasing onto a moved `master` remains the one routine reason to force-push: it
preserves the commits rather than collapsing them.

Docs only — no code, no behaviour change.

@coderabbitai ignore