### PR TITLE
fix(features): track feature history rows by index

### DIFF
--- a/src/app/modules/features/feature-browser-dialog.html
+++ b/src/app/modules/features/feature-browser-dialog.html
@@ -106,7 +106,7 @@
       <div class="pr-history">
         <div class="pr-history-title">History</div>
         <table class="pr-table">
-          @for (e of f.events; track e.pr) {
+          @for (e of f.events; track $index) {
           <tr>
             <td class="pr-date">
               {{ e.date ? (e.date | date: 'mediumDate') : '' }}

--- a/src/app/modules/features/feature-browser-dialog.spec.ts
+++ b/src/app/modules/features/feature-browser-dialog.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { EMPTY } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CompiledFeature } from './feature-corpus';
 import { FeatureCorpusService } from './feature-corpus.service';
@@ -141,5 +141,60 @@ describe('FeatureBrowserDialog what’s-new strip', () => {
 
     more.click();
     expect(scrollIntoView).toHaveBeenCalled();
+  });
+});
+
+describe('FeatureBrowserDialog history table', () => {
+  let fixture: ComponentFixture<FeatureBrowserDialog>;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  // A catch-up doc for an older feature: more than one change predating the PR
+  // workflow, so every such row carries `pr: null`.
+  const prePrWorkflow: CompiledFeature = {
+    ...feature('anchor-watch', 'Anchor Watch'),
+    events: [
+      { pr: null, date: '2024-03-02', title: 'raise the alarm on drag' },
+      { pr: null, date: '2024-03-01', title: 'set an anchor' }
+    ]
+  };
+
+  beforeEach(async () => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    TestBed.configureTestingModule({
+      imports: [FeatureBrowserDialog],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: FeatureCorpusService,
+          useValue: { load: async () => [prePrWorkflow], hueFor: () => 0 }
+        },
+        {
+          provide: MatDialogRef,
+          useValue: { keydownEvents: () => EMPTY, close: () => undefined }
+        }
+      ]
+    });
+
+    fixture = TestBed.createComponent(FeatureBrowserDialog);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  });
+
+  afterEach(() => warn.mockRestore());
+
+  it('renders every pre-PR-workflow change with unique track keys', () => {
+    const rows = Array.from(
+      fixture.nativeElement.querySelectorAll('.pr-table tr')
+    ) as HTMLElement[];
+    expect(
+      rows.map((r) => r.querySelector('.pr-title')?.textContent?.trim())
+    ).toEqual(['raise the alarm on drag', 'set an anchor']);
+
+    // NG0955 — duplicate track keys. Angular only warns, so the rows above still
+    // render; the exposure is mis-keyed DOM reuse when the collection changes.
+    const warnings = warn.mock.calls.map((c) => String(c[0]));
+    expect(warnings.filter((m) => m.includes('NG0955'))).toEqual([]);
   });
 });


### PR DESCRIPTION
The Feature Browser's history table tracked rows by PR number, but `pr` is
`null` for any change predating the PR workflow — omitting it is the documented
convention for direct commits. A feature with two or more such rows therefore
produced duplicate track keys (NG0955). Angular only warns, so both rows still
render, but with non-unique keys it can reuse or reorder the wrong DOM nodes when
the collection changes.

Nothing in the current ledger triggers it — it becomes reachable as soon as a
catch-up doc records more than one pre-PR-workflow change for a feature.

Tracks by index instead, as the what's-new strip already does: the list is
rebuilt wholesale when the selected feature changes, so index tracking is
appropriate here.

Closes #605
