### PR TITLE
fix(plotterext): make the no-settings dialog message legible in dark mode

### DIFF
--- a/src/app/modules/plotterext/panel-dialog.component.spec.ts
+++ b/src/app/modules/plotterext/panel-dialog.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { PlotterPanelDialog } from './panel-dialog.component';
+import { PlotterExtensionService } from './plotterext.service';
+
+describe('PlotterPanelDialog with no configuration panel', () => {
+  let fixture: ComponentFixture<PlotterPanelDialog>;
+
+  const message = () =>
+    fixture.nativeElement.querySelector('.pe-panel-noconfig') as HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PlotterPanelDialog],
+      providers: [
+        provideNoopAnimations(),
+        { provide: MatDialogRef, useValue: { close: () => undefined } },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            extension: 'test-ext',
+            panel: null,
+            title: 'Wind Steer',
+            targetInstance: 'inst-1',
+            targetWidget: 'wind-steer'
+          }
+        },
+        {
+          provide: PlotterExtensionService,
+          useValue: {
+            resolveAssetUrl: (u: string) => u,
+            attachPanel: () => () => undefined,
+            removeWidget: () => undefined
+          }
+        }
+      ]
+    });
+
+    fixture = TestBed.createComponent(PlotterPanelDialog);
+    fixture.detectChanges();
+  });
+
+  it('tells the user the widget has no settings', () => {
+    expect(message()?.textContent?.trim()).toBe('This widget has no settings.');
+  });
+
+  // Issue #653: the message hard-coded `color: rgba(0, 0, 0, 0.6)`, so in dark
+  // mode it rendered near-black on a dark dialog and was invisible. Declaring no
+  // colour lets mat-dialog-content's themed supporting-text colour apply, which
+  // does switch with the theme. The dialog's foreground is stood in for here by
+  // an ancestor colour: if the component pins one of its own, it wins over the
+  // ambient value and this fails — exactly as it did before the fix.
+  it('takes its colour from the dialog rather than a hard-coded one', () => {
+    (fixture.nativeElement as HTMLElement).style.color = 'rgb(1, 2, 3)';
+    expect(getComputedStyle(message()).color).toBe('rgb(1, 2, 3)');
+  });
+});

--- a/src/app/modules/plotterext/panel-dialog.component.spec.ts
+++ b/src/app/modules/plotterext/panel-dialog.component.spec.ts
@@ -47,12 +47,10 @@ describe('PlotterPanelDialog with no configuration panel', () => {
     expect(message()?.textContent?.trim()).toBe('This widget has no settings.');
   });
 
-  // Issue #653: the message hard-coded `color: rgba(0, 0, 0, 0.6)`, so in dark
-  // mode it rendered near-black on a dark dialog and was invisible. Declaring no
-  // colour lets mat-dialog-content's themed supporting-text colour apply, which
-  // does switch with the theme. The dialog's foreground is stood in for here by
-  // an ancestor colour: if the component pins one of its own, it wins over the
-  // ambient value and this fails — exactly as it did before the fix.
+  // Regression guard for #653. The message carries no colour of its own, so it
+  // takes mat-dialog-content's themed supporting-text colour, which follows the
+  // dark theme. The ancestor colour set below stands in for that themed
+  // foreground: a colour pinned on the element would win over it and fail here.
   it('takes its colour from the dialog rather than a hard-coded one', () => {
     (fixture.nativeElement as HTMLElement).style.color = 'rgb(1, 2, 3)';
     expect(getComputedStyle(message()).color).toBe('rgb(1, 2, 3)');

--- a/src/app/modules/plotterext/panel-dialog.component.ts
+++ b/src/app/modules/plotterext/panel-dialog.component.ts
@@ -75,9 +75,9 @@ export interface PlotterPanelDialogData {
         padding: 0;
         height: 60vh;
       }
-      /* No colour of its own: mat-dialog-content already carries the themed
-         supporting-text colour, which switches with the dark theme. Pinning a
-         light-theme value here made the message invisible in dark mode (#653). */
+      /* Declares no colour: mat-dialog-content already carries the themed
+         supporting-text colour, which follows the dark theme. A colour pinned
+         here overrides it and goes invisible against the dark surface. */
       .pe-panel-noconfig {
         padding: 16px 24px;
       }

--- a/src/app/modules/plotterext/panel-dialog.component.ts
+++ b/src/app/modules/plotterext/panel-dialog.component.ts
@@ -75,9 +75,11 @@ export interface PlotterPanelDialogData {
         padding: 0;
         height: 60vh;
       }
+      /* No colour of its own: mat-dialog-content already carries the themed
+         supporting-text colour, which switches with the dark theme. Pinning a
+         light-theme value here made the message invisible in dark mode (#653). */
       .pe-panel-noconfig {
         padding: 16px 24px;
-        color: rgba(0, 0, 0, 0.6);
       }
       iframe {
         display: block;


### PR DESCRIPTION
The "This widget has no settings." message pinned `color: rgba(0, 0, 0, 0.6)`, which is a copy of Angular Material's *light-mode fallback* for dialog supporting text:

```css
.mat-mdc-dialog-content {
  color: var(--mat-dialog-supporting-text-color, var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6)));
}
```

Pinning that value overrode `--mat-dialog-supporting-text-color`, which `all-component-colors($dark-theme)` *does* emit under `.dark-theme`. The dialog chrome therefore went dark while the message stayed near-black, leaving the dialog looking empty apart from the red Remove button.

The element is already a `mat-dialog-content`, so declaring no colour of its own is the whole fix — the themed supporting-text colour then applies in both themes, and that colour is `on-surface-variant`, the same muted look the hard-coded value was reaching for.

Deliberately *not* using `var(--mat-sys-on-surface-variant)` as the issue suggests: FSK's `define-theme` + `all-component-themes` setup never emits the Material 3 system palette, so `--mat-sys-*` tokens always resolve to their light fallback in both themes — see *Component surfaces styled from `--mat-sys-*` tokens go light in dark mode* in the lessons log.

`.pe-remove`'s `#d32f2f` is left as-is: it reads on both themes, and it is a separate concern from the invisible text.

Verified by the new spec, which fails before the fix (`expected 'rgba(0, 0, 0, 0.6)' to be 'rgb(1, 2, 3)'`) and passes after. It sets a colour on an ancestor to stand in for the dialog's themed foreground, so any future re-pinning of a colour on this element trips it.

Closes #653


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the no-configuration dialog message to inherit the active theme’s text color, ensuring proper readability in dark mode.

* **Tests**
  * Added coverage verifying the message content and theme-aware text styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->