### PR TITLE
feat(ui): add "What's New" to the main menu

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -271,6 +271,11 @@
         <span>About</span>
       </a>
 
+      <a mat-menu-item (click)="openFeatureBrowser()">
+        <mat-icon class="icon-accent">tips_and_updates</mat-icon>
+        <span>What's New</span>
+      </a>
+
       <button mat-menu-item (click)="app.showHelp()">
         <mat-icon class="icon-accent">help</mat-icon>
         <span>Help</span>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,7 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
-import { beforeEach, expect, describe, it } from 'vitest';
+import { beforeEach, expect, describe, it, vi } from 'vitest';
 import '@vitest/web-worker';
+import { MatMenuTrigger } from '@angular/material/menu';
+import { By } from '@angular/platform-browser';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -14,5 +16,34 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
+  });
+
+  it('opens the feature browser from the main menu\'s "What\'s New" item', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    const menuButton = fixture.debugElement
+      .queryAll(By.directive(MatMenuTrigger))
+      .find((de) => de.nativeElement.getAttribute('mattooltip') === 'Menu');
+    expect(menuButton).toBeDefined();
+
+    menuButton?.injector.get(MatMenuTrigger).openMenu();
+    fixture.detectChanges();
+
+    const item = Array.from(
+      document.querySelectorAll<HTMLElement>('.mat-mdc-menu-item')
+    ).find((el) => el.textContent?.includes("What's New"));
+    expect(item).toBeDefined();
+
+    const openFeatureBrowser = vi
+      .spyOn(
+        fixture.componentInstance as unknown as {
+          openFeatureBrowser: () => Promise<void>;
+        },
+        'openFeatureBrowser'
+      )
+      .mockResolvedValue(undefined);
+    item?.click();
+    expect(openFeatureBrowser).toHaveBeenCalled();
   });
 });

--- a/vitest-setup.js
+++ b/vitest-setup.js
@@ -14,3 +14,21 @@ class AudioContextMock {
 global.AudioContext = AudioContextMock;
 // Also handle the vendor-prefixed version if your code uses it
 global.webkitAudioContext = AudioContextMock;
+
+// jsdom implements neither of these; rendering AppComponent needs both —
+// matchMedia for dark-mode detection, ResizeObserver for the OpenLayers map.
+global.matchMedia = (media) => ({
+  media,
+  matches: false,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false
+});
+global.ResizeObserver = class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};


### PR DESCRIPTION
The Feature Browser was reachable only from the ⋯ (More actions) menu, where it is
easy to miss. Adding it to the main menu — between **About** and **Help**, alongside
the other "learn about Freeboard" entries — gives it the visibility it needs. The ⋯
entry stays as it is; this is an additional way in, not a move.

The item reuses the existing `openFeatureBrowser()` handler, so opening it from
either menu behaves identically (including extinguishing the unseen-changes
indicator).

The accompanying test renders the real `AppComponent`, opens the main menu and
asserts the item is present and wired. That is the first spec to run change
detection over the full app, which needs two globals jsdom does not provide —
`matchMedia` (dark-mode detection) and `ResizeObserver` (the OpenLayers map) — so
both are stubbed in `vitest-setup.js`.

Closes #611
