### PR TITLE
chore(scripts): let test:ci forward arguments to ng test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Node `>=18`. Install with `npm i`. Angular `21`.
 | `npm run build:web` | build the **webapp** → `public/` (use this, not raw `ng build` — see below) |
 | `npm run build:helper` | build the **helper plugin** → `plugin/` |
 | `npm run build:all` / `build:prod` | both (what CI builds, what `npm pack` runs) |
-| `npm run test:ci` | run unit tests once and **exit** (what CI runs — see below) |
+| `npm run test:ci` | run unit tests once and **exit** (what CI runs — see below); add `-- --include "<spec>"` to run a single file |
 | `npm test` | `ng test` in watch mode (local dev only — does not exit) |
 | `npm run format` | Prettier over `src/` (and `format:all` for `helper/` too) |
 

--- a/docs/freeboard/DEV-LESSONS-LEARNED.md
+++ b/docs/freeboard/DEV-LESSONS-LEARNED.md
@@ -314,20 +314,25 @@ suite, the exit-safe wrapper:
 npm run test:ci      # = ng test, with the force-exit wrapper
 ```
 
-To iterate on **one** spec, you *can* filter — pass the file to `ng test`:
+To iterate on **one** spec, pass the file through the same wrapper — anything after
+`--` is forwarded to `ng test`:
 
 ```bash
-npx ng test --include "src/app/.../foo.spec.ts"
+npm run test:ci -- --include "src/app/.../foo.spec.ts"
 ```
 
-This goes through the Angular pipeline (alias resolves) and runs only that file.
-The one catch: like all `ng test`/`ng build` invocations it **won't self-exit**
-(see *`ng test` / `ng build` don't exit* above) — `test:ci` is wrapped, this raw
-form is not. Background it, wait for the vitest `Test Files` summary, then kill it
-(or just Ctrl-C). So **red→green-verifying a regression test is two single-file
-runs**, not two full-suite runs — once with the fix reverted (new test fails), once
-restored (it passes). Don't reach for `npx vitest` to shortcut it; that's the path
-that fails on the alias.
+This goes through the Angular pipeline (so the alias resolves), runs only that file,
+and still force-exits with a real exit code. **Don't** use the raw
+`npx ng test --include …` form: like every bare `ng test`/`ng build` it won't
+self-exit (see *`ng test` / `ng build` don't exit* above), so it has to be killed by
+hand — unreliable from a script, where a run that died early leaves only
+`Building...` in the log and looks identical to one still compiling.
+
+The exit code is what makes this usable for regression work: **red→green-verifying a
+regression test is two single-file runs**, not two full-suite runs — once with the
+fix reverted (new test fails), once restored (it passes) — and the red run has to
+*report* failure rather than hang. Don't reach for `npx vitest` to shortcut it;
+that's the path that fails on the alias.
 
 ### Never let a destructive command inherit the shell's cwd
 

--- a/scripts/test-ci.mjs
+++ b/scripts/test-ci.mjs
@@ -19,13 +19,18 @@
 // still fails (via the build-error detection, or the hard timeout). Used by
 // `npm run test:ci`; plain `npm test` is left as the normal (watch) command for
 // local development.
+//
+// Extra arguments are passed straight through to `ng test`, so the exit-safe
+// behaviour is also available when filtering to one spec — which is what
+// red->green verifying a regression test needs:
+//   npm run test:ci -- --include "src/app/.../foo.spec.ts"
 
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const ngBin = require.resolve('@angular/cli/bin/ng.js');
-const NG_ARGS = ['test'];
+const NG_ARGS = ['test', ...process.argv.slice(2)];
 
 // Matches vitest's final summary line, e.g. "Test Files  3 passed (3)" or
 // "Test Files  1 failed | 2 passed (3)".


### PR DESCRIPTION
`scripts/test-ci.mjs` hardcoded `const NG_ARGS = ['test']` and forwarded nothing,
so the exit-safe wrapper could only ever run the **whole** suite. Filtering to one
spec meant dropping to a raw `npx ng test --include …`, which is not wrapped and
therefore never terminates — fine to Ctrl-C at a keyboard, unreliable from a script,
where a run that dies early leaves only `Building...` in the log and looks identical
to one still compiling.

Forwarding `process.argv.slice(2)` means one command covers both cases:

```bash
npm run test:ci                                          # whole suite (what CI runs)
npm run test:ci -- --include "src/app/.../foo.spec.ts"   # one spec, still exit-safe
```

The exit code is the point. Red→green verifying a regression test is two
single-file runs, and the red one has to *report* failure rather than hang.

The docs change is the same logical change: the lessons-log entry on running a
single spec described the raw `ng test --include` workaround, which this makes
obsolete, and the `AGENTS.md` command table under-described `test:ci`.

## Verification

No test file — `scripts/` has no test infrastructure. Verified by hand, including
the failure path (a throwaway failing spec, since the exit code is the load-bearing
claim):

| Invocation | Result |
|---|---|
| `npm run test:ci` (no args — what CI runs) | 54 files / 479 tests, exit 0 — unchanged |
| `npm run test:ci -- --include <spec>` | 1 file / 2 tests, force-exits, exit 0 |
| same, with a deliberately failing spec | exit 1 |

Note that CI itself only exercises the no-arg path, which is the one this leaves
untouched — a green run here confirms no regression rather than confirming the new
behaviour.
