### PR TITLE
docs(features): note the main menu as a Feature Browser entry point

### DIFF
--- a/features/changelog.json
+++ b/features/changelog.json
@@ -23,6 +23,7 @@
   { "feature": "feature-browser", "pr": 528, "kind": "new", "since": "v3.0.0", "date": "2026-07-16", "title": "feat(features): add a searchable \"What's New\" feature browser" },
   { "feature": "feature-browser", "pr": 530, "kind": "enhanced", "since": "v3.0.0", "date": "2026-07-17", "title": "feat(features): replace forced onboarding modals with a passive What's New indicator" },
   { "feature": "feature-browser", "pr": 604, "kind": "enhanced", "since": "v3.1.0-beta.0", "date": "2026-07-27", "title": "feat(features): show a feature's newest changes above its instructions" },
+  { "feature": "feature-browser", "pr": 657, "kind": "enhanced", "since": "", "date": "2026-07-31", "title": "feat(ui): add \"What's New\" to the main menu" },
   { "feature": "chart-zoom-limits", "kind": "new", "since": "v2.1.0", "date": "2023-07-06", "title": "limit zoom to selected maps" },
   { "feature": "route-planning", "pr": 580, "kind": "enhanced", "since": "v3.1.0-beta.0", "date": "2026-07-25", "title": "feat(map): delete a route vertex with a long left-click, matching touch" },
   { "feature": "route-planning", "pr": 582, "kind": "enhanced", "since": "v3.1.0-beta.0", "date": "2026-07-25", "title": "feat(routes): unify the route draw and modify helper panels" },

--- a/features/feature-browser.md
+++ b/features/feature-browser.md
@@ -7,6 +7,7 @@ category: Display
 This very window you're looking at right now is the **Feature Browser** — a
 searchable "What's New" window covering everything Freeboard can do. Curious
 what a feature does, how to use it, or when it was added? Open it any time
+from the main menu — **What's New**, between **About** and **Help** — or
 from the **⋯ (More actions)** menu, no matter what you're doing on the
 chart.
 

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -398,6 +398,10 @@
                 <li>
                   Settings: Open the <a href="#settings">Settings</a> screen.
                 </li>
+                <li>
+                  What's New: Open the <b>Feature Browser</b> to browse and
+                  search everything Freeboard can do.
+                </li>
               </ul>
             </li>
           </ul>
@@ -1344,8 +1348,8 @@
               <br />&nbsp;<br />
               <i
                 >For how to use these controls, see the <b>Chart List</b> entry
-                in the Feature Browser (<b>More actions</b> &rarr;
-                <b>What's New</b>).</i
+                in the Feature Browser (<b>Main menu</b> or
+                <b>More actions</b> &rarr; <b>What's New</b>).</i
               >
             </div>
           </div>
@@ -2288,9 +2292,9 @@
           <i
             >For how to use these controls, see the
             <b>Live ETA at Cursor</b> entry in the Feature Browser (<b
-              >More actions</b
+              >Main menu</b
             >
-            &rarr; <b>What's New</b>).</i
+            or <b>More actions</b> &rarr; <b>What's New</b>).</i
           >
           <ul>
             <li>


### PR DESCRIPTION
PR #657 added a second way into the Feature Browser — a **What's New** item in the
main menu, between About and Help — but both shipped documentation surfaces still
described only the ⋯ (More actions) route.

The feature doc now names both entry points. In the online help, the **More Actions**
listing gains the What's New entry it never received when the browser first shipped,
and the two cross-references that send readers to the Feature Browser now name both
routes rather than one.

No feature prose was copied into the help — the pointers stay pointers.

@coderabbitai ignore
