### PR TITLE
fix(skresources): let the symbol pickers scroll on touch

### DIFF
--- a/src/app/modules/skresources/components/notes/note-dialog.html
+++ b/src/app/modules/skresources/components/notes/note-dialog.html
@@ -253,7 +253,14 @@
                   }
                 </mat-select-trigger>
                 @for(i of poiIcons; track i.id) {
-                <mat-option [value]="i.id" [matTooltip]="i.name"
+                <!-- Touch gestures off: on a touch platform MatTooltip sets
+                inline touch-action:none on its trigger to reserve the long
+                press, and every row of this panel is a trigger — so a finger
+                has nowhere to land that scrolls the list (#651). -->
+                <mat-option
+                  [value]="i.id"
+                  [matTooltip]="i.name"
+                  matTooltipTouchGestures="off"
                   ><mat-icon [svgIcon]="i.id">{{i.name}}</mat-icon>
                 </mat-option>
                 }

--- a/src/app/modules/skresources/components/symbol-picker-touch.spec.ts
+++ b/src/app/modules/skresources/components/symbol-picker-touch.spec.ts
@@ -19,12 +19,13 @@ import { WaypointDialog } from './waypoints/waypoint-dialog';
  * On a touch platform `MatTooltip` reserves the long press for itself by
  * writing an inline `touch-action: none` onto its trigger element
  * (`_disableNativeGesturesIfNecessary`). `touch-action` is read from wherever a
- * touch *starts*, so a trigger that fills every row of a scrolling list leaves
- * the finger nowhere to land that pans it: the note dialog's symbol dropdown
- * and the waypoint dialog's symbol grid both became unscrollable, stranding
- * every symbol below the fold. The desktop path takes the `mouseenter` branch
- * and never writes the style, which is why this only shows up on a tablet or a
- * chartplotter — for many Freeboard users, their only input device.
+ * touch *starts*, so a trigger filling every row of a scrolling list leaves the
+ * finger nowhere to land that pans it. Both pickers are built that way — every
+ * option of the note dialog's dropdown and every tile of the waypoint dialog's
+ * grid carries a tooltip — so each turns the tooltip's touch gestures off. The
+ * desktop path takes the `mouseenter` branch and never writes the style, so
+ * only a tablet or a chartplotter depends on this — for many Freeboard users,
+ * their only input device.
  *
  * These render each picker with the platform reported as iOS, since that is
  * what selects the touch branch inside the directive.

--- a/src/app/modules/skresources/components/symbol-picker-touch.spec.ts
+++ b/src/app/modules/skresources/components/symbol-picker-touch.spec.ts
@@ -1,0 +1,149 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Platform } from '@angular/cdk/platform';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSelect } from '@angular/material/select';
+import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { AppFacade } from 'src/app/app.facade';
+import { NoteDialog } from './notes/note-dialog';
+import { WaypointDialog } from './waypoints/waypoint-dialog';
+
+/**
+ * Symbol pickers must stay scrollable under a finger (#651).
+ *
+ * On a touch platform `MatTooltip` reserves the long press for itself by
+ * writing an inline `touch-action: none` onto its trigger element
+ * (`_disableNativeGesturesIfNecessary`). `touch-action` is read from wherever a
+ * touch *starts*, so a trigger that fills every row of a scrolling list leaves
+ * the finger nowhere to land that pans it: the note dialog's symbol dropdown
+ * and the waypoint dialog's symbol grid both became unscrollable, stranding
+ * every symbol below the fold. The desktop path takes the `mouseenter` branch
+ * and never writes the style, which is why this only shows up on a tablet or a
+ * chartplotter — for many Freeboard users, their only input device.
+ *
+ * These render each picker with the platform reported as iOS, since that is
+ * what selects the touch branch inside the directive.
+ */
+
+/** `touch-action: none` set on the element the finger lands on kills the pan. */
+const blocksTouchScroll = (el: HTMLElement) => el.style.touchAction === 'none';
+
+const appStub = {
+  config: {
+    units: { positionFormat: 'HDd' },
+    resources: { notes: { groupNameEdit: false } }
+  }
+} as unknown as AppFacade;
+
+const touchPlatform = {
+  provide: Platform,
+  useValue: { IOS: true, ANDROID: false, isBrowser: true }
+};
+
+const commonProviders = [
+  provideNoopAnimations(),
+  provideHttpClient(),
+  provideHttpClientTesting(),
+  touchPlatform,
+  { provide: AppFacade, useValue: appStub },
+  { provide: MatDialogRef, useValue: { close: () => undefined } }
+];
+
+describe('note dialog symbol dropdown', () => {
+  let fixture: ComponentFixture<NoteDialog>;
+  let overlay: OverlayContainer;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [NoteDialog],
+      providers: [
+        ...commonProviders,
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            title: 'Note',
+            editable: true,
+            addMode: true,
+            note: {
+              name: 'a note',
+              description: '',
+              mimeType: 'text/markdown',
+              properties: {}
+            },
+            position: null
+          }
+        }
+      ]
+    });
+
+    fixture = TestBed.createComponent(NoteDialog);
+    overlay = TestBed.inject(OverlayContainer);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // The options only exist once the panel is open — the symbol select is the
+    // first of the dialog's two (the second picks the note's format).
+    fixture.debugElement
+      .queryAll(By.directive(MatSelect))[0]
+      .componentInstance.open();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('leaves the option rows able to scroll the panel under a finger', () => {
+    const options = Array.from(
+      overlay.getContainerElement().querySelectorAll('mat-option')
+    ) as HTMLElement[];
+
+    // Guard the guard: an empty list would pass the assertion vacuously.
+    expect(options.length).toBeGreaterThan(1);
+    expect(options.filter(blocksTouchScroll)).toEqual([]);
+  });
+});
+
+describe('waypoint dialog symbol grid', () => {
+  let fixture: ComponentFixture<WaypointDialog>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [WaypointDialog],
+      providers: [
+        ...commonProviders,
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            title: 'Waypoint',
+            addMode: true,
+            waypoint: {
+              name: 'a waypoint',
+              description: '',
+              type: 'waypoint',
+              feature: {
+                geometry: { type: 'Point', coordinates: [0, 0] },
+                properties: {}
+              }
+            }
+          }
+        }
+      ]
+    });
+
+    fixture = TestBed.createComponent(WaypointDialog);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('leaves the symbol tiles able to scroll the grid under a finger', () => {
+    const tiles = Array.from(
+      fixture.nativeElement.querySelectorAll('.unselected-icon mat-icon')
+    ) as HTMLElement[];
+
+    expect(tiles.length).toBeGreaterThan(1);
+    expect(tiles.filter(blocksTouchScroll)).toEqual([]);
+  });
+});

--- a/src/app/modules/skresources/components/waypoints/waypoint-dialog.ts
+++ b/src/app/modules/skresources/components/waypoints/waypoint-dialog.ts
@@ -211,9 +211,15 @@ interface DialogData {
                         }"
                         (click)="handleIconSelected($index)"
                       >
+                        <!-- Touch gestures off: on a touch platform MatTooltip
+                        sets inline touch-action:none on its trigger to reserve
+                        the long press, and every tile of this scrolling grid is
+                        a trigger — so a finger has nowhere to land that scrolls
+                        it (#651). -->
                         <mat-icon
                           [svgIcon]="i.svgIcon"
                           [matTooltip]="i.svgIcon"
+                          matTooltipTouchGestures="off"
                         ></mat-icon>
                       </div>
                     }


### PR DESCRIPTION
Freeboard's symbol pickers could not be scrolled with a finger, so every symbol
below the fold was unreachable — worst with "Show all symbols" on. On the tablets
and touchscreen chartplotters much of our audience steers with, that is the only
input method, which left the pickers effectively unusable.

`MatTooltip` claims the long press on a touch platform by writing an inline
`touch-action: none` onto its trigger element. `touch-action` is read from
wherever a touch *begins*, so a trigger occupying every row of a scrolling list
leaves a finger nowhere to land that pans it. Both pickers are built exactly that
way — every option of the note dialog's dropdown and every tile of the waypoint
dialog's grid carries a tooltip — so neither scrolled. The desktop `mouseenter`
branch never writes that style, which is why this never appeared with a mouse.

Turning the tooltip's touch gestures off restores the scroll. The cost is the
long-press symbol name on touch, which could not be used anyway while it was the
thing blocking the scroll.

The waypoint picker is included because it is the same defect in the same
feature, one attribute away, and would be hit immediately after the note dialog
alone was fixed.

The test renders both dialogs with the platform reported as iOS — the condition
that selects the touch branch inside the directive — and asserts no picker row
carries `touch-action: none`. Without the fix it flags all 21 options and all 20
tiles.

No screenshots: nothing changes visually, only whether a drag scrolls. Verified
on a physical touch device — both pickers scroll.

Note on CI: the advisory armv7 (Cerbo GX) leg fails on the 900s `test:ci` hard
timeout. That cap is already nearly exhausted on `master` (763s measured at 53
spec files), so it is tripped by the addition of any spec file rather than by
anything specific to this one — the suite is unchanged in cost on every other
platform. Filed separately.

Closes #651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch scrolling in note and waypoint icon pickers.
  * Prevented icon tooltips from interfering with scrolling on touch devices.
  * Retained desktop tooltip labels and icon selection behavior.

* **Tests**
  * Added regression coverage for touch scrolling in both symbol pickers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->