### PR TITLE
chore(ci): give the emulated armv7 leg a larger test-phase budget

### DIFF
--- a/scripts/test-ci.mjs
+++ b/scripts/test-ci.mjs
@@ -40,7 +40,19 @@ const SUMMARY = /Test Files\s+\d+\s+(?:failed|passed)/;
 // so no vitest summary is coming — fail fast instead of riding the hard timeout.
 const BUILD_ERROR = /✘ \[ERROR\]/;
 const GRACE_MS = 10_000; // let ng exit on its own before we force it
-const HARD_TIMEOUT_MS = 15 * 60 * 1000; // backstop if no summary ever prints
+// Backstop if no summary ever prints. The armv7 (Cerbo GX) CI leg runs the whole
+// suite under QEMU emulation, where the test phase costs ~800s against ~60s
+// native and grows with every spec file added, so it needs a budget the other
+// platforms don't. Only 32-bit ARM gets it (same detection as
+// vitest-base.config.ts) — native keeps the tighter one so real hangs surface
+// quickly.
+//
+// 18min is derived, not a round number. The shared plugin-ci armv7 job is capped
+// at 30min and spends ~600s reaching the test step (npm ci, npm rebuild,
+// build:all, plus checkout and QEMU setup), leaving ~1200s. A budget at that
+// ceiling could never fire — GitHub would kill the job first, with none of this
+// wrapper's diagnostics — so it sits below it, with room for a cold npm cache.
+const HARD_TIMEOUT_MS = (process.arch === 'arm' ? 18 : 15) * 60 * 1000;
 
 const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
 


### PR DESCRIPTION
The advisory armv7 (Cerbo GX) leg runs the full suite under QEMU, where the test
phase costs ~815s against ~60s native. `scripts/test-ci.mjs` applied a single
15-minute backstop on every platform, which left ~85s of headroom at 56 spec
files — so the leg failed whenever a PR added a spec, regardless of what the spec
did. A red advisory job that says nothing about the change that triggered it is
worse than no job.

Size the backstop by platform, the way `vitest-base.config.ts` already sizes
`testTimeout`/`hookTimeout`. Only 32-bit ARM gets the larger budget; every other
platform keeps 15 minutes, so a genuine hang still surfaces quickly.

18 minutes is derived, not picked: the shared `plugin-ci` armv7 job is capped at
30 minutes and spends ~600s reaching the test step (`npm ci`, `npm rebuild`,
`build:all`, plus checkout and QEMU setup), leaving ~1200s. A cap at that ceiling
could never fire — GitHub would kill the job first and report a bare timeout with
none of the wrapper's diagnostics — so it sits below it, with room for a cold npm
cache.

**This buys headroom, not a cure.** Per-file module import and jsdom environment
setup cost ~11s each under emulation — test bodies are only ~10% of the run — so
the 30-minute job cap is the next ceiling, roughly 25 spec files out. Cutting
per-file cost, or running a subset of specs on that leg, is the durable fix if the
leg is worth keeping.

Measured on the last green master run (55 spec files): the docker step took 1394s
= 579s install/build + 815s test phase, with vitest reporting
`Duration 630.30s (transform 62.15s, setup 236.46s, import 786.42s, tests 65.97s,
environment 527.41s)`.

No accompanying spec: the change is a constant in a Node script, and the test
target only collects specs under `src/`, so a test asserting it would add ~11s to
the very leg this unblocks while testing implementation rather than behaviour. The
derivation is documented in the code instead.

Closes #664
