### PR TITLE
chore(deps): ignore jsdom major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,15 @@ updates:
         update-types:
           - 'version-update:semver-major'
           - 'version-update:semver-minor'
+      # jsdom 30 requires Node '^22.22.2 || ^24.15.0 || >=26', dropping Node 20.
+      # The advisory armv7 (Cerbo GX / Venus OS) leg runs Node 20, where jsdom 30
+      # installs (EBADENGINE is only a warning) but then throws on require, so
+      # every spec errors and the leg fails permanently. jsdom is dev-only, so
+      # this costs no runtime support — but a leg that is always red reports
+      # nothing about the change under test. Revisit if that leg moves off
+      # Node 20; in-range minor/patch still flow through the groups.
+      - dependency-name: 'jsdom'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
jsdom 30 requires Node `^22.22.2 || ^24.15.0 || >=26`, dropping Node 20. The advisory armv7 (Cerbo GX / Venus OS) leg runs Node 20, where jsdom 30 installs — `EBADENGINE` is only a warning — but then throws on require, so every spec errors and the leg fails. Observed on #660: 54 errors, "no tests", then the 900s cap.

jsdom is a devDependency, so this costs no runtime support — users install without devDeps. What it costs is signal: a permanently red leg reports nothing about the change under test, and burns ~25 minutes of QEMU per run to say so. Related: #664, which tracks that leg's timeout headroom.

Keeping the rule here rather than using an `@dependabot ignore` comment puts the decision and its rationale in the repo alongside the other five ignore rules, instead of in Dependabot's hidden per-PR state.

Closes #660.

@coderabbitai ignore