### PR TITLE
fix(charts): keep zoom range and source when cloning a chart

### DIFF
--- a/src/app/modules/skresources/resource-classes.spec.ts
+++ b/src/app/modules/skresources/resource-classes.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { SKChart } from './resource-classes';
+
+/**
+ * `SKChart` is constructed from a server chart resource, which spells its zoom
+ * bounds `minzoom`/`maxzoom` and its source `$source`. The instance spells them
+ * `minZoom`/`maxZoom`/`source`, so re-constructing from an existing instance --
+ * how the chart cache clones an entry to trigger a re-render -- must not fall
+ * back to the class defaults and drop those fields.
+ */
+describe('SKChart', () => {
+  it('keeps the declared zoom range when cloning an instance', () => {
+    const original = new SKChart({
+      name: 'Rannikkokartat',
+      url: 'http://x/{z}/{x}/{y}.png',
+      minzoom: 9,
+      maxzoom: 13
+    });
+
+    const clone = new SKChart(original);
+
+    expect(clone.minZoom).toBe(9);
+    expect(clone.maxZoom).toBe(13);
+  });
+
+  it('keeps the source when cloning an instance', () => {
+    const original = new SKChart({
+      name: 'Local chart',
+      url: 'http://x/{z}/{x}/{y}.png',
+      $source: 'resources-provider'
+    });
+
+    expect(new SKChart(original).source).toBe('resources-provider');
+  });
+
+  it('reads the zoom range and source from a server chart resource', () => {
+    const chart = new SKChart({
+      name: 'Merikarttasarjat',
+      url: 'http://x/{z}/{x}/{y}.png',
+      minzoom: 5,
+      maxzoom: 15,
+      $source: 'charts-plugin'
+    });
+
+    expect(chart.minZoom).toBe(5);
+    expect(chart.maxZoom).toBe(15);
+    expect(chart.source).toBe('charts-plugin');
+  });
+
+  it('honours a declared minimum of 0 rather than treating it as absent', () => {
+    const chart = new SKChart({
+      name: 'World',
+      url: 'http://x/{z}/{x}/{y}.png',
+      minzoom: 0,
+      maxzoom: 0
+    });
+
+    expect(new SKChart(chart).minZoom).toBe(0);
+    expect(new SKChart(chart).maxZoom).toBe(0);
+  });
+
+  it('falls back to the class defaults when no range is declared', () => {
+    const chart = new SKChart({
+      name: 'No range',
+      url: 'http://x/{z}/{x}/{y}.png'
+    });
+
+    expect(chart.minZoom).toBe(0);
+    expect(chart.maxZoom).toBe(24);
+    expect(new SKChart(chart).minZoom).toBe(0);
+    expect(new SKChart(chart).maxZoom).toBe(24);
+  });
+});

--- a/src/app/modules/skresources/resource-classes.ts
+++ b/src/app/modules/skresources/resource-classes.ts
@@ -137,17 +137,19 @@ export class SKChart {
   imageAdjustment?: ChartImageAdjustment;
   proxy: boolean;
 
-  constructor(chart?: ChartResource) {
+  // Accepts a server chart resource or an existing SKChart: the chart cache
+  // re-constructs an entry from an instance to trigger a re-render, and the
+  // instance spells these three fields differently to the resource.
+  constructor(chart?: ChartResource | SKChart) {
+    const src = chart as (ChartResource & SKChart) | undefined;
     this.identifier = chart?.identifier ? chart.identifier : undefined;
     this.name = chart?.name ? chart.name : undefined;
     this.description = chart?.description ? chart.description : undefined;
     this.layers = chart?.layers ? chart.layers : [];
     this.bounds = chart?.bounds ? chart.bounds : undefined;
     this.format = chart?.format ? chart.format : undefined;
-    this.minZoom =
-      typeof chart?.minzoom !== 'undefined' ? chart.minzoom : this.minZoom;
-    this.maxZoom =
-      typeof chart?.maxzoom !== 'undefined' ? chart.maxzoom : this.maxZoom;
+    this.minZoom = src?.minzoom ?? src?.minZoom ?? this.minZoom;
+    this.maxZoom = src?.maxzoom ?? src?.maxZoom ?? this.maxZoom;
     this.tileSize =
       typeof chart?.tileSize !== 'undefined' ? chart.tileSize : this.tileSize;
     this.type = chart?.type ? chart.type : undefined;
@@ -157,7 +159,7 @@ export class SKChart {
         ? chart.scale
         : this.scale;
     this.style = chart?.style ?? undefined;
-    this.source = chart?.$source ?? undefined;
+    this.source = src?.$source ?? src?.source ?? undefined;
     this.defaultOpacity = chart?.defaultOpacity ?? 1;
     this.imageAdjustment = chart?.imageAdjustment;
     this.proxy = chart?.proxy ?? false;


### PR DESCRIPTION
Cloning an `SKChart` silently reset two of its fields.

The constructor reads a chart resource, which spells the zoom bounds `minzoom`/`maxzoom` and the source `$source`. An `SKChart` instance spells them `minZoom`/`maxZoom`/`source`, so re-constructing from an existing instance fell through to the class defaults — resetting the declared range to 0–24 and dropping the source. Three call sites clone this way: both live-preview setters in `SKResourceService`, and `updateFullList()` in the chart list.

Visible today: adjust a chart's opacity, and that chart's zoom limits reset to 0–24 and the delete button disappears from its row (the template gates on `source`).

The constructor now accepts either shape. `resource-classes.spec.ts` is new — it covers the clone round trip, the source, the server-resource path, and a declared bound of 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart creation and cloning to preserve zoom limits and source metadata.
  * Correctly handles zero-valued zoom settings and applies defaults only when values are missing.

* **Tests**
  * Added coverage for chart construction, cloning, server-resource field mapping, metadata preservation, and zoom fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->