### PR TITLE
fix(charts): make the adjustment palette usable beside the chart list

### DIFF
--- a/src/app/lib/components/dialogs/image-adjustment-dialog.ts
+++ b/src/app/lib/components/dialogs/image-adjustment-dialog.ts
@@ -40,7 +40,7 @@ const toRatio = (percent: number) => percent / 100;
   template: `
     <div
       class="_ap-image-adjustment"
-      style="overflow: hidden;"
+      style="overflow: hidden; color: var(--mat-app-text-color);"
       cdkDrag
       cdkDragRootElement=".cdk-overlay-pane"
       [cdkDragFreeDragPosition]="initialPosition"
@@ -51,7 +51,18 @@ const toRatio = (percent: number) => percent / 100;
         style="display:flex; align-items:center; cursor:move; padding: 4px 4px 0 12px;"
       >
         <mat-icon style="opacity:0.6;">tune</mat-icon>
-        <div style="flex: 1 1 auto; padding-left: 8px; font-weight: 500;">
+        <div
+          style="
+            flex: 1 1 auto;
+            min-width: 0;
+            padding-left: 8px;
+            font-weight: 500;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          "
+          [title]="data.text"
+        >
           {{ data.text }}
         </div>
         <button mat-icon-button aria-label="Close" (click)="handleClose(false)">

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -317,10 +317,9 @@ export class ChartListComponent extends ResourceListBase {
   }
 
   protected itemImageAdjustment(chart: FBChart) {
-    // The palette is modeless and owned by the service so it survives the chart
-    // list closing, which frees the map for the live adjustment preview.
+    // The palette is modeless and owned by the service, and the list stays open
+    // beside it: adjusting one chart of a stack usually means adjusting more.
     this.skres.openImageAdjustment(chart);
-    this.close();
   }
 
   updateFullList(chart: FBChart) {

--- a/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
+++ b/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
@@ -123,32 +123,46 @@ describe('openImageAdjustment (#457)', () => {
     // The palette now opens clear of the chart list, so an offset saved against
     // the old origin can put the drag handle -- the only way to move it back --
     // past the viewport edge.
-    const withViewport = (width: number, fn: () => void) => {
-      const original = window.innerWidth;
-      Object.defineProperty(window, 'innerWidth', {
-        value: width,
-        configurable: true
-      });
+    const withViewport = (
+      width: number,
+      height: number | undefined,
+      fn: () => void
+    ) => {
+      const original = {
+        width: window.innerWidth,
+        height: window.innerHeight
+      };
+      const set = (w: number, h: number) => {
+        Object.defineProperty(window, 'innerWidth', {
+          value: w,
+          configurable: true
+        });
+        Object.defineProperty(window, 'innerHeight', {
+          value: h,
+          configurable: true
+        });
+      };
+      set(width, height ?? original.height);
       try {
         fn();
       } finally {
-        Object.defineProperty(window, 'innerWidth', {
-          value: original,
-          configurable: true
-        });
+        set(original.width, original.height);
       }
     };
 
     const openWith = (
       pos: { x: number; y: number } | null,
-      viewportWidth: number
+      viewportWidth: number,
+      viewportHeight?: number
     ) => {
       const { svc, config, getData } = svcWithResult({
         apply: false,
         value: { brightness: 1, contrast: 1 }
       });
       config.imageAdjustPalettePos = pos;
-      withViewport(viewportWidth, () => svc.openImageAdjustment(chart()));
+      withViewport(viewportWidth, viewportHeight, () =>
+        svc.openImageAdjustment(chart())
+      );
       return getData().position;
     };
 
@@ -161,6 +175,19 @@ describe('openImageAdjustment (#457)', () => {
 
     it('pulls a negative vertical offset back to the top', () => {
       expect(openWith({ x: 0, y: -500 }, 1024).y).toBe(0);
+    });
+
+    it('pulls an offset below the bottom edge back into view', () => {
+      // Saved on a tall window, restored on a short one: without a downward
+      // clamp the palette opens past the fold, taking its drag handle with it.
+      const y = openWith({ x: 0, y: 900 }, 1024, 600).y;
+      expect(y).toBeLessThan(900);
+      // Its header still sits above the bottom of the 600px viewport.
+      expect(70 + y).toBeLessThanOrEqual(600 - 40);
+    });
+
+    it('does not push the palette above the top on a very short viewport', () => {
+      expect(openWith({ x: 0, y: 300 }, 1024, 60).y).toBe(0);
     });
 
     it('leaves a position that already fits alone', () => {

--- a/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
+++ b/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
@@ -119,6 +119,65 @@ describe('openImageAdjustment (#457)', () => {
     expect(getData().position).toEqual({ x: 120, y: 40 });
   });
 
+  describe('keeping a remembered position on screen', () => {
+    // The palette now opens clear of the chart list, so an offset saved against
+    // the old origin can put the drag handle -- the only way to move it back --
+    // past the viewport edge.
+    const withViewport = (width: number, fn: () => void) => {
+      const original = window.innerWidth;
+      Object.defineProperty(window, 'innerWidth', {
+        value: width,
+        configurable: true
+      });
+      try {
+        fn();
+      } finally {
+        Object.defineProperty(window, 'innerWidth', {
+          value: original,
+          configurable: true
+        });
+      }
+    };
+
+    const openWith = (
+      pos: { x: number; y: number } | null,
+      viewportWidth: number
+    ) => {
+      const { svc, config, getData } = svcWithResult({
+        apply: false,
+        value: { brightness: 1, contrast: 1 }
+      });
+      config.imageAdjustPalettePos = pos;
+      withViewport(viewportWidth, () => svc.openImageAdjustment(chart()));
+      return getData().position;
+    };
+
+    it('pulls a position past the right edge back into view', () => {
+      const position = openWith({ x: 4000, y: 40 }, 1024);
+      expect(position.x).toBeLessThan(4000);
+      // Still far enough left that the whole 290px palette fits.
+      expect(position.x).toBeLessThanOrEqual(1024 - 290);
+    });
+
+    it('pulls a negative vertical offset back to the top', () => {
+      expect(openWith({ x: 0, y: -500 }, 1024).y).toBe(0);
+    });
+
+    it('leaves a position that already fits alone', () => {
+      expect(openWith({ x: 40, y: 40 }, 1600)).toEqual({ x: 40, y: 40 });
+    });
+
+    it('passes through when no position was ever saved', () => {
+      expect(openWith(null, 1024)).toBeNull();
+    });
+
+    it('keeps the palette on screen on a viewport too narrow for both', () => {
+      // Clamped to the gap rather than pushed off to the right of the list.
+      const position = openWith({ x: 0, y: 0 }, 420);
+      expect(position.x).toBeLessThanOrEqual(420 - 290);
+    });
+  });
+
   it('persists the palette position when dragged', () => {
     const { svc, config, saveConfig, getData } = svcWithResult({
       apply: false,

--- a/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
+++ b/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { SKResourceService } from './resources.service';
 import { ChartImageAdjustment, FBChart } from 'src/app/types';
 import { ImageAdjustmentDialogResult } from 'src/app/lib/components';
@@ -216,5 +216,67 @@ describe('openImageAdjustment (#457)', () => {
 
     expect(config.imageAdjustPalettePos).toEqual({ x: 200, y: 90 });
     expect(saveConfig).toHaveBeenCalledOnce();
+  });
+});
+
+/**
+ * A replaced palette closes an exit animation after its replacement is already
+ * on screen, so its cancel path runs late. On a slow client that is long enough
+ * for a queued click to have opened the replacement and moved the value, and a
+ * revert landing then would put the pre-edit adjustment back over it.
+ */
+describe('openImageAdjustment — a palette closing after it was replaced', () => {
+  const svcWithLateClose = () => {
+    const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+    const closes: Subject<ImageAdjustmentDialogResult | undefined>[] = [];
+    const chartImageAdjustment: Record<string, ChartImageAdjustment> = {
+      c1: { brightness: 1.1, contrast: 1.2 },
+      c2: { brightness: 0.9, contrast: 1 }
+    };
+    (svc as unknown as { app: unknown }).app = {
+      config: {
+        selections: { chartImageAdjustment },
+        imageAdjustPalettePos: null
+      },
+      saveConfig: vi.fn()
+    };
+    (svc as unknown as { dialog: unknown }).dialog = {
+      open: () => {
+        const closed = new Subject<ImageAdjustmentDialogResult | undefined>();
+        closes.push(closed);
+        return { afterClosed: () => closed, close: vi.fn() };
+      }
+    };
+    const setSpy = vi.fn();
+    svc.chartSetImageAdjustment = setSpy;
+    return { svc, closes, setSpy };
+  };
+
+  const chartNamed = (id: string): FBChart =>
+    [id, { name: id }, true] as unknown as FBChart;
+
+  it('leaves the preview to a replacement over the same chart', () => {
+    const { svc, closes, setSpy } = svcWithLateClose();
+
+    svc.openImageAdjustment(chartNamed('c1'));
+    svc.openImageAdjustment(chartNamed('c1'));
+    setSpy.mockClear();
+    closes[0].next(undefined);
+
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('still reverts its own chart when the replacement is for another', () => {
+    const { svc, closes, setSpy } = svcWithLateClose();
+
+    svc.openImageAdjustment(chartNamed('c1'));
+    svc.openImageAdjustment(chartNamed('c2'));
+    setSpy.mockClear();
+    closes[0].next(undefined);
+
+    expect(setSpy).toHaveBeenCalledWith('c1', {
+      brightness: 1.1,
+      contrast: 1.2
+    });
   });
 });

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -1,7 +1,11 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { moveItemInArray } from '@angular/cdk/drag-drop';
 import { HttpErrorResponse } from '@angular/common/http';
-import { MatDialog } from '@angular/material/dialog';
+import {
+  MatDialog,
+  MatDialogConfig,
+  MatDialogRef
+} from '@angular/material/dialog';
 import ngeohash from 'ngeohash';
 import { Collection, Feature } from 'ol';
 
@@ -83,6 +87,11 @@ export class SKResourceService {
 
   private app = inject(AppFacade);
   private dialog = inject(MatDialog);
+  // The open modeless per-chart palette (image adjustment or minimum zoom).
+  // They are backdrop-less and share a position, so a second one would cover the
+  // first completely — and the covered one still reverts its chart when closed.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private chartPaletteRef?: MatDialogRef<any, any>;
   private signalk = inject(SignalKClient);
   private worker = inject(SKWorkerService);
   private mapInteract = inject(FBMapInteractService);
@@ -859,8 +868,8 @@ export class SKResourceService {
   /**
    * @description Open the modeless, draggable Image Adjustment palette for a
    * chart. Sliders take effect live; SAVE persists per-chart, closing (cancel)
-   * reverts to the pre-edit values. Owned here (not the chart list) so it
-   * survives the chart list closing to free the map.
+   * reverts to the pre-edit values. Owned here (not the chart list) so the list
+   * can stay open beside it while several charts are adjusted.
    * @param chart Chart to adjust
    */
   public openImageAdjustment(chart: FBChart) {
@@ -872,38 +881,117 @@ export class SKResourceService {
         chart[1]?.imageAdjustment)
     };
 
-    this.dialog
-      .open(ImageAdjustmentDialog, {
-        hasBackdrop: false,
-        disableClose: true,
-        autoFocus: false,
-        restoreFocus: false,
-        position: { top: '70px', left: '8px' },
-        width: '290px',
-        data: {
-          text: chart[1]?.name ?? '',
-          value: { ...original },
-          position: this.app.config.imageAdjustPalettePos,
-          onChange: (value: ChartImageAdjustment) => {
-            this.chartSetImageAdjustment(id, value);
-          },
-          onMoved: (position: PalettePosition) => {
-            this.app.config.imageAdjustPalettePos = position;
-            this.app.saveConfig();
-          }
-        }
-      })
-      .afterClosed()
-      .subscribe((result: ImageAdjustmentDialogResult) => {
-        if (result?.apply) {
-          this.app.config.selections.chartImageAdjustment[id] = result.value;
-          this.chartSetImageAdjustment(id, result.value);
+    const ref = this.openChartPalette(ImageAdjustmentDialog, {
+      width: '290px',
+      data: {
+        text: chart[1]?.name ?? '',
+        value: { ...original },
+        position: this.onScreenPalettePosition(
+          this.app.config.imageAdjustPalettePos,
+          290
+        ),
+        onChange: (value: ChartImageAdjustment) => {
+          this.chartSetImageAdjustment(id, value);
+        },
+        onMoved: (position: PalettePosition) => {
+          this.app.config.imageAdjustPalettePos = position;
           this.app.saveConfig();
-        } else {
-          // cancelled - restore the pre-edit adjustment
-          this.chartSetImageAdjustment(id, original);
         }
-      });
+      }
+    });
+
+    ref.afterClosed().subscribe((result: ImageAdjustmentDialogResult) => {
+      this.releaseChartPalette(ref);
+      if (result?.apply) {
+        this.app.config.selections.chartImageAdjustment[id] = result.value;
+        this.chartSetImageAdjustment(id, result.value);
+        this.app.saveConfig();
+      } else {
+        // cancelled - restore the pre-edit adjustment
+        this.chartSetImageAdjustment(id, original);
+      }
+    });
+  }
+
+  /**
+   * @description Open a modeless per-chart palette, replacing any already open.
+   * They are backdrop-less and share a position, so only one may be on screen.
+   * @param component Palette component
+   * @param config Component-specific dialog config
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private openChartPalette<T>(
+    component: any,
+    config: MatDialogConfig
+  ): MatDialogRef<T> {
+    this.chartPaletteRef?.close();
+    this.chartPaletteRef = this.dialog.open(component, {
+      hasBackdrop: false,
+      disableClose: true,
+      autoFocus: false,
+      restoreFocus: false,
+      // Clear of the chart list, which stays open beside it, unless the
+      // viewport is too narrow for both.
+      position: { top: '70px', left: `${this.chartDialogLeft()}px` },
+      ...config
+    });
+    return this.chartPaletteRef;
+  }
+
+  /**
+   * @description Forget a closed palette. `afterClosed` fires after the next
+   * `open()` has already stored its ref, so only clear the field when it still
+   * points at the palette that closed.
+   * @param ref Palette that closed
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private releaseChartPalette(ref: MatDialogRef<any, any>) {
+    if (this.chartPaletteRef === ref) {
+      this.chartPaletteRef = undefined;
+    }
+  }
+
+  /**
+   * @description A saved palette drag offset brought back on screen. The offset
+   * is relative to where the palette opens, which moved to clear the chart list,
+   * so an offset saved against the old origin could put the drag handle -- the
+   * only way to move it back -- past the viewport edge.
+   */
+  private onScreenPalettePosition(
+    position: PalettePosition | null,
+    width: number
+  ): PalettePosition | null {
+    if (!position) {
+      return position;
+    }
+    // The saved offset is relative to where the palette opens, which moved to
+    // clear the chart list. Left as-is, a palette dragged right under the old
+    // origin could land past the viewport edge, taking its drag handle with it.
+    const left = this.chartDialogLeft();
+    const maxX = window.innerWidth - left - width - 8;
+    const minX = -(left - 8);
+    return {
+      x: Math.max(minX, Math.min(position.x, maxX)),
+      y: Math.max(0, position.y)
+    };
+  }
+
+  /**
+   * @description Left offset that clears the chart list when both are open,
+   * clamped so the palette stays on screen on a narrow display.
+   */
+  private chartDialogLeft(): number {
+    // Matches .leftMenuPanel in app.component.css.
+    const CHART_LIST_WIDTH = 315;
+    const DIALOG_WIDTH = 300;
+    const GAP = 8;
+    return Math.max(
+      GAP,
+      Math.min(
+        CHART_LIST_WIDTH + GAP,
+        window.innerWidth - DIALOG_WIDTH - GAP * 2
+      )
+    );
   }
 
   /**

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -97,6 +97,9 @@ export class SKResourceService {
   // They are backdrop-less and share a position, so a second one would cover the
   // first completely — and the covered one still reverts its chart when closed.
   private chartPaletteRef?: MatDialogRef<unknown, unknown>;
+  // What the open palette edits, so a palette closing after its replacement
+  // has opened can tell a hand-over from an unrelated palette taking the slot.
+  private chartPaletteEdit?: string;
   private signalk = inject(SignalKClient);
   private worker = inject(SKWorkerService);
   private mapInteract = inject(FBMapInteractService);
@@ -889,32 +892,37 @@ export class SKResourceService {
     const ref = this.openChartPalette<
       ImageAdjustmentDialog,
       ImageAdjustmentDialogResult
-    >(ImageAdjustmentDialog, {
-      width: '290px',
-      data: {
-        text: chart[1]?.name ?? '',
-        value: { ...original },
-        position: this.onScreenPalettePosition(
-          this.app.config.imageAdjustPalettePos,
-          290
-        ),
-        onChange: (value: ChartImageAdjustment) => {
-          this.chartSetImageAdjustment(id, value);
-        },
-        onMoved: (position: PalettePosition) => {
-          this.app.config.imageAdjustPalettePos = position;
-          this.app.saveConfig();
+    >(
+      ImageAdjustmentDialog,
+      {
+        width: '290px',
+        data: {
+          text: chart[1]?.name ?? '',
+          value: { ...original },
+          position: this.onScreenPalettePosition(
+            this.app.config.imageAdjustPalettePos,
+            290
+          ),
+          onChange: (value: ChartImageAdjustment) => {
+            this.chartSetImageAdjustment(id, value);
+          },
+          onMoved: (position: PalettePosition) => {
+            this.app.config.imageAdjustPalettePos = position;
+            this.app.saveConfig();
+          }
         }
-      }
-    });
+      },
+      `imageAdjustment:${id}`
+    );
 
     ref.afterClosed().subscribe((result?: ImageAdjustmentDialogResult) => {
+      const handedOver = this.paletteHandedOver(`imageAdjustment:${id}`, ref);
       this.releaseChartPalette(ref);
       if (result?.apply) {
         this.app.config.selections.chartImageAdjustment[id] = result.value;
         this.chartSetImageAdjustment(id, result.value);
         this.app.saveConfig();
-      } else {
+      } else if (!handedOver) {
         // cancelled - restore the pre-edit adjustment
         this.chartSetImageAdjustment(id, original);
       }
@@ -926,10 +934,14 @@ export class SKResourceService {
    * They are backdrop-less and share a position, so only one may be on screen.
    * @param component Palette component
    * @param config Component-specific dialog config
+   * @param edit What the palette edits, as `<setting>:<chart id>` -- the same
+   * string identifies a later palette as a continuation of this edit rather
+   * than a different one
    */
   private openChartPalette<T, R>(
     component: ComponentType<T>,
-    config: MatDialogConfig<unknown>
+    config: MatDialogConfig<unknown>,
+    edit: string
   ): MatDialogRef<T, R> {
     this.chartPaletteRef?.close();
     const ref = this.dialog.open<T, unknown, R>(component, {
@@ -946,6 +958,7 @@ export class SKResourceService {
       ...config
     });
     this.chartPaletteRef = ref;
+    this.chartPaletteEdit = edit;
     return ref;
   }
 
@@ -958,7 +971,24 @@ export class SKResourceService {
   private releaseChartPalette(ref: MatDialogRef<unknown, unknown>) {
     if (this.chartPaletteRef === ref) {
       this.chartPaletteRef = undefined;
+      this.chartPaletteEdit = undefined;
     }
+  }
+
+  /**
+   * @description True when the palette that closed was replaced by a newer one
+   * over the same edit. Its preview belongs to the replacement by then, so the
+   * cancel path must leave it alone -- `afterClosed` arrives an exit animation
+   * late, and on a slow client that is long enough for a queued click to have
+   * opened the replacement and moved the value.
+   * @param edit Edit the closing palette was opened for
+   * @param ref Palette that closed
+   */
+  private paletteHandedOver(
+    edit: string,
+    ref: MatDialogRef<unknown, unknown>
+  ): boolean {
+    return this.chartPaletteRef !== ref && this.chartPaletteEdit === edit;
   }
 
   /**

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { moveItemInArray } from '@angular/cdk/drag-drop';
+import { ComponentType } from '@angular/cdk/portal';
 import { HttpErrorResponse } from '@angular/common/http';
 import {
   MatDialog,
@@ -95,8 +96,7 @@ export class SKResourceService {
   // The open modeless per-chart palette (image adjustment or minimum zoom).
   // They are backdrop-less and share a position, so a second one would cover the
   // first completely — and the covered one still reverts its chart when closed.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private chartPaletteRef?: MatDialogRef<any, any>;
+  private chartPaletteRef?: MatDialogRef<unknown, unknown>;
   private signalk = inject(SignalKClient);
   private worker = inject(SKWorkerService);
   private mapInteract = inject(FBMapInteractService);
@@ -886,7 +886,10 @@ export class SKResourceService {
         chart[1]?.imageAdjustment)
     };
 
-    const ref = this.openChartPalette(ImageAdjustmentDialog, {
+    const ref = this.openChartPalette<
+      ImageAdjustmentDialog,
+      ImageAdjustmentDialogResult
+    >(ImageAdjustmentDialog, {
       width: '290px',
       data: {
         text: chart[1]?.name ?? '',
@@ -905,7 +908,7 @@ export class SKResourceService {
       }
     });
 
-    ref.afterClosed().subscribe((result: ImageAdjustmentDialogResult) => {
+    ref.afterClosed().subscribe((result?: ImageAdjustmentDialogResult) => {
       this.releaseChartPalette(ref);
       if (result?.apply) {
         this.app.config.selections.chartImageAdjustment[id] = result.value;
@@ -924,13 +927,12 @@ export class SKResourceService {
    * @param component Palette component
    * @param config Component-specific dialog config
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private openChartPalette<T>(
-    component: any,
-    config: MatDialogConfig
-  ): MatDialogRef<T> {
+  private openChartPalette<T, R>(
+    component: ComponentType<T>,
+    config: MatDialogConfig<unknown>
+  ): MatDialogRef<T, R> {
     this.chartPaletteRef?.close();
-    this.chartPaletteRef = this.dialog.open(component, {
+    const ref = this.dialog.open<T, unknown, R>(component, {
       hasBackdrop: false,
       disableClose: true,
       autoFocus: false,
@@ -943,7 +945,8 @@ export class SKResourceService {
       },
       ...config
     });
-    return this.chartPaletteRef;
+    this.chartPaletteRef = ref;
+    return ref;
   }
 
   /**
@@ -952,8 +955,7 @@ export class SKResourceService {
    * points at the palette that closed.
    * @param ref Palette that closed
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private releaseChartPalette(ref: MatDialogRef<any, any>) {
+  private releaseChartPalette(ref: MatDialogRef<unknown, unknown>) {
     if (this.chartPaletteRef === ref) {
       this.chartPaletteRef = undefined;
     }

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -80,6 +80,11 @@ export type SKResourceType =
 
 export type SKSelection = SKResourceType | 'aisTargets' | 'infolayers';
 
+/** Where a per-chart palette opens, below the map's top controls. */
+const PALETTE_TOP = 70;
+/** Header depth kept on screen, so the palette's drag handle stays reachable. */
+const PALETTE_HEADER = 40;
+
 // ** Signal K resource operations
 @Injectable({ providedIn: 'root' })
 export class SKResourceService {
@@ -932,7 +937,10 @@ export class SKResourceService {
       restoreFocus: false,
       // Clear of the chart list, which stays open beside it, unless the
       // viewport is too narrow for both.
-      position: { top: '70px', left: `${this.chartDialogLeft()}px` },
+      position: {
+        top: `${PALETTE_TOP}px`,
+        left: `${this.chartDialogLeft()}px`
+      },
       ...config
     });
     return this.chartPaletteRef;
@@ -970,9 +978,12 @@ export class SKResourceService {
     const left = this.chartDialogLeft();
     const maxX = window.innerWidth - left - width - 8;
     const minX = -(left - 8);
+    // Downward too: an offset saved on a tall window drops the palette off the
+    // bottom of a short one, which hides the same drag handle.
+    const maxY = Math.max(0, window.innerHeight - PALETTE_TOP - PALETTE_HEADER);
     return {
       x: Math.max(minX, Math.min(position.x, maxX)),
-      y: Math.max(0, position.y)
+      y: Math.max(0, Math.min(position.y, maxY))
     };
   }
 


### PR DESCRIPTION
## What problem does this solve?

Opening the Image Adjustment palette closed the chart list, so adjusting several
charts in a stack meant reopening the list every time.

Making the palette modeless exposed two problems the old behaviour had been
hiding. The saved drag position is relative to where the palette opens, and that
origin moved — an offset saved against the old one could put the palette's drag
handle, the only way to move it back, past the viewport edge. And with the list
reachable, a second palette could open on top of the first; closing the covered
one reverts an adjustment the visible one already saved.

Two independent bugs fixed while in here: the palette's text was unreadable in
dark mode (Angular Material themes the dialog surface but not its colour, so the
palette's own markup inherited black on a near-black surface —
`rgb(0,0,0)` on `rgb(24,18,17)`), and a long chart name wrapped to two lines and
collided with the line below it.

## How does it work?

The palette opens beside the chart list, which stays put. Saved positions are
clamped back on screen on both axes, and only one per-chart palette is open at a
time. The dialog takes `--mat-app-text-color`, which follows the theme — measured
`rgb(237,224,221)` dark, `rgb(26,27,31)` light. The header is single-line with an
ellipsis and the full name on hover.

## What changes for the user?

Adjusting the brightness and contrast of several charts is now one pass instead of
one round trip per chart. Open **Charts**, press the **Image Adjustment** button
(the sliders icon) on a row, and the palette appears beside the list rather than
replacing it — so the next chart's button is still there, one click away. Pressing
it on a second chart moves the palette to that chart instead of stacking a second
one on top.

The palette can be dragged anywhere and remembers where it was put. If it was last
left near the edge of a larger window, it now comes back on screen rather than
somewhere its title bar cannot be reached. In dark mode its text is legible; it
used to be black on near-black. A chart with a long name no longer pushes the
palette's own controls out of line.

## How was this tested?

`resources-open-image-adjustment.spec.ts` covers the clamping at wide and narrow
viewports. The existing "opens at the remembered position" test passed only
because jsdom's default width left the saved offset in range, so it no longer
proved anything on its own.

CI green across the matrix; `npm run build:web` and `npm run test:ci` clean
locally too, bar two specs that fail the same way on an untouched `origin/master`
here and pass in CI.

## Checklist

- [x] One logical change; version numbers untouched.
- [x] `features/` untouched — the user-facing change is described above instead.
- [x] Skimmed [`DEV-LESSONS-LEARNED.md`](../docs/freeboard/DEV-LESSONS-LEARNED.md) for traps relevant to this change.
- [x] Tests added/updated for new behaviour and `npm run test:ci` passes.

---

**First of three.** #679 and #680 are stacked on this branch; merge order is
**#678 → #679 → #680**. Each stands on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image-adjustment palettes remain open alongside the chart list for easier editing.
  * Palettes open beside the chart list and stay within the visible screen area.
  * Opening a new palette automatically closes the previously open one.
  * SAVE keeps image adjustments, while cancellation restores the original values.
* **Improvements**
  * Long adjustment titles display on one line with an ellipsis; hovering reveals the full title.
  * Improved text visibility within the image-adjustment dialog.
  * Palette replacement now behaves reliably when switching between charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->