### PR TITLE
feat(charts): add a per-chart minimum zoom level

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -392,6 +392,7 @@ export function cleanConfig(
       chartOrder: ['openstreetmap', 'openseamap'],
       chartOpacity: {},
       chartImageAdjustment: {},
+      chartDisplayMinZoom: {},
       aisTargets: null,
       aisTargetTypes: [],
       aisFilterByShipType: false,
@@ -422,6 +423,9 @@ export function cleanConfig(
   }
   if (typeof settings.selections.chartImageAdjustment === 'undefined') {
     settings.selections.chartImageAdjustment = {};
+  }
+  if (typeof settings.selections.chartDisplayMinZoom === 'undefined') {
+    settings.selections.chartDisplayMinZoom = {};
   }
 
   if (typeof settings.selections.tracks === 'undefined') {
@@ -647,6 +651,7 @@ export function defaultConfig(): IAppConfig {
       chartOrder: ['openstreetmap', 'openseamap'], // chart layer ordering
       chartOpacity: {},
       chartImageAdjustment: {},
+      chartDisplayMinZoom: {},
       aisTargets: null,
       aisTargetTypes: [],
       aisFilterByShipType: false,

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -270,6 +270,10 @@ export class AppFacade extends InfoService {
   mapViewTopCenter = signal<Position>([0, 0]); // top-centre of viewport (rotation-aware)
   mapViewRightCenter = signal<Position>([0, 0]); // right-centre of viewport (rotation-aware)
   mapViewRotation = signal<number>(0); // OL view rotation in radians (CCW positive)
+  // Current map zoom, mirroring config.map.zoomLevel for consumers that need to
+  // react to it (chart display zoom ranges). Seeded from the restored config so
+  // it is correct before the first map move.
+  mapZoom = signal<number>(0);
   // programmatic map move request (e.g. from a plotter extension). A new
   // object reference each time so the consuming effect always reacts.
   mapMoveRequest = signal<{ center: Position; zoom?: number } | null>(null);
@@ -544,6 +548,7 @@ export class AppFacade extends InfoService {
 
     this.sTrueMagChoice.set(this.config.units.headingAttribute);
     this.s57.setOptions(this.config.map.s57Options);
+    this.mapZoom.set(this.config.map.zoomLevel);
 
     // emit settings$.ready
     this.debug(`doPostConfigLoad(): emit config$.ready`);

--- a/src/app/lib/components/dialogs/chart-min-zoom-dialog.spec.ts
+++ b/src/app/lib/components/dialogs/chart-min-zoom-dialog.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  displayMinZoomError,
+  displayMinZoomLabel,
+  parseZoomBound,
+  zoomToBoundText,
+  ZOOM_ENTRY_MAX,
+  ZOOM_ENTRY_MIN
+} from './chart-min-zoom-dialog';
+
+describe('parseZoomBound', () => {
+  it('reads a typed zoom level', () => {
+    expect(parseZoomBound('12')).toEqual({ value: 12, invalid: false });
+  });
+
+  it('keeps a fractional level', () => {
+    expect(parseZoomBound('12.4')).toEqual({ value: 12.4, invalid: false });
+  });
+
+  it('treats an empty field as no bound rather than an error', () => {
+    expect(parseZoomBound('')).toEqual({ invalid: false });
+    expect(parseZoomBound('   ')).toEqual({ invalid: false });
+    expect(parseZoomBound(null)).toEqual({ invalid: false });
+  });
+
+  it('rejects a non-numeric entry', () => {
+    expect(parseZoomBound('abc').invalid).toBe(true);
+  });
+
+  it('rejects levels outside the map zoom range', () => {
+    expect(parseZoomBound(ZOOM_ENTRY_MIN - 1).invalid).toBe(true);
+    expect(parseZoomBound(ZOOM_ENTRY_MAX + 1).invalid).toBe(true);
+    expect(parseZoomBound(ZOOM_ENTRY_MIN).invalid).toBe(false);
+    expect(parseZoomBound(ZOOM_ENTRY_MAX).invalid).toBe(false);
+  });
+});
+
+describe('displayMinZoomError', () => {
+  it('accepts a level in range', () => {
+    expect(displayMinZoomError({ value: 12, invalid: false })).toBeNull();
+  });
+
+  it('accepts an empty bound', () => {
+    expect(displayMinZoomError({ invalid: false })).toBeNull();
+  });
+
+  it('reports an out-of-range entry', () => {
+    expect(displayMinZoomError({ invalid: true })).toContain('between');
+  });
+});
+
+describe('displayMinZoomLabel', () => {
+  it('matches the dialog wording', () => {
+    expect(displayMinZoomLabel(12)).toBe('from z12');
+  });
+
+  it('labels nothing when no minimum is set', () => {
+    expect(displayMinZoomLabel()).toBe('');
+    expect(displayMinZoomLabel(undefined)).toBe('');
+  });
+
+  it('labels a minimum of 0', () => {
+    expect(displayMinZoomLabel(0)).toBe('from z0');
+  });
+});
+
+describe('zoomToBoundText', () => {
+  it('reports the map zoom to one decimal, rounding down', () => {
+    expect(zoomToBoundText(12.37)).toBe('12.3');
+    expect(zoomToBoundText(12)).toBe('12');
+  });
+
+  it('never yields a bound above the zoom it was captured at', () => {
+    // The bound must not hide the chart at the very zoom the user took it from:
+    // the layer minimum is bound - MIN_ZOOM_EPSILON and OL's minimum is exclusive.
+    for (const zoom of [12.35, 12.36, 12.37, 9.99, 15.05, 2.5]) {
+      expect(Number(zoomToBoundText(zoom))).toBeLessThanOrEqual(zoom);
+    }
+  });
+
+  it('yields an empty field for an unknown zoom', () => {
+    expect(zoomToBoundText(undefined as unknown as number)).toBe('');
+  });
+});

--- a/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
+++ b/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
@@ -115,10 +115,16 @@ export function zoomToBoundText(zoom: number): string {
         style="display: flex; align-items: center; gap: 4px; padding: 10px 8px 0 16px;"
       >
         <div style="font-size: 13px;">Show from</div>
+        <!--
+          step="any" rather than a tenth: the spinner and arrow keys still move
+          by 1, which is the useful increment here, while a fractional bound --
+          which the target button produces from the map zoom -- stays valid.
+          A numeric step would tie the two together and make one of them wrong.
+        -->
         <input
           type="number"
           inputmode="decimal"
-          step="0.1"
+          step="any"
           aria-label="Lowest zoom level to show this chart at"
           [min]="ZOOM_ENTRY_MIN"
           [max]="ZOOM_ENTRY_MAX"

--- a/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
+++ b/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
@@ -8,6 +8,7 @@ import {
   MAT_DIALOG_DATA
 } from '@angular/material/dialog';
 import { CdkDrag, CdkDragHandle } from '@angular/cdk/drag-drop';
+import { truncateZoomToDisplay } from 'src/app/lib/zoom-display';
 
 export interface ChartMinZoomDialogResult {
   apply: boolean;
@@ -56,12 +57,12 @@ export function displayMinZoomLabel(value?: number): string {
 }
 
 /**
- * Zoom level as taken from the map, at the precision the map reports. Rounds
- * down: rounding to nearest could land above the zoom the user captured it at,
- * which would hide the chart the moment they pressed the button.
+ * Zoom level as taken from the map, at the precision the zoom readout shows it
+ * — the same truncation, so the captured bound is the number the user can see
+ * on screen and is never above the zoom they took it from.
  */
 export function zoomToBoundText(zoom: number): string {
-  return Number.isFinite(zoom) ? String(Math.floor(zoom * 10) / 10) : '';
+  return Number.isFinite(zoom) ? String(truncateZoomToDisplay(zoom)) : '';
 }
 
 @Component({

--- a/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
+++ b/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
@@ -86,7 +86,7 @@ export function zoomToBoundText(zoom: number): string {
         cdkDragHandle
         style="display:flex; align-items:center; cursor:move; padding: 4px 4px 0 12px;"
       >
-        <mat-icon style="opacity:0.6;">open_in_full</mat-icon>
+        <mat-icon style="opacity:0.6;">vertical_align_bottom</mat-icon>
         <div
           style="
             flex: 1 1 auto;

--- a/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
+++ b/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
@@ -118,6 +118,7 @@ export function zoomToBoundText(zoom: number): string {
         <input
           type="number"
           inputmode="decimal"
+          step="0.1"
           aria-label="Lowest zoom level to show this chart at"
           [min]="ZOOM_ENTRY_MIN"
           [max]="ZOOM_ENTRY_MAX"

--- a/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
+++ b/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
@@ -10,6 +10,15 @@ import {
 import { CdkDrag, CdkDragHandle } from '@angular/cdk/drag-drop';
 import { truncateZoomToDisplay } from 'src/app/lib/zoom-display';
 
+export interface ChartMinZoomDialogData {
+  text: string;
+  value?: number;
+  declaredMin?: number;
+  declaredMax?: number;
+  currentZoom: () => number;
+  onChange: (value?: number) => void;
+}
+
 export interface ChartMinZoomDialogResult {
   apply: boolean;
   value?: number;
@@ -195,14 +204,7 @@ export class ChartMinZoomDialog implements OnInit {
   protected dialogRef = inject(
     MatDialogRef<ChartMinZoomDialog, ChartMinZoomDialogResult>
   );
-  protected data = inject<{
-    text: string;
-    value?: number;
-    declaredMin?: number;
-    declaredMax?: number;
-    currentZoom: () => number;
-    onChange: (value?: number) => void;
-  }>(MAT_DIALOG_DATA);
+  protected data = inject<ChartMinZoomDialogData>(MAT_DIALOG_DATA);
 
   protected error = computed(() =>
     displayMinZoomError(parseZoomBound(this.text()))

--- a/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
+++ b/src/app/lib/components/dialogs/chart-min-zoom-dialog.ts
@@ -1,0 +1,255 @@
+import { Component, OnInit, computed, signal, inject } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import {
+  MatDialogModule,
+  MatDialogRef,
+  MAT_DIALOG_DATA
+} from '@angular/material/dialog';
+import { CdkDrag, CdkDragHandle } from '@angular/cdk/drag-drop';
+
+export interface ChartMinZoomDialogResult {
+  apply: boolean;
+  value?: number;
+}
+
+// Widest zoom range the map view is ever clamped to (AppFacade.MAP_ZOOM_EXTENT
+// narrows to the selected charts, so entry stays deliberately wider than that).
+export const ZOOM_ENTRY_MIN = 1;
+export const ZOOM_ENTRY_MAX = 28;
+
+export interface ZoomBound {
+  value?: number;
+  invalid: boolean;
+}
+
+/**
+ * A bound as typed: empty means "no bound", which is a valid state rather than
+ * an error.
+ */
+export function parseZoomBound(text: string | number | null): ZoomBound {
+  if (text === null || text === undefined || String(text).trim() === '') {
+    return { invalid: false };
+  }
+  const value = Number(text);
+  if (
+    !Number.isFinite(value) ||
+    value < ZOOM_ENTRY_MIN ||
+    value > ZOOM_ENTRY_MAX
+  ) {
+    return { invalid: true };
+  }
+  return { value, invalid: false };
+}
+
+/** Why the entered level cannot be applied, or null when it can. */
+export function displayMinZoomError(bound: ZoomBound): string | null {
+  return bound.invalid
+    ? `Enter a zoom level between ${ZOOM_ENTRY_MIN} and ${ZOOM_ENTRY_MAX}`
+    : null;
+}
+
+/** Compact label for a configured minimum, e.g. for a chart list row. */
+export function displayMinZoomLabel(value?: number): string {
+  return typeof value === 'number' ? `from z${value}` : '';
+}
+
+/**
+ * Zoom level as taken from the map, at the precision the map reports. Rounds
+ * down: rounding to nearest could land above the zoom the user captured it at,
+ * which would hide the chart the moment they pressed the button.
+ */
+export function zoomToBoundText(zoom: number): string {
+  return Number.isFinite(zoom) ? String(Math.floor(zoom * 10) / 10) : '';
+}
+
+@Component({
+  selector: 'ap-chart-min-zoom-dialog',
+  imports: [
+    MatIconModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatTooltipModule,
+    CdkDrag,
+    CdkDragHandle
+  ],
+  template: `
+    <div
+      class="_ap-chart-min-zoom"
+      style="overflow: hidden; color: var(--mat-app-text-color);"
+      cdkDrag
+      cdkDragRootElement=".cdk-overlay-pane"
+    >
+      <div
+        cdkDragHandle
+        style="display:flex; align-items:center; cursor:move; padding: 4px 4px 0 12px;"
+      >
+        <mat-icon style="opacity:0.6;">open_in_full</mat-icon>
+        <div
+          style="
+            flex: 1 1 auto;
+            min-width: 0;
+            padding-left: 8px;
+            font-weight: 500;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          "
+          [title]="data.text"
+        >
+          {{ data.text }}
+        </div>
+        <button mat-icon-button aria-label="Close" (click)="handleClose(false)">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+
+      <div
+        style="padding: 0 16px; font-size: 12px; opacity: 0.7; margin-top: -4px;"
+      >
+        {{ declaredText() }} &middot; map at z{{ currentZoomText() }}
+      </div>
+
+      <div
+        style="display: flex; align-items: center; gap: 4px; padding: 10px 8px 0 16px;"
+      >
+        <div style="font-size: 13px;">Show from</div>
+        <input
+          type="number"
+          inputmode="decimal"
+          aria-label="Lowest zoom level to show this chart at"
+          [min]="ZOOM_ENTRY_MIN"
+          [max]="ZOOM_ENTRY_MAX"
+          [value]="text()"
+          (change)="onTextChange($event)"
+          style="
+            width: 70px;
+            height: 34px;
+            box-sizing: border-box;
+            padding: 0 0 0 8px;
+            font: inherit;
+            font-size: 14px;
+            color: inherit;
+            background: transparent;
+            border: 1px solid rgba(128, 128, 128, 0.5);
+            border-radius: 4px;
+          "
+        />
+        <button
+          mat-icon-button
+          aria-label="Use the current map zoom"
+          matTooltip="Use current map zoom"
+          (click)="useCurrentZoom()"
+        >
+          <mat-icon>my_location</mat-icon>
+        </button>
+        <button
+          mat-icon-button
+          aria-label="Clear"
+          matTooltip="Clear"
+          [disabled]="text() === ''"
+          (click)="clear()"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+
+      @if (error()) {
+        <div
+          role="alert"
+          style="padding: 4px 16px 0; font-size: 12px;"
+          class="mat-mdc-form-field-error"
+        >
+          {{ error() }}
+        </div>
+      } @else {
+        <div style="padding: 4px 16px 0; font-size: 12px; opacity: 0.7;">
+          {{ summary() }}
+        </div>
+      }
+
+      <mat-dialog-actions style="min-height: 38px; padding: 0 8px 2px;">
+        <span style="flex: 1 1 auto"></span>
+        <button mat-button [disabled]="!!error()" (click)="handleClose(true)">
+          APPLY
+        </button>
+      </mat-dialog-actions>
+    </div>
+  `
+})
+export class ChartMinZoomDialog implements OnInit {
+  protected readonly ZOOM_ENTRY_MIN = ZOOM_ENTRY_MIN;
+  protected readonly ZOOM_ENTRY_MAX = ZOOM_ENTRY_MAX;
+
+  protected text = signal<string>('');
+
+  protected dialogRef = inject(
+    MatDialogRef<ChartMinZoomDialog, ChartMinZoomDialogResult>
+  );
+  protected data = inject<{
+    text: string;
+    value?: number;
+    declaredMin?: number;
+    declaredMax?: number;
+    currentZoom: () => number;
+    onChange: (value?: number) => void;
+  }>(MAT_DIALOG_DATA);
+
+  protected error = computed(() =>
+    displayMinZoomError(parseZoomBound(this.text()))
+  );
+
+  protected summary = computed(() => {
+    const value = this.currentValue();
+    return typeof value === 'number'
+      ? `Hidden below z${value}`
+      : 'Shown at every zoom level';
+  });
+
+  ngOnInit() {
+    this.text.set(
+      typeof this.data.value === 'number' ? String(this.data.value) : ''
+    );
+  }
+
+  protected declaredText() {
+    const { declaredMin, declaredMax } = this.data;
+    return typeof declaredMin === 'number' && typeof declaredMax === 'number'
+      ? `data z${declaredMin}–z${declaredMax}`
+      : 'data zoom range unknown';
+  }
+
+  protected currentZoomText() {
+    return zoomToBoundText(this.data.currentZoom());
+  }
+
+  protected onTextChange(e: Event) {
+    // Committed value only (change, not input): a partially typed "1" on the
+    // way to "14" would otherwise preview as the chart flashing off the map.
+    this.setText((e.target as HTMLInputElement).value);
+  }
+
+  protected useCurrentZoom() {
+    this.setText(zoomToBoundText(this.data.currentZoom()));
+  }
+
+  protected clear() {
+    this.setText('');
+  }
+
+  private setText(text: string) {
+    this.text.set(text);
+    if (!this.error() && typeof this.data?.onChange === 'function') {
+      this.data.onChange(this.currentValue());
+    }
+  }
+
+  private currentValue(): number | undefined {
+    return parseZoomBound(this.text()).value;
+  }
+
+  protected handleClose(apply: boolean) {
+    this.dialogRef.close({ apply, value: this.currentValue() });
+  }
+}

--- a/src/app/lib/components/dialogs/index.ts
+++ b/src/app/lib/components/dialogs/index.ts
@@ -14,3 +14,4 @@ export * from './multiselectlist-dialog';
 export * from './singleselectlist-dialog';
 export * from './slider-dialog';
 export * from './image-adjustment-dialog';
+export * from './chart-min-zoom-dialog';

--- a/src/app/lib/zoom-display.spec.ts
+++ b/src/app/lib/zoom-display.spec.ts
@@ -18,6 +18,13 @@ describe('truncateZoomToDisplay', () => {
     expect(truncateZoomToDisplay(14)).toBe(14);
   });
 
+  it('does not lift a level that has not reached the next tenth', () => {
+    // A view sitting a hair below 14 is below 14, however close: naming it
+    // 14.0 is the readout claiming a level the map is not at.
+    expect(truncateZoomToDisplay(13.99999995)).toBe(13.9);
+    expect(truncateZoomToDisplay(27.999999999)).toBe(27.9);
+  });
+
   it('yields a value that prints without floating-point noise', () => {
     for (let tenths = 0; tenths <= 280; tenths++) {
       const text = String(truncateZoomToDisplay(tenths / 10 + 0.03));

--- a/src/app/lib/zoom-display.spec.ts
+++ b/src/app/lib/zoom-display.spec.ts
@@ -1,0 +1,50 @@
+import { expect, describe, it } from 'vitest';
+import { truncateZoomToDisplay, zoomDisplayText } from './zoom-display';
+import {
+  isZoomWithinLayerRange,
+  resolveLayerZoomRange
+} from 'src/app/modules/map/ol/lib/charts/chart-utils';
+
+describe('truncateZoomToDisplay', () => {
+  it('truncates to a tenth rather than rounding', () => {
+    expect(truncateZoomToDisplay(13.9757)).toBe(13.9);
+    expect(truncateZoomToDisplay(15.05)).toBe(15);
+    expect(truncateZoomToDisplay(9.99)).toBe(9.9);
+  });
+
+  it('leaves a level already on a tenth alone', () => {
+    // 12.3 * 10 is 122.99999999999999, which a bare floor drops to 12.2.
+    expect(truncateZoomToDisplay(12.3)).toBe(12.3);
+    expect(truncateZoomToDisplay(14)).toBe(14);
+  });
+
+  it('yields a value that prints without floating-point noise', () => {
+    for (let tenths = 0; tenths <= 280; tenths++) {
+      const text = String(truncateZoomToDisplay(tenths / 10 + 0.03));
+      expect(text.length).toBeLessThanOrEqual(4);
+    }
+  });
+});
+
+describe('zoomDisplayText', () => {
+  it('carries one decimal', () => {
+    expect(zoomDisplayText(14)).toBe('14.0');
+    expect(zoomDisplayText(13.9757)).toBe('13.9');
+  });
+
+  it('never names a level a chart set to it would be hidden at', () => {
+    // The bug this pins: a rounding readout showed "14.0" from z13.95 up, while
+    // a chart with a z14 minimum stayed off the map until z14 — the user was
+    // told they were at the level they had configured, and saw nothing.
+    const resolved = resolveLayerZoomRange(
+      { minZoom: 5, maxZoom: 15, displayMinZoom: 14 },
+      20,
+      true
+    );
+    for (const zoom of [13.9, 13.95, 13.9757, 13.999, 14, 14.05]) {
+      if (zoomDisplayText(zoom) === '14.0') {
+        expect(isZoomWithinLayerRange(resolved, zoom)).toBe(true);
+      }
+    }
+  });
+});

--- a/src/app/lib/zoom-display.ts
+++ b/src/app/lib/zoom-display.ts
@@ -9,11 +9,15 @@ const ZOOM_DISPLAY_STEPS = 10;
  * map is not at yet.
  *
  * Truncating in floating point needs the product settled first: 12.3 * 10 is
- * 122.99999999999999, which floors to 12.2.
+ * 122.99999999999999, which floors to 12.2. The allowance is one ulp of the
+ * product, so it covers that error and nothing a view can be at: rounding to a
+ * fixed number of decimals instead would lift a zoom genuinely below a tenth
+ * over it, which is the reporting this function exists to stop.
  */
 export function truncateZoomToDisplay(zoom: number): number {
-  const steps = Number((zoom * ZOOM_DISPLAY_STEPS).toFixed(6));
-  return Math.floor(steps) / ZOOM_DISPLAY_STEPS;
+  const steps = zoom * ZOOM_DISPLAY_STEPS;
+  const settled = steps + Number.EPSILON * Math.max(1, Math.abs(steps));
+  return Math.floor(settled) / ZOOM_DISPLAY_STEPS;
 }
 
 /** Zoom level for the map readout, always carrying its one decimal. */

--- a/src/app/lib/zoom-display.ts
+++ b/src/app/lib/zoom-display.ts
@@ -1,0 +1,22 @@
+/** Tenths per zoom level — the precision every level is shown and entered at. */
+const ZOOM_DISPLAY_STEPS = 10;
+
+/**
+ * A zoom level as the app shows it: truncated to a tenth, never rounded, so
+ * every level displayed is one the view has actually reached. Rounding would
+ * report z14.0 from z13.95 up, and a chart configured to appear from z14 is
+ * legitimately off the map at 13.95 — the readout would be naming a level the
+ * map is not at yet.
+ *
+ * Truncating in floating point needs the product settled first: 12.3 * 10 is
+ * 122.99999999999999, which floors to 12.2.
+ */
+export function truncateZoomToDisplay(zoom: number): number {
+  const steps = Number((zoom * ZOOM_DISPLAY_STEPS).toFixed(6));
+  return Math.floor(steps) / ZOOM_DISPLAY_STEPS;
+}
+
+/** Zoom level for the map readout, always carrying its one decimal. */
+export function zoomDisplayText(zoom: number): string {
+  return truncateZoomToDisplay(zoom).toFixed(1);
+}

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -129,7 +129,7 @@
             "
           ></span>
           &nbsp;
-          <span [innerText]="'Zm: ' + mapZoomLevel().toFixed(1)"></span>
+          <span [innerText]="'Zm: ' + mapZoomText()"></span>
           @if (cursorInfo(); as ci) {
             &nbsp;
             <span

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -690,6 +690,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   // handle map move / zoom
   protected onMapMoveEnd(e: FBMapEvent) {
     this.app.config.map.zoomLevel = e.zoom;
+    this.app.mapZoom.set(e.zoom);
 
     this.app.mapExtent.update(() => e.extent);
     this.app.mapViewTopCenter.update(() => e.topCenter as Position);

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -50,6 +50,7 @@ import { Feature as GeoJsonFeature } from 'geojson';
 import { Convert, TARGET_UNIT } from 'src/app/lib/convert';
 import { GeoUtils, Angle } from 'src/app/lib/geoutils';
 import { zoomKeyDirection } from 'src/app/lib/zoom-keys';
+import { zoomDisplayText } from 'src/app/lib/zoom-display';
 import { computeCursorEta, CursorEtaInfo } from './cursor-eta';
 import { CursorPin, tapFadeMs, TAP_MAX_DURATION } from './cursor-marker';
 import {
@@ -261,6 +262,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   protected olMapControls = mapControls;
   protected olMapInteractions = signal<Array<{ name: string }>>([]);
   protected mapZoomLevel = signal<number>(1);
+  protected mapZoomText = computed(() => zoomDisplayText(this.mapZoomLevel()));
   protected mapCenterPositon = signal<Position>([0, 0]);
   protected mapRotation = signal<number>(0);
 

--- a/src/app/modules/map/ol/lib/charts/chart-utils.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils.spec.ts
@@ -2,8 +2,127 @@ import { expect, describe, it } from 'vitest';
 import {
   extentFromBounds,
   isChartInView,
-  resolveLayerMaxZoom
+  isZoomWithinLayerRange,
+  resolveLayerMaxZoom,
+  resolveLayerZoomRange
 } from './chart-utils';
+
+describe('resolveLayerZoomRange', () => {
+  // A chart declaring tiles for z5-z15, the shape the Traficom raster sets have.
+  const chart = (displayMinZoom?: number) => ({
+    minZoom: 5,
+    maxZoom: 15,
+    displayMinZoom
+  });
+
+  describe('without a display minimum (existing behaviour)', () => {
+    it('matches the current max resolution with over-zoom on and off', () => {
+      expect(resolveLayerZoomRange(chart(), 20, true).max).toBe(
+        resolveLayerMaxZoom(15, 20, true)
+      );
+      expect(resolveLayerZoomRange(chart(), 20, false).max).toBe(
+        resolveLayerMaxZoom(15, 20, false)
+      );
+    });
+
+    it('keeps the legacy 0.1 offset on the declared minimum', () => {
+      expect(resolveLayerZoomRange(chart(), 20, true).min).toBeCloseTo(4.9);
+    });
+
+    it('leaves a declared minimum below the offset untouched', () => {
+      expect(
+        resolveLayerZoomRange({ minZoom: 0, maxZoom: 24 }, 20, true).min
+      ).toBe(0);
+    });
+  });
+
+  describe('display minimum', () => {
+    it('shows the chart at exactly the configured level', () => {
+      const { min } = resolveLayerZoomRange(chart(12), 20, true);
+      // OpenLayers' layer minimum is exclusive: visible while zoom > min.
+      expect(12).toBeGreaterThan(min);
+      expect(11.99).toBeLessThan(min);
+    });
+
+    it('does not inherit the legacy 0.1 offset', () => {
+      expect(resolveLayerZoomRange(chart(12), 20, true).min).toBeGreaterThan(
+        11.9
+      );
+    });
+
+    it('yields to a higher declared minimum', () => {
+      expect(resolveLayerZoomRange(chart(3), 20, true).min).toBeCloseTo(4.9);
+    });
+
+    it('honours a bound set at the chart’s own declared minimum', () => {
+      // The common case: the user picks the level the chart's data starts at.
+      // The legacy 0.1 offset would draw it from 4.9, ignoring the bound.
+      const { min } = resolveLayerZoomRange(chart(5), 20, true);
+      expect(5).toBeGreaterThan(min);
+      expect(4.99).toBeLessThan(min);
+    });
+
+    it('applies to a chart that declares no minimum', () => {
+      const { min } = resolveLayerZoomRange(
+        { maxZoom: 15, displayMinZoom: 12 },
+        20,
+        true
+      );
+      expect(12).toBeGreaterThan(min);
+      expect(11.99).toBeLessThan(min);
+    });
+
+    it('leaves the maximum entirely alone', () => {
+      expect(resolveLayerZoomRange(chart(12), 20, true).max).toBe(
+        resolveLayerMaxZoom(15, 20, true)
+      );
+      expect(resolveLayerZoomRange(chart(12), 20, false).max).toBe(15);
+    });
+
+    it('never draws a chart below the zoom its tiles start at', () => {
+      // Asking for z3 on a chart whose data starts at z5 must not invent tiles.
+      const { min } = resolveLayerZoomRange(chart(3), 20, true);
+      expect(min).toBeGreaterThanOrEqual(4.9);
+    });
+  });
+
+  it('hands over between charts at the level the next one starts', () => {
+    // Coastal charts from z9, boating charts from z12: at z12 the boating
+    // chart is drawn, and the coastal one is still there underneath it.
+    const coastal = resolveLayerZoomRange(chart(9), 20, true);
+    const boating = resolveLayerZoomRange(chart(12), 20, true);
+    expect(isZoomWithinLayerRange(coastal, 11.99)).toBe(true);
+    expect(isZoomWithinLayerRange(boating, 11.99)).toBe(false);
+    expect(isZoomWithinLayerRange(coastal, 12)).toBe(true);
+    expect(isZoomWithinLayerRange(boating, 12)).toBe(true);
+  });
+});
+
+describe('isZoomWithinLayerRange', () => {
+  it('follows OpenLayers bounds: minimum exclusive, maximum inclusive', () => {
+    const range = { min: 9, max: 13 };
+    expect(isZoomWithinLayerRange(range, 9)).toBe(false);
+    expect(isZoomWithinLayerRange(range, 9.0001)).toBe(true);
+    expect(isZoomWithinLayerRange(range, 13)).toBe(true);
+    expect(isZoomWithinLayerRange(range, 13.0001)).toBe(false);
+  });
+
+  it('treats an absent bound as unbounded at that end', () => {
+    expect(isZoomWithinLayerRange({ max: 13 }, 2)).toBe(true);
+    expect(isZoomWithinLayerRange({ min: 9 }, 28)).toBe(true);
+    expect(isZoomWithinLayerRange({}, 11)).toBe(true);
+  });
+
+  it('reports a chart hidden by its declared minimum as not visible', () => {
+    // Display minimum asks for z8 up, but the chart has no tiles below z10.
+    const resolved = resolveLayerZoomRange(
+      { minZoom: 10, maxZoom: 15, displayMinZoom: 8 },
+      20,
+      true
+    );
+    expect(isZoomWithinLayerRange(resolved, 9)).toBe(false);
+  });
+});
 
 describe('resolveLayerMaxZoom', () => {
   it('returns chart max when over-zoom disabled', () => {

--- a/src/app/modules/map/ol/lib/charts/chart-utils.ts
+++ b/src/app/modules/map/ol/lib/charts/chart-utils.ts
@@ -68,6 +68,69 @@ export function chartLayerClassName(id: string): string {
   return 'ol-layer chart-' + String(id).replace(/[^\w-]/g, '-');
 }
 
+/**
+ * Compensates for OpenLayers' exclusive layer minimum-zoom bound so a display
+ * minimum of z12 shows the chart at exactly z12. Small enough that the bound
+ * stays sharp between adjacent chart bands, unlike the historic 0.1 applied to
+ * a chart's declared minimum.
+ */
+const MIN_ZOOM_EPSILON = 1e-6;
+
+/**
+ * Layer min/max zoom for a chart, combining its declared range (what tiles
+ * exist), the user's display minimum (the lowest zoom they want it drawn at)
+ * and the global over-zoom setting.
+ *
+ * The display minimum only ever restricts: a chart is never drawn below the
+ * zoom its own tiles start at. The maximum is untouched by it, so which chart
+ * wins where several overlap stays a question of layer order. With no display
+ * minimum the result is what the layers used before it existed.
+ */
+export function resolveLayerZoomRange(
+  chart: {
+    minZoom?: number;
+    maxZoom?: number;
+    displayMinZoom?: number;
+  },
+  mapMaxZoom?: number,
+  overZoomTiles = false
+): { min: number | undefined; max: number | undefined } {
+  const declaredMin = chart.minZoom;
+  const displayMin = chart.displayMinZoom;
+
+  // A display minimum below the chart's own is meaningless — there are no tiles
+  // down there — so the declared one wins. At or above it, the user's bound
+  // applies with the sharp offset.
+  const displayMinApplies =
+    typeof displayMin === 'number' &&
+    (typeof declaredMin !== 'number' || displayMin >= declaredMin);
+
+  // Historic offset, kept so charts without a display minimum render exactly as
+  // they did before.
+  const declaredLayerMin = declaredMin >= 0.1 ? declaredMin - 0.1 : declaredMin;
+
+  return {
+    min: displayMinApplies ? displayMin - MIN_ZOOM_EPSILON : declaredLayerMin,
+    max: resolveLayerMaxZoom(chart.maxZoom, mapMaxZoom, overZoomTiles)
+  };
+}
+
+/**
+ * Whether a layer resolved to this zoom range is drawn at the given zoom,
+ * following OpenLayers' bounds: the minimum is exclusive, the maximum
+ * inclusive. Lets the chart list report visibility the same way the map
+ * decides it.
+ */
+export function isZoomWithinLayerRange(
+  range: { min?: number; max?: number },
+  zoom: number
+): boolean {
+  return (
+    (typeof range.min !== 'number' || zoom > range.min) &&
+    (typeof range.max !== 'number' || zoom <= range.max)
+  );
+}
+
 export function resolveLayerMaxZoom(
   chartMax?: number,
   mapMax?: number,

--- a/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-raster-chart.component.ts
@@ -19,7 +19,7 @@ import {
   attachImageAdjustmentFilter,
   chartLayerClassName,
   extentFromBounds,
-  resolveLayerMaxZoom
+  resolveLayerZoomRange
 } from './chart-utils';
 
 import { ChartImageAdjustment, FBChart } from 'src/app/types';
@@ -68,9 +68,8 @@ export class RasterChartLayerComponent implements OnDestroy {
     }
 
     if (!this.layer) {
-      const maxZ = chart[1].maxZoom;
-      const layerMaxZ = resolveLayerMaxZoom(
-        maxZ,
+      const zoom = resolveLayerZoomRange(
+        chart[1],
         this.mapMaxZoom(),
         this.overZoomTiles()
       );
@@ -78,15 +77,10 @@ export class RasterChartLayerComponent implements OnDestroy {
       if (chart[0] === 'openstreetmap') {
         this.layer = osmLayer(chartLayerClassName(chart[0]));
         this.layer.setZIndex(this.zIndex());
-        this.layer.setMinZoom(chart[1].minZoom);
-        this.layer.setMaxZoom(layerMaxZ);
+        this.layer.setMinZoom(zoom.min);
+        this.layer.setMaxZoom(zoom.max);
         this.layer.setOpacity(chart[1].defaultOpacity ?? 1);
       } else {
-        const minZ =
-          chart[1].minZoom && chart[1].minZoom >= 0.1
-            ? chart[1].minZoom - 0.1
-            : chart[1].minZoom;
-
         if (chart[1].url.indexOf('.pmtiles') !== -1) {
           this.layer = initPMTilesXYZLayer(
             chart[1],
@@ -97,20 +91,22 @@ export class RasterChartLayerComponent implements OnDestroy {
           this.layer = new TileLayer({
             source: new XYZ({
               url: chart[1].url,
-              maxZoom: maxZ,
+              // Tile source keeps the declared maximum: the display range gates
+              // rendering, it never changes which tiles exist.
+              maxZoom: chart[1].maxZoom,
               tileSize: chart[1].tileSize ?? 256
             }),
             preload: 0,
             zIndex: this.zIndex(),
-            minZoom: minZ,
-            maxZoom: layerMaxZ,
+            minZoom: zoom.min,
+            maxZoom: zoom.max,
             opacity: chart[1].defaultOpacity ?? 1,
             className: chartLayerClassName(chart[0])
           });
         }
         if (this.layer) {
-          this.layer.setMinZoom(minZ);
-          this.layer.setMaxZoom(layerMaxZ);
+          this.layer.setMinZoom(zoom.min);
+          this.layer.setMaxZoom(zoom.max);
         }
       }
       if (this.layer) {
@@ -127,19 +123,14 @@ export class RasterChartLayerComponent implements OnDestroy {
         map.addLayer(this.layer);
       }
     } else {
-      const minZ =
-        chart[1].minZoom && chart[1].minZoom >= 0.1
-          ? chart[1].minZoom - 0.1
-          : chart[1].minZoom;
-      const maxZ = chart[1].maxZoom;
-      const layerMaxZ = resolveLayerMaxZoom(
-        maxZ,
+      const zoom = resolveLayerZoomRange(
+        chart[1],
         this.mapMaxZoom(),
         this.overZoomTiles()
       );
       this.layer.setZIndex(this.zIndex());
-      this.layer.setMinZoom(minZ);
-      this.layer.setMaxZoom(layerMaxZ);
+      this.layer.setMinZoom(zoom.min);
+      this.layer.setMaxZoom(zoom.max);
       this.layer.setOpacity(chart[1].defaultOpacity ?? 1);
       this.layer.setExtent(extentFromBounds(chart[1].bounds));
     }

--- a/src/app/modules/map/ol/lib/charts/layer-tilejson-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-tilejson-chart.component.ts
@@ -18,7 +18,7 @@ import {
   attachImageAdjustmentFilter,
   chartLayerClassName,
   extentFromBounds,
-  resolveLayerMaxZoom
+  resolveLayerZoomRange
 } from './chart-utils';
 
 // ** Freeboard TileJSON Chart **
@@ -65,13 +65,8 @@ export class TileJsonChartLayerComponent implements OnDestroy {
     }
 
     if (!this.layer) {
-      const minZ =
-        chart[1].minZoom && chart[1].minZoom >= 0.1
-          ? chart[1].minZoom - 0.1
-          : chart[1].minZoom;
-      const maxZ = chart[1].maxZoom;
-      const layerMaxZ = resolveLayerMaxZoom(
-        maxZ,
+      const zoom = resolveLayerZoomRange(
+        chart[1],
         this.mapMaxZoom(),
         this.overZoomTiles()
       );
@@ -83,8 +78,8 @@ export class TileJsonChartLayerComponent implements OnDestroy {
         }),
         preload: 0,
         zIndex: this.zIndex(),
-        minZoom: minZ,
-        maxZoom: layerMaxZ,
+        minZoom: zoom.min,
+        maxZoom: zoom.max,
         opacity: chart[1].defaultOpacity ?? 1,
         extent: extentFromBounds(chart[1].bounds),
         className: chartLayerClassName(chart[0])
@@ -99,19 +94,14 @@ export class TileJsonChartLayerComponent implements OnDestroy {
         map.addLayer(this.layer);
       }
     } else {
-      const minZ =
-        chart[1].minZoom && chart[1].minZoom >= 0.1
-          ? chart[1].minZoom - 0.1
-          : chart[1].minZoom;
-      const maxZ = chart[1].maxZoom;
-      const layerMaxZ = resolveLayerMaxZoom(
-        maxZ,
+      const zoom = resolveLayerZoomRange(
+        chart[1],
         this.mapMaxZoom(),
         this.overZoomTiles()
       );
       this.layer.setZIndex(this.zIndex());
-      this.layer.setMinZoom(minZ);
-      this.layer.setMaxZoom(layerMaxZ);
+      this.layer.setMinZoom(zoom.min);
+      this.layer.setMaxZoom(zoom.max);
       this.layer.setOpacity(chart[1].defaultOpacity ?? 1);
       this.layer.setExtent(extentFromBounds(chart[1].bounds));
     }

--- a/src/app/modules/map/ol/lib/charts/layer-wms-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wms-chart.component.ts
@@ -20,7 +20,7 @@ import {
   attachImageAdjustmentFilter,
   chartLayerClassName,
   extentFromBounds,
-  resolveLayerMaxZoom
+  resolveLayerZoomRange
 } from './chart-utils';
 
 // ** Freeboard WMS Chart **
@@ -102,13 +102,8 @@ export class WmsChartLayerComponent implements OnDestroy {
     }
 
     if (!this.layer) {
-      const minZ =
-        chart[1].minZoom && chart[1].minZoom >= 0.1
-          ? chart[1].minZoom - 0.1
-          : chart[1].minZoom;
-      const maxZ = chart[1].maxZoom;
-      const layerMaxZ = resolveLayerMaxZoom(
-        maxZ,
+      const zoom = resolveLayerZoomRange(
+        chart[1],
         this.mapMaxZoom(),
         this.overZoomTiles()
       );
@@ -122,8 +117,8 @@ export class WmsChartLayerComponent implements OnDestroy {
         }),
         preload: 0,
         zIndex: this.zIndex(),
-        minZoom: minZ,
-        maxZoom: layerMaxZ,
+        minZoom: zoom.min,
+        maxZoom: zoom.max,
         opacity: chart[1].defaultOpacity ?? 1,
         extent: extentFromBounds(chart[1].bounds),
         className: chartLayerClassName(chart[0])
@@ -138,19 +133,14 @@ export class WmsChartLayerComponent implements OnDestroy {
         this.map.addLayer(this.layer);
       }
     } else {
-      const minZ =
-        chart[1].minZoom && chart[1].minZoom >= 0.1
-          ? chart[1].minZoom - 0.1
-          : chart[1].minZoom;
-      const maxZ = chart[1].maxZoom;
-      const layerMaxZ = resolveLayerMaxZoom(
-        maxZ,
+      const zoom = resolveLayerZoomRange(
+        chart[1],
         this.mapMaxZoom(),
         this.overZoomTiles()
       );
       this.layer.setZIndex(this.zIndex());
-      this.layer.setMinZoom(minZ);
-      this.layer.setMaxZoom(layerMaxZ);
+      this.layer.setMinZoom(zoom.min);
+      this.layer.setMaxZoom(zoom.max);
       this.layer.setOpacity(chart[1].defaultOpacity ?? 1);
       this.layer.setExtent(extentFromBounds(chart[1].bounds));
       const src = this.layer.getSource() as TileWMS;

--- a/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
@@ -20,7 +20,7 @@ import {
   attachImageAdjustmentFilter,
   chartLayerClassName,
   extentFromBounds,
-  resolveLayerMaxZoom
+  resolveLayerZoomRange
 } from './chart-utils';
 
 // ** Freeboard WMTS Chart **
@@ -83,13 +83,8 @@ export class WmtsChartLayerComponent implements OnDestroy {
     });
 
     if (!this.layer) {
-      const minZ =
-        chart[1].minZoom && chart[1].minZoom >= 0.1
-          ? chart[1].minZoom - 0.1
-          : chart[1].minZoom;
-      const maxZ = chart[1].maxZoom;
-      const layerMaxZ = resolveLayerMaxZoom(
-        maxZ,
+      const zoom = resolveLayerZoomRange(
+        chart[1],
         this.mapMaxZoom(),
         this.overZoomTiles()
       );
@@ -98,8 +93,8 @@ export class WmtsChartLayerComponent implements OnDestroy {
         source: new WMTS(options),
         preload: 0,
         zIndex: this.zIndex(),
-        minZoom: minZ,
-        maxZoom: layerMaxZ,
+        minZoom: zoom.min,
+        maxZoom: zoom.max,
         opacity: chart[1].defaultOpacity ?? 1,
         extent: extentFromBounds(chart[1].bounds),
         className: chartLayerClassName(chart[0])
@@ -114,19 +109,14 @@ export class WmtsChartLayerComponent implements OnDestroy {
         map.addLayer(this.layer);
       }
     } else {
-      const minZ =
-        chart[1].minZoom && chart[1].minZoom >= 0.1
-          ? chart[1].minZoom - 0.1
-          : chart[1].minZoom;
-      const maxZ = chart[1].maxZoom;
-      const layerMaxZ = resolveLayerMaxZoom(
-        maxZ,
+      const zoom = resolveLayerZoomRange(
+        chart[1],
         this.mapMaxZoom(),
         this.overZoomTiles()
       );
       this.layer.setZIndex(this.zIndex());
-      this.layer.setMinZoom(minZ);
-      this.layer.setMaxZoom(layerMaxZ);
+      this.layer.setMinZoom(zoom.min);
+      this.layer.setMaxZoom(zoom.max);
       this.layer.setOpacity(chart[1].defaultOpacity ?? 1);
       this.layer.setExtent(extentFromBounds(chart[1].bounds));
     }

--- a/src/app/modules/skresources/components/charts/chartlist-refresh.spec.ts
+++ b/src/app/modules/skresources/components/charts/chartlist-refresh.spec.ts
@@ -1,0 +1,99 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MatDialog } from '@angular/material/dialog';
+
+import { ChartListComponent } from './chartlist';
+import { SKResourceService } from '../../resources.service';
+import { SKWorkerService } from 'src/app/modules/skstream/skstream.service';
+import { AppFacade } from 'src/app/app.facade';
+import { SKResourceGroupService } from '../groups/groups.service';
+import { FBMapInteractService } from 'src/app/modules/map/fbmap-interact.service';
+import type { FBChart, FBCharts } from 'src/app/types';
+
+/**
+ * A chart missing from a listing has not necessarily been deleted — a provider
+ * that is down this session takes its charts out of the list and brings them
+ * back later. The per-chart settings have to survive that, so a refresh must
+ * not touch them; `deleteChart` drops them on a confirmed delete instead
+ * (`resources-delete-chart.spec.ts`).
+ */
+const chart = (id: string): FBChart => [id, { name: id } as never, true];
+
+describe('ChartListComponent — refreshing the list keeps per-chart settings', () => {
+  let listed: FBCharts;
+  let selections: {
+    chartOpacity: Record<string, number>;
+    chartImageAdjustment: Record<string, unknown>;
+    chartDisplayMinZoom: Record<string, number>;
+  };
+  let saveConfig: ReturnType<typeof vi.fn>;
+
+  const refresh = async (c: ChartListComponent) => {
+    await (c as unknown as { initItems: () => Promise<void> }).initItems();
+  };
+
+  beforeEach(() => {
+    // The provider serving 'b' is down, so the listing carries 'a' alone.
+    listed = [chart('a')];
+    selections = {
+      chartOpacity: { a: 0.5, b: 0.7 },
+      chartImageAdjustment: { b: { brightness: 1.4, contrast: 1 } },
+      chartDisplayMinZoom: { a: 12, b: 14 }
+    };
+    saveConfig = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: SKResourceService,
+          useValue: {
+            listFromServer: async () => listed,
+            appendOSM: (list: FBCharts) => list,
+            arrangeChartLayers: (list: FBCharts) => [...list],
+            selectionClean: vi.fn()
+          }
+        },
+        {
+          provide: SKWorkerService,
+          useValue: { resourceUpdate: signal({ path: '' }) }
+        },
+        {
+          provide: AppFacade,
+          useValue: {
+            mapExtent: signal<number[]>([0, 0, 1, 1]),
+            sIsFetching: signal(false),
+            debug: vi.fn(),
+            config: { selections },
+            saveConfig,
+            parseHttpErrorResponse: vi.fn(),
+            data: { chartBounds: { show: false, charts: [] } }
+          }
+        },
+        { provide: MatDialog, useValue: {} },
+        { provide: SKResourceGroupService, useValue: {} },
+        { provide: FBMapInteractService, useValue: {} }
+      ]
+    });
+    TestBed.overrideComponent(ChartListComponent, { set: { template: '' } });
+  });
+
+  it('keeps the settings of a chart the listing left out', async () => {
+    const fixture = TestBed.createComponent(ChartListComponent);
+    fixture.componentRef.setInput('selectedCharts', ['a']);
+
+    await refresh(fixture.componentInstance);
+
+    expect(selections.chartOpacity['b']).toBe(0.7);
+    expect(selections.chartImageAdjustment['b']).toBeDefined();
+    expect(selections.chartDisplayMinZoom['b']).toBe(14);
+  });
+
+  it('does not write the config on a refresh', async () => {
+    const fixture = TestBed.createComponent(ChartListComponent);
+    fixture.componentRef.setInput('selectedCharts', ['a']);
+
+    await refresh(fixture.componentInstance);
+
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/modules/skresources/components/charts/chartlist.html
+++ b/src/app/modules/skresources/components/charts/chartlist.html
@@ -166,7 +166,7 @@
               >
                 {{r[1].description}}
               </div>
-              @if(minZoomLabelFor(r)) {
+              @let minZoomLabel = minZoomLabelFor(r); @if(minZoomLabel) {
               <div
                 style="
                   display: flex;
@@ -182,7 +182,7 @@
                 <mat-icon style="font-size: 14px; width: 14px; height: 14px"
                   >open_in_full</mat-icon
                 >
-                <span>{{minZoomLabelFor(r)}}</span>
+                <span>{{minZoomLabel}}</span>
                 @if(isBoundedOut(r)) {
                 <span style="font-style: italic"
                   >&mdash; hidden at this zoom</span

--- a/src/app/modules/skresources/components/charts/chartlist.html
+++ b/src/app/modules/skresources/components/charts/chartlist.html
@@ -180,7 +180,7 @@
                 "
               >
                 <mat-icon style="font-size: 14px; width: 14px; height: 14px"
-                  >open_in_full</mat-icon
+                  >vertical_align_bottom</mat-icon
                 >
                 <span>{{minZoomLabel}}</span>
                 @if(isBoundedOut(r)) {
@@ -257,7 +257,7 @@
                 matTooltip="Minimum Zoom Level"
                 matTooltipPosition="above"
               >
-                <mat-icon>open_in_full</mat-icon>
+                <mat-icon>vertical_align_bottom</mat-icon>
               </button>
             </div>
             } @if(r[1].proxy) {

--- a/src/app/modules/skresources/components/charts/chartlist.html
+++ b/src/app/modules/skresources/components/charts/chartlist.html
@@ -166,6 +166,30 @@
               >
                 {{r[1].description}}
               </div>
+              @if(minZoomLabelFor(r)) {
+              <div
+                style="
+                  display: flex;
+                  align-items: center;
+                  gap: 4px;
+                  font-size: 11px;
+                  opacity: 0.75;
+                  text-overflow: ellipsis;
+                  overflow-x: hidden;
+                  white-space: pre;
+                "
+              >
+                <mat-icon style="font-size: 14px; width: 14px; height: 14px"
+                  >open_in_full</mat-icon
+                >
+                <span>{{minZoomLabelFor(r)}}</span>
+                @if(isBoundedOut(r)) {
+                <span style="font-style: italic"
+                  >&mdash; hidden at this zoom</span
+                >
+                }
+              </div>
+              }
             </div>
             <div style="text-align: right">
               <mat-checkbox
@@ -223,6 +247,17 @@
                 matTooltipPosition="above"
               >
                 <mat-icon>tune</mat-icon>
+              </button>
+            </div>
+            <div style="width: 100%; text-align: right">
+              <button
+                mat-icon-button
+                [disabled]="!r[2]"
+                (click)="itemDisplayMinZoom(r)"
+                matTooltip="Minimum Zoom Level"
+                matTooltipPosition="above"
+              >
+                <mat-icon>open_in_full</mat-icon>
               </button>
             </div>
             } @if(r[1].proxy) {

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -33,14 +33,19 @@ import { SKWorkerService } from 'src/app/modules/skstream/skstream.service';
 import { ResourceListBase } from '../resource-list-baseclass';
 import { FBMapInteractService } from 'src/app/modules/map/fbmap-interact.service';
 import {
+  displayMinZoomLabel,
   SingleSelectListDialog,
   SliderInputDialog,
   SliderInputDialogResult
 } from 'src/app/lib/components';
+import {
+  isChartInView,
+  isZoomWithinLayerRange,
+  resolveLayerZoomRange
+} from 'src/app/modules/map/ol/lib/charts/chart-utils';
 import { SKResourceGroupService } from '../groups/groups.service';
 import { SKChart } from '../../resource-classes';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { isChartInView } from 'src/app/modules/map/ol/lib/charts/chart-utils';
 
 @Component({
   selector: 'chart-list',
@@ -144,6 +149,7 @@ export class ChartListComponent extends ResourceListBase {
       this.doFilter();
       this.cleanOpacityConfig();
       this.cleanImageAdjustmentConfig();
+      this.cleanDisplayMinZoomConfig();
       this.skres.selectionClean(
         this.collection,
         this.fullList.map((i) => i[0])
@@ -177,6 +183,19 @@ export class ChartListComponent extends ResourceListBase {
     keys.forEach((key) => {
       if (!listIds.includes(key)) {
         delete this.app.config.selections.chartImageAdjustment[key];
+      }
+    });
+  }
+
+  /**
+   * Clean orphaned chartDisplayMinZoom keys from config
+   */
+  cleanDisplayMinZoomConfig() {
+    const keys = Object.keys(this.app.config.selections.chartDisplayMinZoom);
+    const listIds = this.fullList.map((i) => i[0]);
+    keys.forEach((key) => {
+      if (!listIds.includes(key)) {
+        delete this.app.config.selections.chartDisplayMinZoom[key];
       }
     });
   }
@@ -314,6 +333,55 @@ export class ChartListComponent extends ResourceListBase {
           return;
         }
       });
+  }
+
+  /**
+   * @description Compact label for a chart's configured display minimum zoom.
+   * @param chart Chart entry
+   */
+  protected minZoomLabelFor(chart: FBChart): string {
+    // Only the raster layers honour a display minimum, so only they may claim
+    // one -- the control is likewise offered on `isImageLayer` charts alone.
+    return this.isImageLayer(chart)
+      ? displayMinZoomLabel(chart[1]?.displayMinZoom)
+      : '';
+  }
+
+  /**
+   * @description True when a selected chart is not drawn at the current map
+   * zoom because of its display minimum. Resolved the same way the map layer
+   * resolves it, so the list cannot claim a chart is showing when it is not.
+   * Charts with no display minimum are never marked -- other reasons a chart
+   * may not be visible are out of scope.
+   * @param chart Chart entry
+   */
+  protected isBoundedOut(chart: FBChart): boolean {
+    if (
+      !chart[2] ||
+      !this.isImageLayer(chart) ||
+      typeof chart[1]?.displayMinZoom !== 'number'
+    ) {
+      return false;
+    }
+    return !isZoomWithinLayerRange(
+      resolveLayerZoomRange(
+        chart[1],
+        this.app.MAP_ZOOM_EXTENT.max,
+        this.app.config.map.overZoomTiles
+      ),
+      this.app.mapZoom()
+    );
+  }
+
+  protected itemDisplayMinZoom(chart: FBChart) {
+    // The list stays open: balancing an overlapping set means moving between
+    // charts, and the list is where their levels and hidden state are shown --
+    // so the applied value has to land on the list's own copy of the chart, or
+    // the row keeps reporting the state from before the edit.
+    this.skres.openDisplayMinZoom(chart, (value?: number) => {
+      chart[1].displayMinZoom = value;
+      this.updateFullList(chart);
+    });
   }
 
   protected itemImageAdjustment(chart: FBChart) {

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -147,9 +147,14 @@ export class ChartListComponent extends ResourceListBase {
       this.fullList = this.skres.appendOSM(this.fullList);
       this.app.sIsFetching.set(false);
       this.doFilter();
-      this.cleanOpacityConfig();
-      this.cleanImageAdjustmentConfig();
-      this.cleanDisplayMinZoomConfig();
+      const cleaned = [
+        this.cleanOpacityConfig(),
+        this.cleanImageAdjustmentConfig(),
+        this.cleanDisplayMinZoomConfig()
+      ].some(Boolean);
+      if (cleaned) {
+        this.app.saveConfig();
+      }
       this.skres.selectionClean(
         this.collection,
         this.fullList.map((i) => i[0])
@@ -163,41 +168,42 @@ export class ChartListComponent extends ResourceListBase {
 
   /**
    * Clean orphaned chartOpacity keys from config
+   * @returns true when a key was removed, so the caller can persist.
    */
-  cleanOpacityConfig() {
-    const keys = Object.keys(this.app.config.selections.chartOpacity);
-    const listIds = this.fullList.map((i) => i[0]);
-    keys.forEach((key) => {
-      if (!listIds.includes(key)) {
-        delete this.app.config.selections.chartOpacity[key];
-      }
-    });
+  cleanOpacityConfig(): boolean {
+    return this.cleanOrphanedKeys(this.app.config.selections.chartOpacity);
   }
 
   /**
    * Clean orphaned chartImageAdjustment keys from config
+   * @returns true when a key was removed, so the caller can persist.
    */
-  cleanImageAdjustmentConfig() {
-    const keys = Object.keys(this.app.config.selections.chartImageAdjustment);
-    const listIds = this.fullList.map((i) => i[0]);
-    keys.forEach((key) => {
-      if (!listIds.includes(key)) {
-        delete this.app.config.selections.chartImageAdjustment[key];
-      }
-    });
+  cleanImageAdjustmentConfig(): boolean {
+    return this.cleanOrphanedKeys(
+      this.app.config.selections.chartImageAdjustment
+    );
   }
 
   /**
    * Clean orphaned chartDisplayMinZoom keys from config
+   * @returns true when a key was removed, so the caller can persist.
    */
-  cleanDisplayMinZoomConfig() {
-    const keys = Object.keys(this.app.config.selections.chartDisplayMinZoom);
+  cleanDisplayMinZoomConfig(): boolean {
+    return this.cleanOrphanedKeys(
+      this.app.config.selections.chartDisplayMinZoom
+    );
+  }
+
+  /**
+   * Drop per-chart settings for charts the server no longer lists.
+   */
+  private cleanOrphanedKeys(settings: Record<string, unknown>): boolean {
     const listIds = this.fullList.map((i) => i[0]);
-    keys.forEach((key) => {
-      if (!listIds.includes(key)) {
-        delete this.app.config.selections.chartDisplayMinZoom[key];
-      }
-    });
+    const orphaned = Object.keys(settings).filter(
+      (key) => !listIds.includes(key)
+    );
+    orphaned.forEach((key) => delete settings[key]);
+    return orphaned.length > 0;
   }
 
   /**

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -147,14 +147,6 @@ export class ChartListComponent extends ResourceListBase {
       this.fullList = this.skres.appendOSM(this.fullList);
       this.app.sIsFetching.set(false);
       this.doFilter();
-      const cleaned = [
-        this.cleanOpacityConfig(),
-        this.cleanImageAdjustmentConfig(),
-        this.cleanDisplayMinZoomConfig()
-      ].some(Boolean);
-      if (cleaned) {
-        this.app.saveConfig();
-      }
       this.skres.selectionClean(
         this.collection,
         this.fullList.map((i) => i[0])
@@ -164,46 +156,6 @@ export class ChartListComponent extends ResourceListBase {
       this.app.parseHttpErrorResponse(err);
       this.fullList = [];
     }
-  }
-
-  /**
-   * Clean orphaned chartOpacity keys from config
-   * @returns true when a key was removed, so the caller can persist.
-   */
-  cleanOpacityConfig(): boolean {
-    return this.cleanOrphanedKeys(this.app.config.selections.chartOpacity);
-  }
-
-  /**
-   * Clean orphaned chartImageAdjustment keys from config
-   * @returns true when a key was removed, so the caller can persist.
-   */
-  cleanImageAdjustmentConfig(): boolean {
-    return this.cleanOrphanedKeys(
-      this.app.config.selections.chartImageAdjustment
-    );
-  }
-
-  /**
-   * Clean orphaned chartDisplayMinZoom keys from config
-   * @returns true when a key was removed, so the caller can persist.
-   */
-  cleanDisplayMinZoomConfig(): boolean {
-    return this.cleanOrphanedKeys(
-      this.app.config.selections.chartDisplayMinZoom
-    );
-  }
-
-  /**
-   * Drop per-chart settings for charts the server no longer lists.
-   */
-  private cleanOrphanedKeys(settings: Record<string, unknown>): boolean {
-    const listIds = this.fullList.map((i) => i[0]);
-    const orphaned = Object.keys(settings).filter(
-      (key) => !listIds.includes(key)
-    );
-    orphaned.forEach((key) => delete settings[key]);
-    return orphaned.length > 0;
   }
 
   /**

--- a/src/app/modules/skresources/components/charts/chartlist.ts
+++ b/src/app/modules/skresources/components/charts/chartlist.ts
@@ -349,10 +349,11 @@ export class ChartListComponent extends ResourceListBase {
 
   /**
    * @description True when a selected chart is not drawn at the current map
-   * zoom because of its display minimum. Resolved the same way the map layer
+   * zoom. Only charts carrying a display minimum are marked, since the notice
+   * hangs off that label -- but the test is the layer's whole resolved range,
+   * so a chart held back by its own declared bounds still reports itself
+   * hidden rather than appearing to be on. Resolved the way the map layer
    * resolves it, so the list cannot claim a chart is showing when it is not.
-   * Charts with no display minimum are never marked -- other reasons a chart
-   * may not be visible are out of scope.
    * @param chart Chart entry
    */
   protected isBoundedOut(chart: FBChart): boolean {

--- a/src/app/modules/skresources/resource-classes.spec.ts
+++ b/src/app/modules/skresources/resource-classes.spec.ts
@@ -23,6 +23,18 @@ describe('SKChart', () => {
     expect(clone.maxZoom).toBe(13);
   });
 
+  it('keeps a local display minimum zoom when cloning an instance', () => {
+    // The chart list clones through SKChart after the minimum is applied, so
+    // losing it here takes the row's own label and hidden state with it.
+    const original = new SKChart({
+      name: 'Local chart',
+      url: 'http://x/{z}/{x}/{y}.png'
+    });
+    original.displayMinZoom = 10;
+
+    expect(new SKChart(original).displayMinZoom).toBe(10);
+  });
+
   it('keeps the source when cloning an instance', () => {
     const original = new SKChart({
       name: 'Local chart',

--- a/src/app/modules/skresources/resource-classes.ts
+++ b/src/app/modules/skresources/resource-classes.ts
@@ -135,6 +135,7 @@ export class SKChart {
   style: string;
   defaultOpacity: number;
   imageAdjustment?: ChartImageAdjustment;
+  displayMinZoom?: number;
   proxy: boolean;
 
   // Accepts a server chart resource or an existing SKChart: the chart cache
@@ -162,6 +163,7 @@ export class SKChart {
     this.source = src?.$source ?? src?.source ?? undefined;
     this.defaultOpacity = chart?.defaultOpacity ?? 1;
     this.imageAdjustment = chart?.imageAdjustment;
+    this.displayMinZoom = chart?.displayMinZoom;
     this.proxy = chart?.proxy ?? false;
   }
 }

--- a/src/app/modules/skresources/resources-charts-min-zoom.spec.ts
+++ b/src/app/modules/skresources/resources-charts-min-zoom.spec.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { signal } from '@angular/core';
+import { SKResourceService } from './resources.service';
+import { FBCharts } from 'src/app/types';
+
+/**
+ * A chart's display minimum zoom is a local preference: it stops the chart
+ * being drawn below that zoom, and is stored per chart id in config rather
+ * than on the server's chart resource. Both paths that build chart objects
+ * must apply it -- `transformChart` for server charts and `appendOSM` for the
+ * built-in ones -- and it must never reach the server on the chart-properties
+ * PUT.
+ *
+ * `appendOSM` / `transformChart` only read `this.app`, so exercise them on a
+ * bare prototype instance with a mock app -- no Angular DI needed.
+ */
+function svcWithDisplayMinZoom(chartDisplayMinZoom: Record<string, number>) {
+  const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+  (svc as unknown as { app: unknown }).app = {
+    config: {
+      selections: { charts: null, chartOpacity: {}, chartDisplayMinZoom }
+    }
+  };
+  return svc;
+}
+
+function transform(svc: SKResourceService, id: string) {
+  return (
+    svc as unknown as {
+      transformChart: (c: unknown, id: string) => { displayMinZoom?: number };
+    }
+  ).transformChart({ name: 'X', url: 'http://x/{z}/{x}/{y}.png' }, id);
+}
+
+describe('chart display minimum zoom', () => {
+  it('transformChart applies a stored minimum to a server chart', () => {
+    const svc = svcWithDisplayMinZoom({ 'my-chart': 9 });
+    expect(transform(svc, 'my-chart').displayMinZoom).toBe(9);
+  });
+
+  it('appendOSM applies a stored minimum to the built-in OSM charts', () => {
+    const svc = svcWithDisplayMinZoom({ openstreetmap: 10 });
+    const osm = (svc.appendOSM([]) as FBCharts).find(
+      (c) => c[0] === 'openstreetmap'
+    );
+    expect(osm?.[1].displayMinZoom).toBe(10);
+  });
+
+  it('honours a minimum of 0 (not dropped as falsy)', () => {
+    const svc = svcWithDisplayMinZoom({ 'my-chart': 0 });
+    expect(transform(svc, 'my-chart').displayMinZoom).toBe(0);
+  });
+
+  it('leaves charts untouched when config holds no minimum for them', () => {
+    const svc = svcWithDisplayMinZoom({ 'other-chart': 5 });
+    expect(transform(svc, 'my-chart').displayMinZoom).toBeUndefined();
+  });
+
+  it('tolerates a config saved before the feature existed', () => {
+    const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+    (svc as unknown as { app: unknown }).app = {
+      config: { selections: { charts: null, chartOpacity: {} } }
+    };
+    expect(transform(svc, 'my-chart').displayMinZoom).toBeUndefined();
+    expect(() => svc.appendOSM([])).not.toThrow();
+  });
+
+  describe('live update', () => {
+    // Two cached charts; the setter should rebuild only the one addressed.
+    const cachedCharts = () =>
+      [
+        [
+          'chart-a',
+          {
+            name: 'A',
+            url: 'http://a/{z}/{x}/{y}.png',
+            minZoom: 5,
+            maxZoom: 15
+          },
+          true
+        ],
+        ['chart-b', { name: 'B', url: 'http://b/{z}/{x}/{y}.png' }, true]
+      ] as unknown as FBCharts;
+
+    function svcWithCache() {
+      const svc = Object.create(
+        SKResourceService.prototype
+      ) as SKResourceService;
+      (svc as unknown as { chartCacheSignal: unknown }).chartCacheSignal =
+        signal(cachedCharts());
+      return svc;
+    }
+
+    const cache = (svc: SKResourceService) =>
+      (
+        svc as unknown as {
+          chartCacheSignal: () => FBCharts;
+        }
+      ).chartCacheSignal();
+
+    it('applies a minimum to the addressed chart', () => {
+      const svc = svcWithCache();
+      svc.chartSetDisplayMinZoom('chart-a', 9);
+      expect(cache(svc)[0][1].displayMinZoom).toBe(9);
+    });
+
+    it('keeps the declared zoom range of the chart it rebuilds', () => {
+      const svc = svcWithCache();
+      svc.chartSetDisplayMinZoom('chart-a', 9);
+      expect(cache(svc)[0][1].minZoom).toBe(5);
+      expect(cache(svc)[0][1].maxZoom).toBe(15);
+    });
+
+    it('leaves the other cached charts untouched', () => {
+      const svc = svcWithCache();
+      const before = cache(svc)[1];
+      svc.chartSetDisplayMinZoom('chart-a', 9);
+      expect(cache(svc)[1]).toBe(before);
+    });
+
+    it('clears the minimum when passed nothing', () => {
+      const svc = svcWithCache();
+      svc.chartSetDisplayMinZoom('chart-a', 9);
+      svc.chartSetDisplayMinZoom('chart-a', undefined);
+      expect(cache(svc)[0][1].displayMinZoom).toBeUndefined();
+    });
+
+    it('ignores an unknown chart id', () => {
+      const svc = svcWithCache();
+      const before = cache(svc);
+      svc.chartSetDisplayMinZoom('nope', 9);
+      expect(cache(svc)).toBe(before);
+    });
+  });
+
+  it('strips the minimum from the chart sent back to the server', () => {
+    const svc = svcWithDisplayMinZoom({});
+    const chart = transform(
+      svcWithDisplayMinZoom({ 'my-chart': 9 }),
+      'my-chart'
+    );
+    const outbound = (
+      svc as unknown as {
+        withoutDisplayMinZoom: (c: unknown) => Record<string, unknown>;
+      }
+    ).withoutDisplayMinZoom(chart);
+
+    expect('displayMinZoom' in outbound).toBe(false);
+    expect(outbound.url).toBe('http://x/{z}/{x}/{y}.png');
+  });
+});

--- a/src/app/modules/skresources/resources-delete-chart.spec.ts
+++ b/src/app/modules/skresources/resources-delete-chart.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { of } from 'rxjs';
+import { SKResourceService } from './resources.service';
+
+/**
+ * Deleting a chart is the one moment the app knows a chart is gone rather than
+ * merely absent, so it is where the per-chart settings held for it are dropped.
+ * `deleteChart` only touches `app` and `deleteFromServer`, so exercise it on a
+ * bare prototype instance with those stubbed -- no Angular DI needed.
+ */
+function svcWithCharts(confirm: boolean, deleteResult: Promise<void>) {
+  const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+  const saveConfig = vi.fn();
+  const parseHttpErrorResponse = vi.fn();
+  const selections = {
+    chartOpacity: { c1: 0.5, c2: 0.8 },
+    chartImageAdjustment: { c1: { brightness: 1.2, contrast: 1 } },
+    chartDisplayMinZoom: { c1: 14, c2: 9 }
+  };
+  (svc as unknown as { app: unknown }).app = {
+    config: { selections },
+    saveConfig,
+    parseHttpErrorResponse,
+    showConfirm: () => of({ ok: confirm })
+  };
+  const deleteFromServer = vi.fn(() => deleteResult);
+  svc.deleteFromServer = deleteFromServer;
+  return {
+    svc,
+    selections,
+    saveConfig,
+    deleteFromServer,
+    parseHttpErrorResponse
+  };
+}
+
+// deleteChart hands the settings cleanup to the delete promise, so let the
+// microtask queue drain before asserting.
+const settled = () => new Promise((resolve) => setTimeout(resolve));
+
+describe('deleteChart', () => {
+  it('drops every per-chart setting held for the deleted chart', async () => {
+    const { svc, selections, saveConfig } = svcWithCharts(
+      true,
+      Promise.resolve()
+    );
+
+    svc.deleteChart('c1');
+    await settled();
+
+    expect(selections.chartOpacity).not.toHaveProperty('c1');
+    expect(selections.chartImageAdjustment).not.toHaveProperty('c1');
+    expect(selections.chartDisplayMinZoom).not.toHaveProperty('c1');
+    expect(saveConfig).toHaveBeenCalledOnce();
+  });
+
+  it('leaves the other charts’ settings alone', async () => {
+    const { svc, selections } = svcWithCharts(true, Promise.resolve());
+
+    svc.deleteChart('c1');
+    await settled();
+
+    expect(selections.chartOpacity['c2']).toBe(0.8);
+    expect(selections.chartDisplayMinZoom['c2']).toBe(9);
+  });
+
+  it('keeps the settings when the server delete fails', async () => {
+    const { svc, selections, saveConfig, parseHttpErrorResponse } =
+      svcWithCharts(true, Promise.reject(new Error('offline')));
+
+    svc.deleteChart('c1');
+    await settled();
+
+    expect(selections.chartDisplayMinZoom['c1']).toBe(14);
+    expect(saveConfig).not.toHaveBeenCalled();
+    expect(parseHttpErrorResponse).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the settings when the delete is not confirmed', async () => {
+    const { svc, selections, deleteFromServer, saveConfig } = svcWithCharts(
+      false,
+      Promise.resolve()
+    );
+
+    svc.deleteChart('c1');
+    await settled();
+
+    expect(deleteFromServer).not.toHaveBeenCalled();
+    expect(selections.chartDisplayMinZoom['c1']).toBe(14);
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not write the config when the chart held no settings', async () => {
+    const { svc, saveConfig } = svcWithCharts(true, Promise.resolve());
+
+    svc.deleteChart('never-configured');
+    await settled();
+
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/modules/skresources/resources-open-display-min-zoom.spec.ts
+++ b/src/app/modules/skresources/resources-open-display-min-zoom.spec.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi } from 'vitest';
+import { of, Subject } from 'rxjs';
+import { SKResourceService } from './resources.service';
+import { FBChart } from 'src/app/types';
+import { ChartMinZoomDialogResult } from 'src/app/lib/components';
+
+/**
+ * Behaviour tests for the modeless minimum-zoom palette owned by the service.
+ * APPLY persists per-chart and updates the render cache, clearing removes the
+ * entry entirely, and closing reverts the live preview. `openDisplayMinZoom`
+ * only touches `app`, `dialog` and `chartSetDisplayMinZoom`, so exercise it on
+ * a bare prototype instance with those stubbed -- no Angular DI needed.
+ */
+function svcWithResult(
+  result: ChartMinZoomDialogResult | undefined,
+  stored: Record<string, number> = {}
+) {
+  const svc = Object.create(SKResourceService.prototype) as SKResourceService;
+  const saveConfig = vi.fn();
+  const config = {
+    selections: { chartDisplayMinZoom: stored },
+    map: { zoomLevel: 11 }
+  };
+  (svc as unknown as { app: unknown }).app = {
+    config,
+    saveConfig,
+    mapZoom: () => 11
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let openedData: any;
+  const closeSpy = vi.fn();
+  (svc as unknown as { dialog: unknown }).dialog = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    open: (_cmp: unknown, cfg: any) => {
+      openedData = cfg.data;
+      return { afterClosed: () => of(result), close: closeSpy };
+    }
+  };
+  const setSpy = vi.fn();
+  svc.chartSetDisplayMinZoom = setSpy;
+  return {
+    svc,
+    saveConfig,
+    stored,
+    setSpy,
+    closeSpy,
+    getData: () => openedData
+  };
+}
+
+const chart = (displayMinZoom?: number): FBChart =>
+  [
+    'c1',
+    { name: 'Rannikkokartat', minZoom: 5, maxZoom: 15, displayMinZoom },
+    true
+  ] as unknown as FBChart;
+
+describe('openDisplayMinZoom', () => {
+  it('APPLY persists the level to config and applies it to the cache', () => {
+    const { svc, saveConfig, stored, setSpy } = svcWithResult({
+      apply: true,
+      value: 12
+    });
+
+    svc.openDisplayMinZoom(chart());
+
+    expect(stored['c1']).toBe(12);
+    expect(setSpy).toHaveBeenLastCalledWith('c1', 12);
+    expect(saveConfig).toHaveBeenCalledOnce();
+  });
+
+  it('APPLY with no level removes the entry rather than storing undefined', () => {
+    // A left-behind key is re-injected by transformChart on the next refresh,
+    // so a cleared minimum would come back.
+    const { svc, stored, setSpy } = svcWithResult(
+      { apply: true, value: undefined },
+      { c1: 12 }
+    );
+
+    svc.openDisplayMinZoom(chart(12));
+
+    expect('c1' in stored).toBe(false);
+    expect(setSpy).toHaveBeenLastCalledWith('c1', undefined);
+  });
+
+  it('closing without applying reverts the preview and writes nothing', () => {
+    const { svc, saveConfig, stored, setSpy } = svcWithResult(
+      { apply: false, value: 16 },
+      { c1: 12 }
+    );
+
+    svc.openDisplayMinZoom(chart(12));
+
+    expect(stored['c1']).toBe(12);
+    expect(setSpy).toHaveBeenLastCalledWith('c1', 12);
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('reports the applied level back to the caller', () => {
+    // The chart list keeps its own copy of the chart and needs the applied
+    // value to keep its row honest.
+    const { svc } = svcWithResult({ apply: true, value: 12 });
+    const applied = vi.fn();
+
+    svc.openDisplayMinZoom(chart(), applied);
+
+    expect(applied).toHaveBeenCalledWith(12);
+  });
+
+  it('does not report back when the dialog was closed without applying', () => {
+    const { svc } = svcWithResult({ apply: false, value: 12 });
+    const applied = vi.fn();
+
+    svc.openDisplayMinZoom(chart(), applied);
+
+    expect(applied).not.toHaveBeenCalled();
+  });
+
+  it('seeds the dialog from config, falling back to the chart', () => {
+    const fromConfig = svcWithResult(undefined, { c1: 9 });
+    fromConfig.svc.openDisplayMinZoom(chart(12));
+    expect(fromConfig.getData().value).toBe(9);
+
+    const fromChart = svcWithResult(undefined);
+    fromChart.svc.openDisplayMinZoom(chart(12));
+    expect(fromChart.getData().value).toBe(12);
+  });
+
+  describe('single-instance guard', () => {
+    /**
+     * `afterClosed` emits asynchronously in Angular Material -- the container
+     * defers it -- so a stub that emits synchronously would never reproduce the
+     * ordering that matters here. Each palette gets a subject the test closes
+     * by hand.
+     */
+    function svcWithOpenPalettes() {
+      const svc = Object.create(
+        SKResourceService.prototype
+      ) as SKResourceService;
+      (svc as unknown as { app: unknown }).app = {
+        config: { selections: { chartDisplayMinZoom: {} } },
+        saveConfig: vi.fn(),
+        mapZoom: () => 11
+      };
+      const opened: Array<{
+        close: ReturnType<typeof vi.fn>;
+        emit: () => void;
+      }> = [];
+      (svc as unknown as { dialog: unknown }).dialog = {
+        open: () => {
+          const subject = new Subject<ChartMinZoomDialogResult>();
+          const ref = {
+            afterClosed: () => subject,
+            close: vi.fn(),
+            emit: () => {
+              subject.next({ apply: false });
+              subject.complete();
+            }
+          };
+          opened.push(ref);
+          return ref;
+        }
+      };
+      svc.chartSetDisplayMinZoom = vi.fn();
+      return { svc, opened };
+    }
+
+    it('closes the open palette before opening another', () => {
+      const { svc, opened } = svcWithOpenPalettes();
+
+      svc.openDisplayMinZoom(chart());
+      svc.openDisplayMinZoom(chart());
+
+      expect(opened).toHaveLength(2);
+      expect(opened[0].close).toHaveBeenCalled();
+    });
+
+    it('keeps tracking the replacement when the replaced palette closes late', () => {
+      // The replaced palette's afterClosed fires after its replacement has
+      // already been stored; clearing the reference blindly there would leave
+      // the replacement untracked and let a third palette stack on top of it.
+      const { svc, opened } = svcWithOpenPalettes();
+
+      svc.openDisplayMinZoom(chart());
+      svc.openDisplayMinZoom(chart());
+      opened[0].emit();
+      svc.openDisplayMinZoom(chart());
+
+      expect(opened).toHaveLength(3);
+      expect(opened[1].close).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/modules/skresources/resources-open-display-min-zoom.spec.ts
+++ b/src/app/modules/skresources/resources-open-display-min-zoom.spec.ts
@@ -139,7 +139,10 @@ describe('openDisplayMinZoom', () => {
         SKResourceService.prototype
       ) as SKResourceService;
       (svc as unknown as { app: unknown }).app = {
-        config: { selections: { chartDisplayMinZoom: {} } },
+        config: {
+          selections: { chartDisplayMinZoom: {}, chartImageAdjustment: {} },
+          imageAdjustPalettePos: null
+        },
         saveConfig: vi.fn(),
         mapZoom: () => 11
       };
@@ -162,8 +165,10 @@ describe('openDisplayMinZoom', () => {
           return ref;
         }
       };
-      svc.chartSetDisplayMinZoom = vi.fn();
-      return { svc, opened };
+      const setMinZoom = vi.fn();
+      svc.chartSetDisplayMinZoom = setMinZoom;
+      svc.chartSetImageAdjustment = vi.fn();
+      return { svc, opened, setMinZoom };
     }
 
     it('closes the open palette before opening another', () => {
@@ -189,6 +194,32 @@ describe('openDisplayMinZoom', () => {
 
       expect(opened).toHaveLength(3);
       expect(opened[1].close).toHaveBeenCalled();
+    });
+
+    it('leaves the bound to a replacement over the same chart', () => {
+      // The late cancel would otherwise put the pre-edit bound back over the
+      // value the replacement is previewing.
+      const { svc, opened, setMinZoom } = svcWithOpenPalettes();
+
+      svc.openDisplayMinZoom(chart(12));
+      svc.openDisplayMinZoom(chart(12));
+      setMinZoom.mockClear();
+      opened[0].emit();
+
+      expect(setMinZoom).not.toHaveBeenCalled();
+    });
+
+    it('still reverts when the palette taking over edits something else', () => {
+      // An image adjustment palette for the same chart is not a continuation of
+      // this edit: it leaves the bound alone, so the bound has to revert.
+      const { svc, opened, setMinZoom } = svcWithOpenPalettes();
+
+      svc.openDisplayMinZoom(chart(12));
+      svc.openImageAdjustment(chart(12));
+      setMinZoom.mockClear();
+      opened[0].emit();
+
+      expect(setMinZoom).toHaveBeenCalledWith('c1', 12);
     });
   });
 });

--- a/src/app/modules/skresources/resources-open-display-min-zoom.spec.ts
+++ b/src/app/modules/skresources/resources-open-display-min-zoom.spec.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { of, Subject } from 'rxjs';
 import { SKResourceService } from './resources.service';
 import { FBChart } from 'src/app/types';
-import { ChartMinZoomDialogResult } from 'src/app/lib/components';
+import {
+  ChartMinZoomDialogData,
+  ChartMinZoomDialogResult
+} from 'src/app/lib/components';
 
 /**
  * Behaviour tests for the modeless minimum-zoom palette owned by the service.
@@ -26,12 +29,10 @@ function svcWithResult(
     saveConfig,
     mapZoom: () => 11
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let openedData: any;
+  let openedData: ChartMinZoomDialogData;
   const closeSpy = vi.fn();
   (svc as unknown as { dialog: unknown }).dialog = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    open: (_cmp: unknown, cfg: any) => {
+    open: (_cmp: unknown, cfg: { data: ChartMinZoomDialogData }) => {
       openedData = cfg.data;
       return { afterClosed: () => of(result), close: closeSpy };
     }

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -594,6 +594,10 @@ export class SKResourceService {
         if (typeof adj !== 'undefined') {
           c[1].imageAdjustment = adj;
         }
+        const dmz = this.app.config.selections.chartDisplayMinZoom?.[c[0]];
+        if (typeof dmz !== 'undefined') {
+          c[1].displayMinZoom = dmz;
+        }
       });
     }
     chtList.push(OSM[1]);
@@ -658,6 +662,10 @@ export class SKResourceService {
     const adj = this.app.config.selections.chartImageAdjustment?.[id];
     if (typeof adj !== 'undefined') {
       chart.imageAdjustment = adj;
+    }
+    const dmz = this.app.config.selections.chartDisplayMinZoom?.[id];
+    if (typeof dmz !== 'undefined') {
+      chart.displayMinZoom = dmz;
     }
     return new SKChart(chart);
   }
@@ -874,6 +882,31 @@ export class SKResourceService {
   }
 
   /**
+   * @description Update the display minimum zoom of a Chart object in the
+   * Chart Cache so a currently-visible layer re-renders.
+   * @param id Chart identifier
+   * @param value Zoom level to set. Omit to clear it.
+   */
+  public chartSetDisplayMinZoom(id: string, value?: number) {
+    if (!id) {
+      return;
+    }
+    const idx = this.chartCacheSignal().findIndex((c: FBChart) => c[0] === id);
+    if (idx !== -1) {
+      this.chartCacheSignal.update((current: FBCharts) => {
+        return current.map((c: FBChart) => {
+          if (c[0] !== id) {
+            return c;
+          }
+          const updated = new SKChart(c[1]);
+          updated.displayMinZoom = value;
+          return [c[0], updated, c[2]];
+        });
+      });
+    }
+  }
+
+  /**
    * @description Open the modeless, draggable Image Adjustment palette for a
    * chart. Sliders take effect live; SAVE persists per-chart, closing (cancel)
    * reverts to the pre-edit values. Owned here (not the chart list) so the list
@@ -928,6 +961,7 @@ export class SKResourceService {
       }
     });
   }
+
 
   /**
    * @description Open a modeless per-chart palette, replacing any already open.
@@ -1243,11 +1277,26 @@ export class SKResourceService {
       .afterClosed()
       .subscribe((r: { save: boolean; chart: SKChart }) => {
         if (r.save) {
-          this.putToServer('charts', id, r.chart).catch((err) =>
-            this.app.parseHttpErrorResponse(err)
-          );
+          this.putToServer(
+            'charts',
+            id,
+            this.withoutDisplayMinZoom(r.chart)
+          ).catch((err) => this.app.parseHttpErrorResponse(err));
         }
       });
+  }
+
+  /**
+   * @description Copy of a chart without its display minimum zoom, which is a
+   * local preference rather than part of the server's chart resource. Charts
+   * fetched for editing come through `transformChart()`, so the range is
+   * present on the object the properties dialog hands back.
+   * @param chart Chart to strip
+   */
+  private withoutDisplayMinZoom(chart: SKChart): SKChart {
+    const outbound = { ...chart };
+    delete outbound.displayMinZoom;
+    return outbound;
   }
 
   /**

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -72,6 +72,8 @@ import { groupBy } from 'rxjs/operators';
 import { SKWorkerService } from '../skstream/skstream.service';
 import { ChartSeedJobDialog } from './components/charts/chart-seedjob-dialog';
 import {
+  ChartMinZoomDialog,
+  ChartMinZoomDialogResult,
   ImageAdjustmentDialog,
   ImageAdjustmentDialogResult
 } from 'src/app/lib/components';
@@ -962,6 +964,57 @@ export class SKResourceService {
     });
   }
 
+  /**
+   * @description Open the modeless Display Zoom dialog for a chart. The bound
+   * takes effect live so the map can be zoomed to judge it; APPLY persists
+   * per-chart, closing reverts to the pre-edit value. Owned here (not the chart
+   * list) so the list can stay open alongside it while a set is balanced.
+   * Opening one for another chart closes the current one, discarding its
+   * preview.
+   * @param chart Chart to bound
+   * @param onApplied Called with the persisted value so the caller can mirror
+   * it onto its own copy of the chart
+   */
+  public openDisplayMinZoom(
+    chart: FBChart,
+    onApplied?: (value?: number) => void
+  ) {
+    const id = chart[0];
+    const original =
+      this.app.config.selections.chartDisplayMinZoom[id] ??
+      chart[1]?.displayMinZoom;
+
+    const ref = this.openChartPalette(ChartMinZoomDialog, {
+      width: '300px',
+      data: {
+        text: chart[1]?.name ?? '',
+        value: original,
+        declaredMin: chart[1]?.minZoom,
+        declaredMax: chart[1]?.maxZoom,
+        currentZoom: () => this.app.mapZoom(),
+        onChange: (value?: number) => {
+          this.chartSetDisplayMinZoom(id, value);
+        }
+      }
+    });
+
+    ref.afterClosed().subscribe((result: ChartMinZoomDialogResult) => {
+      this.releaseChartPalette(ref);
+      if (result?.apply) {
+        if (typeof result.value === 'number') {
+          this.app.config.selections.chartDisplayMinZoom[id] = result.value;
+        } else {
+          delete this.app.config.selections.chartDisplayMinZoom[id];
+        }
+        this.chartSetDisplayMinZoom(id, result.value);
+        this.app.saveConfig();
+        onApplied?.(result.value);
+      } else {
+        // closed without applying - restore the pre-edit value
+        this.chartSetDisplayMinZoom(id, original);
+      }
+    });
+  }
 
   /**
    * @description Open a modeless per-chart palette, replacing any already open.

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -1013,21 +1013,26 @@ export class SKResourceService {
     const ref = this.openChartPalette<
       ChartMinZoomDialog,
       ChartMinZoomDialogResult
-    >(ChartMinZoomDialog, {
-      width: '300px',
-      data: {
-        text: chart[1]?.name ?? '',
-        value: original,
-        declaredMin: chart[1]?.minZoom,
-        declaredMax: chart[1]?.maxZoom,
-        currentZoom: () => this.app.mapZoom(),
-        onChange: (value?: number) => {
-          this.chartSetDisplayMinZoom(id, value);
+    >(
+      ChartMinZoomDialog,
+      {
+        width: '300px',
+        data: {
+          text: chart[1]?.name ?? '',
+          value: original,
+          declaredMin: chart[1]?.minZoom,
+          declaredMax: chart[1]?.maxZoom,
+          currentZoom: () => this.app.mapZoom(),
+          onChange: (value?: number) => {
+            this.chartSetDisplayMinZoom(id, value);
+          }
         }
-      }
-    });
+      },
+      `displayMinZoom:${id}`
+    );
 
     ref.afterClosed().subscribe((result?: ChartMinZoomDialogResult) => {
+      const handedOver = this.paletteHandedOver(`displayMinZoom:${id}`, ref);
       this.releaseChartPalette(ref);
       if (result?.apply) {
         if (typeof result.value === 'number') {
@@ -1038,7 +1043,7 @@ export class SKResourceService {
         this.chartSetDisplayMinZoom(id, result.value);
         this.app.saveConfig();
         onApplied?.(result.value);
-      } else {
+      } else if (!handedOver) {
         // closed without applying - restore the pre-edit value
         this.chartSetDisplayMinZoom(id, original);
       }

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -726,11 +726,37 @@ export class SKResourceService {
       )
       .subscribe((result: { ok: boolean }) => {
         if (result && result.ok) {
-          this.deleteFromServer('charts', id, 'resources-provider').catch(
-            (err: HttpErrorResponse) => this.app.parseHttpErrorResponse(err)
-          );
+          this.deleteFromServer('charts', id, 'resources-provider')
+            .then(() => this.forgetChartSettings(id))
+            .catch((err: HttpErrorResponse) =>
+              this.app.parseHttpErrorResponse(err)
+            );
         }
       });
+  }
+
+  /**
+   * @description Drop the per-chart settings held for a chart that is gone.
+   * Called on a confirmed delete rather than when a chart is missing from a
+   * listing: a provider that is down this session takes its charts out of the
+   * list without them having been deleted, and the settings are the user's
+   * work -- an opacity, an image adjustment, a minimum zoom tuned against a
+   * chart set. They cost a few config keys if a chart is deleted elsewhere,
+   * and cannot be recovered if dropped while the chart is only away.
+   * @param id Chart identifier
+   */
+  private forgetChartSettings(id: string) {
+    const selections = this.app.config.selections;
+    const held = [
+      selections.chartOpacity,
+      selections.chartImageAdjustment,
+      selections.chartDisplayMinZoom
+    ].filter((settings) => id in settings);
+    if (held.length === 0) {
+      return;
+    }
+    held.forEach((settings) => delete settings[id]);
+    this.app.saveConfig();
   }
 
   /**

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -984,7 +984,10 @@ export class SKResourceService {
       this.app.config.selections.chartDisplayMinZoom[id] ??
       chart[1]?.displayMinZoom;
 
-    const ref = this.openChartPalette(ChartMinZoomDialog, {
+    const ref = this.openChartPalette<
+      ChartMinZoomDialog,
+      ChartMinZoomDialogResult
+    >(ChartMinZoomDialog, {
       width: '300px',
       data: {
         text: chart[1]?.name ?? '',
@@ -998,7 +1001,7 @@ export class SKResourceService {
       }
     });
 
-    ref.afterClosed().subscribe((result: ChartMinZoomDialogResult) => {
+    ref.afterClosed().subscribe((result?: ChartMinZoomDialogResult) => {
       this.releaseChartPalette(ref);
       if (result?.apply) {
         if (typeof result.value === 'number') {

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -257,6 +257,7 @@ export interface IAppConfig {
     chartOrder: string[]; // chart layer ordering
     chartOpacity: Record<string, number>;
     chartImageAdjustment: Record<string, ChartImageAdjustment>;
+    chartDisplayMinZoom: Record<string, number>;
     aisTargets: string[];
     aisTargetTypes: number[];
     aisFilterByShipType: boolean;

--- a/src/app/types/resources/signalk.ts
+++ b/src/app/types/resources/signalk.ts
@@ -78,6 +78,9 @@ export interface ChartResource {
   tileSize?: number;
   defaultOpacity?: number;
   imageAdjustment?: ChartImageAdjustment;
+  // Lowest zoom level the chart is drawn at, as a local display preference.
+  // Distinct from the declared `minzoom`, which describes the tiles that exist.
+  displayMinZoom?: number;
   proxy?: boolean;
   $source?: string;
   style?: string;


### PR DESCRIPTION
## What problem does this solve?

Chart sets covering the same water at different scales are drawn on top of each
other, and a large-scale sheet is clutter until you are zoomed in far enough to
want it. Every hydrographic office publishes raster charts in overlapping scale
bands — NOAA's RNC series is Overview / General / Coastal / Approach / Harbor,
Traficom's Finnish sets are Yleiskartat / Merikarttasarjat / Rannikkokartat /
Satamakartat. Freeboard already picks the right band automatically for S-57,
because usage band is in the standard; raster has no equivalent, so the only fix
was ticking and unticking charts by hand while navigating.

## How does it work?

A chart can be given a lowest zoom level to appear at. It is a local preference
(`config.selections.chartDisplayMinZoom`), stored per chart id alongside the
existing per-chart opacity and image adjustment, and stripped from the chart the
properties dialog sends back to the server.

`resolveLayerZoomRange()` in `chart-utils.ts` combines the chart's declared range,
the user's minimum and the global over-zoom setting in one place; the raster, WMS,
WMTS and TileJSON layers use it. The minimum only ever restricts — a chart is
never drawn below the zoom its own tiles start at — and the top of the range is
untouched, so "Keep tiles visible on max zoom" behaves exactly as before. Charts
with no minimum resolve exactly as they did.

One change reaches outside charts: the status-bar zoom readout now truncates to a
tenth instead of rounding. Rounding reported `Zm: 14.0` from z13.95 up, so a chart
set to appear from z14 was legitimately off the map at a zoom the app was calling
14.0. Truncating means a level shown is always one the view has reached, and the
readout, the dialog's capture button and the layer bound all now use the same
convention.

## What changes for the user?

You can give each chart in an overlapping set the zoom it starts earning its place
at — coastal from z9, boating from z12, harbour from z14 — and each appears as you
zoom in, over the top of the coarser charts already drawn. Which one you see where
several overlap is still decided by chart order.

The control is in **Charts**, on each raster chart's row: the **minimum zoom**
button (a downward arrow onto a baseline), next to opacity and image adjustment.
It opens a small modeless dialog beside the chart list, which stays open, because
balancing an overlapping set means moving between charts. Type a level, or press
the target button to take the map's current zoom. The dialog shows the chart's own
data range for reference, and APPLY commits; closing it without applying puts the
old value back.

A chart carrying a minimum shows `from z12` under its name in the list, and adds
`— hidden at this zoom` while it is not being drawn — so a ticked chart that is
not on screen says why rather than looking broken. Charts you never set a minimum
on behave exactly as before.

The zoom readout in the status bar now counts up rather than rounding: a view a
hair under z14 reads `Zm: 13.9` where it used to read `Zm: 14.0`. It never claims
a level the map has not reached, which is what makes "set 14, zoom to 14, see the
chart" work.

## Known limitation

`chart.list` in the Plotter Extensions `charts` capability still reports
`visible: true` for a chart hidden by its minimum, and its `minZoom` is the
declared tile minimum rather than the effective one. That is a documented
host-agnostic contract, so it is not changed here — raised as
[joelkoz/signalk-plotterext-bus#2](https://github.com/joelkoz/signalk-plotterext-bus/issues/2)
with the options laid out.

## How was this tested?

Unit tests cover the resolver's precedence and bounds, config persistence and
injection, the dialog's parse/validate/label helpers, the dialog lifecycle (apply,
clear, revert, replacement), and the zoom-display truncation — including the case
that every zoom the readout shows as `14.0` draws a chart configured for z14.

Verified against a live Signal K server with the four Traficom sets: sweeping
z7.6→z14.8 and back draws exactly one chart at every sample with clean handovers
at each configured level, and a chart set to 14 now appears at the moment the
readout reaches 14.0.

CI green across the matrix; `npm run build:web` and `npm run test:ci` clean
locally too, bar two specs that fail the same way on an untouched `origin/master`
here and pass in CI.

## Checklist

- [x] One logical change; version numbers untouched.
- [x] `features/` untouched — the user-facing change is described above instead.
- [x] Skimmed [`DEV-LESSONS-LEARNED.md`](../docs/freeboard/DEV-LESSONS-LEARNED.md) for traps relevant to this change.
- [x] Tests added/updated for new behaviour and `npm run test:ci` passes.

---

**Second of three.** Stacked on #678, so its two commits appear here too; #680 is
stacked on this one. Merge order **#678 → #679 → #680**.
