### PR TITLE
docs(features): make the feature corpus maintainer-owned

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,8 @@ Before opening this PR, please consider:
   clearly-scoped features are always welcome; refactors or "improvements" without
   a concrete problem being solved are likely to be closed.
 - Do NOT change version numbers — maintainers handle versioning at release.
+- Do NOT edit `features/` (the Feature Browser corpus / changelog.json) — maintainers
+  compile it after merge. Describe the user-facing change below instead.
 - Keep this description succinct. The diff shows WHAT changed; tell us WHY and
   briefly HOW. If you used AI, trim the fluff — we'll ask if we need more.
 
@@ -21,6 +23,20 @@ See CONTRIBUTING.md / AGENTS.md for the full guidelines.
 
 <!-- Briefly, the approach. Note any breaking changes. -->
 
+## What changes for the user?
+
+<!-- Write this for someone using the app, not someone reading the diff: what can they
+     now do that they couldn't, where is the control and what is it called, what do they
+     see, and why would they want it? Mention any non-obvious interaction with existing
+     behaviour.
+
+     This is the text the Feature Browser documentation gets written from after merge,
+     so it's worth a few real sentences. Do NOT edit features/ yourself — deciding
+     whether this extends an existing feature or is a new one needs the whole corpus in
+     view, and that's a maintainer job.
+
+     Skip this section only if the change has no user-visible effect. -->
+
 ## How was this tested?
 
 <!-- How you verified it. New behaviour should have tests (npm run test:ci).
@@ -29,5 +45,6 @@ See CONTRIBUTING.md / AGENTS.md for the full guidelines.
 ## Checklist
 
 - [ ] One logical change; version numbers untouched.
+- [ ] `features/` untouched — the user-facing change is described above instead.
 - [ ] Skimmed [`DEV-LESSONS-LEARNED.md`](../docs/freeboard/DEV-LESSONS-LEARNED.md) for traps relevant to this change.
 - [ ] Tests added/updated for new behaviour and `npm run test:ci` passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,8 +222,11 @@ the code. Use the DeepWiki MCP (or the web URLs) before guessing at architecture
 
 **Freeboard-specific** (`docs/freeboard/`):
 - [`feature-browser.md`](docs/freeboard/feature-browser.md) — the Feature Browser and
-  its `features/` corpus + change ledger: how to author a feature doc and record a
-  change (the hand-authoring contract).
+  its `features/` corpus + change ledger. **`features/` is maintainer-owned: do not
+  add or edit feature docs or `changelog.json` in a contributor PR** — describe the
+  user-facing change in the PR description instead, and the corpus is compiled after
+  merge. The doc covers the model, the category list, and the maintainer contract for
+  recording a change.
 - [`freeboard-plotter-ext-support.md`](docs/freeboard/freeboard-plotter-ext-support.md)
   — Freeboard's host implementation of the Plotter Extensions API (incl. the
   `routes` capability).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,16 @@ Before you open a PR (full detail in [`AGENTS.md`](AGENTS.md)):
    - Keep the description succinct: the motivation (why) and the approach (how), not
      the mechanics (what). Include before/after screenshots for UI changes. If you
      use AI, **trim the fluff** — maintainers will ask if they need more.
+   - **Document the change in the description — but don't edit `features/`.** Fill in
+     *What changes for the user?* properly: what they can now do, where the control is,
+     what they see. That prose is what the in-app Feature Browser documentation gets
+     written from after merge, so it's worth real sentences rather than a restatement of
+     the diff.
+     The `features/` corpus itself is maintainer-owned. Deciding whether your change
+     extends an existing feature or is a new one requires the whole corpus in view — the
+     areas overlap, and from inside one PR the only visible option is "new", which is
+     usually the wrong answer. Rationale in
+     [`docs/freeboard/feature-browser.md`](docs/freeboard/feature-browser.md).
 7. [CodeRabbit](https://coderabbit.ai/) reviews automatically. **Give every finding
    an explicit disposition — fix it, or reply on the thread explaining why it
    doesn't apply.** Don't leave findings silently unanswered: CodeRabbit learns from

--- a/docs/freeboard/feature-browser.md
+++ b/docs/freeboard/feature-browser.md
@@ -164,7 +164,55 @@ These are the judgement calls the model is built around — read them before aut
   *Symbols* feature (whose code didn't change — wind-barbs just opted in) → **no** symbols
   row. This keeps each feature's history to PRs that actually changed it.
 
-## Contract for adding an entry (no tooling required)
+## Who maintains the corpus
+
+**Maintainers own `features/`. Contributors should not edit it — and in particular
+should never append to `features/changelog.json`.**
+
+This isn't gatekeeping. The corpus is a **model of the whole app**, and almost every
+decision it requires depends on what is already in it:
+
+- **Where does this change belong?** A new capability is usually a *section of an
+  existing feature*, not a new feature. Deciding that means reading every existing doc
+  and knowing which one owns the area — and the areas overlap. A new per-chart control
+  in the chart list could plausibly extend *Chart List* (which has a "Per-chart actions"
+  section), or *Chart Zoom Limits* (if it concerns zoom boundaries), or stand alone as
+  its own feature the way *Chart Image Adjustment* does. All three are arguable; picking
+  right needs the whole picture. A contributor who hasn't read the corpus will
+  reasonably create a new doc every time, because that is the only option visible from
+  inside a single PR.
+- **`kind` is derived, not declared** — `new` versus `enhanced` follows directly from the
+  answer above, not from the PR's `feat`/`fix` prefix.
+- **`pr` is the number of the PR that actually merged.** A PR that gets renumbered,
+  split, superseded, or closed in favour of another leaves a row pointing at something
+  that never landed.
+- **`since` is the release the change shipped in**, which is unknowable at PR time.
+- **`changelog.json` is append-at-the-tail**, so concurrent PRs collide on the same
+  lines, and stacked branches make review tooling report phantom duplicate records.
+
+So the division of labour is:
+
+| what | who | when |
+|---|---|---|
+| the code | contributor | in the PR |
+| **a description of what changes for the user** | **contributor** | **in the PR description** |
+| `features/<id>.md` | maintainer | after merge |
+| the `changelog.json` row | maintainer | after merge |
+| `since` | maintainer | at release |
+
+**What to do instead, as a contributor: write the documentation in the PR description.**
+Not a summary of the diff — an explanation aimed at the person using the app. What can
+they now do that they couldn't? Where is the control and what is it called? What do they
+see when they use it? Why would they want to? If there's a non-obvious interaction with
+an existing behaviour, say so.
+
+That prose is the deliverable. It is the raw material the feature doc is written from,
+and a good one makes the corpus work mechanical — a thin one means the maintainer has to
+come back and ask. Screenshots earn their place for the same reason. What is *not* asked
+of you is deciding where it lands in the corpus, and that is the part you'd have to
+guess at.
+
+## Maintainer contract for adding an entry (no tooling required)
 
 1. **New user-facing feature** → add `features/<id>.md` (with a valid `category`), and
    append a `{ "kind": "new", "date": "…", "title": "…" }` row.
@@ -172,4 +220,7 @@ These are the judgement calls the model is built around — read them before aut
    `{ "kind": "enhanced", "date": "…", "title": "…" }` row. Do not create a second doc.
 3. **A PR with no user-facing change** → append a `{ "feature": null, "kind": "skip",
    "reason": "…" }` row.
-</content>
+
+In all three cases the row is added **after the PR merges**, when its number and final
+title are known. Take `title` from the merged PR verbatim — it is what the release-notes
+generator emits.


### PR DESCRIPTION
## What problem does this solve?

The contributor-facing docs asked contributors to add a `features/<id>.md` doc and
append a `features/changelog.json` row as part of their PR. That asks for a decision
they can't make.

Whether a change **extends an existing feature or is a new one** depends on the whole
corpus, and the areas overlap. A new per-chart control in the chart list could
reasonably extend **Chart List** (which has a "Per-chart actions" section), or **Chart
Zoom Limits** (if it concerns zoom boundaries), or stand alone the way **Chart Image
Adjustment** does. All three are arguable. From inside a single PR the only visible
option is "new", so that's what gets created — usually wrongly.

The ledger has the same problem mechanically: `pr` is only known once a PR merges,
`kind` is derived from prior rows, `since` is a release-time fact, and the file is
append-at-the-tail so concurrent PRs collide on the same lines (stacked branches also
make review tooling report phantom duplicate records).

## How does it work?

`features/` becomes explicitly maintainer-owned, compiled after merge. Contributors
document the change in the PR description instead.

- **`docs/freeboard/feature-browser.md`** — new *Who maintains the corpus* section
  covering the division of labour and the reasoning; the existing authoring contract is
  retitled *Maintainer contract* and notes rows are added after merge. Also removes a
  stray `</content>` artifact at the end of the file.
- **`.github/pull_request_template.md`** — new **What changes for the user?** section
  with guidance on writing it, plus a header note and a checklist line.
- **`CONTRIBUTING.md`** — document in the description, don't edit `features/`, with the
  reason and a link to the full rationale.
- **`AGENTS.md`** — the documentation-index entry now states the ownership rule, so
  coding agents reading it don't send contributors the other way.

No code or behaviour changes; documentation only.

## What changes for the user?

Nothing — contributor-facing documentation only.

## How was this tested?

Markdown only, outside `src/`, so the prettier gate (`src/**/*.{ts,html}`) doesn't apply.
New cross-references verified to resolve from the repo root.

## Checklist

- [x] One logical change; version numbers untouched.
- [x] `features/` untouched — the user-facing change is described above instead.
- [x] Skimmed `DEV-LESSONS-LEARNED.md` for traps relevant to this change.
- [x] No behaviour change, so no tests added.

@coderabbitai ignore
