### PR TITLE
fix(instruments): allow form submission in the instrument panel iframe

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -409,10 +409,13 @@
                 "
               >
                 @if (app.instrumentPanel().activate) {
+                  <!-- allow-forms: embedded webapps submit forms (e.g. KIP's
+                       Signal K sign-in). Matches the plotter extension iframe
+                       baseline — fault containment, not a security boundary. -->
                   <iframe
                     [src]="instUrl()"
                     style="width: 345px; height: 100%"
-                    sandbox="allow-scripts allow-same-origin"
+                    sandbox="allow-scripts allow-same-origin allow-forms"
                   >
                   </iframe>
                 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -67,9 +67,15 @@ describe('AppComponent', () => {
     // jsdom neither enforces sandbox nor reflects it onto the `sandbox`
     // DOMTokenList, so read the attribute. Without allow-forms, Chrome blocks
     // form submission from the embedded webapp, making it impossible to sign in.
-    const sandbox = (iframe?.getAttribute('sandbox') ?? '').split(/\s+/);
-    expect(sandbox).toContain('allow-forms');
-    expect(sandbox).toContain('allow-scripts');
-    expect(sandbox).toContain('allow-same-origin');
+    // Asserting the exact set also catches a relaxation, such as a later change
+    // granting allow-top-navigation.
+    const sandbox = (iframe?.getAttribute('sandbox') ?? '')
+      .split(/\s+/)
+      .filter(Boolean);
+    expect(sandbox.sort()).toEqual([
+      'allow-forms',
+      'allow-same-origin',
+      'allow-scripts'
+    ]);
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { AppFacade } from './app.facade';
 import { beforeEach, expect, describe, it, vi } from 'vitest';
 import '@vitest/web-worker';
 import { MatMenuTrigger } from '@angular/material/menu';
@@ -45,5 +46,30 @@ describe('AppComponent', () => {
       .mockResolvedValue(undefined);
     item?.click();
     expect(openFeatureBrowser).toHaveBeenCalled();
+  });
+
+  it('sandboxes the instrument panel iframe with form submission allowed', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    // ngOnInit resets `activate` from config, so open the panel after it runs.
+    TestBed.inject(AppFacade).instrumentPanel.set({
+      open: true,
+      activate: true
+    });
+    fixture.detectChanges();
+
+    // The only iframe inside the sidenav is the instrument panel; the plotter
+    // extension frames render outside mat-sidenav-container.
+    const iframe = fixture.debugElement.query(By.css('mat-sidenav iframe'))
+      ?.nativeElement as HTMLIFrameElement | undefined;
+    expect(iframe).toBeDefined();
+
+    // jsdom neither enforces sandbox nor reflects it onto the `sandbox`
+    // DOMTokenList, so read the attribute. Without allow-forms, Chrome blocks
+    // form submission from the embedded webapp, making it impossible to sign in.
+    const sandbox = (iframe?.getAttribute('sandbox') ?? '').split(/\s+/);
+    expect(sandbox).toContain('allow-forms');
+    expect(sandbox).toContain('allow-scripts');
+    expect(sandbox).toContain('allow-same-origin');
   });
 });


### PR DESCRIPTION
KIP running as the instrument panel can't be signed in to under Chrome — the sign-in form submits, nothing happens, and no error surfaces.

The instrument panel iframe carried `sandbox="allow-scripts allow-same-origin"`, so Chrome blocks form submission from it. The reporter's console shows `Blocked form submission ... the 'allow-forms' permission is not set`, sourced to `/@mxtommy/kip/#/options`. It isn't KIP-specific: any webapp set as an instrument panel favourite that uses a real form hits the same wall.

The plotter extension iframes (widget, panel drawer, panel dialog, background runtime) already use `allow-scripts allow-same-origin allow-forms`. This brings the instrument panel — the one remaining iframe in the app — up to that same baseline.

No security tradeoff: `allow-same-origin` together with `allow-scripts` already makes the sandbox fault containment rather than a boundary, since such a frame can clear its own sandbox attribute via the parent. Navigation, popups and modals stay withheld.

Verified by signing in to KIP through the instrument panel in Chrome against a local server.

The added spec asserts the exact sandbox token set, so it fails both if `allow-forms` goes missing and if a later change grants something broader. jsdom neither enforces sandbox nor reflects it onto the `sandbox` DOMTokenList, so the assertion reads the attribute — the browser-level behaviour itself isn't reachable from the unit suite.

Closes #671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instrument panel forms can now be submitted directly within the embedded panel.

* **Tests**
  * Added coverage to verify the embedded panel uses the expected sandbox permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->