### PR TITLE
fix(instruments): hide the toolbar button when no instruments app is selected

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -818,26 +818,34 @@
                 [style.top.px]="60 + plotterExt.toolbarTopOffset()"
               >
                 <!-- instrument sidebar open button -->
-                <div class="instrumentPanelToggle buttonPanelItem">
-                  @if (
-                    app.instrumentPanelAvailable() &&
-                    !app.instrumentPanel().open &&
-                    !infoPanel.opened() &&
-                    !isInteracting() &&
-                    !app.data.vessels.activeId
-                  ) {
-                    <button
-                      class="button-toolbar"
-                      mat-mini-fab
-                      (click)="openInstrumentPanel()"
-                      matTooltip="Instruments"
-                      matTooltipPosition="before"
-                    >
-                      <mat-icon>av_timer</mat-icon>
-                    </button>
-                  }
-                  <br />&nbsp;<br />&nbsp;
-                </div>
+                @if (
+                  app.instrumentPanelAvailable() &&
+                  app.config.display.plugins.instruments
+                ) {
+                  <!-- The slot is only dropped when instruments are
+                       unavailable; the transient conditions below hide the
+                       button but keep its space so the buttons under it do
+                       not shift as the user works. -->
+                  <div class="instrumentPanelToggle buttonPanelItem">
+                    @if (
+                      !app.instrumentPanel().open &&
+                      !infoPanel.opened() &&
+                      !isInteracting() &&
+                      !app.data.vessels.activeId
+                    ) {
+                      <button
+                        class="button-toolbar"
+                        mat-mini-fab
+                        (click)="openInstrumentPanel()"
+                        matTooltip="Instruments"
+                        matTooltipPosition="before"
+                      >
+                        <mat-icon>av_timer</mat-icon>
+                      </button>
+                    }
+                    <br />&nbsp;<br />&nbsp;
+                  </div>
+                }
 
                 <!-- Web audio enable -->
                 @if (audioStatus() !== 'running') {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -48,6 +48,47 @@ describe('AppComponent', () => {
     expect(openFeatureBrowser).toHaveBeenCalled();
   });
 
+  it('drops the Instruments toolbar slot when no instruments app is selected', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = TestBed.inject(AppFacade);
+    app.uiConfig.update((c) => Object.assign({}, c, { toolbarButtons: true }));
+
+    app.config.display.plugins.instruments = '/@signalk/instrumentpanel';
+    fixture.detectChanges();
+    expect(
+      fixture.debugElement.query(By.css('.instrumentPanelToggle button'))
+    ).not.toBeNull();
+
+    // Settings -> Display -> Select Instruments App: "None" stores a null url.
+    app.config.display.plugins.instruments = null;
+    fixture.detectChanges();
+    // The whole slot goes, not just the button: .buttonPanelItem is a fixed
+    // 48px, so leaving it behind would hold an empty gap in the toolbar.
+    expect(
+      fixture.debugElement.query(By.css('.instrumentPanelToggle'))
+    ).toBeNull();
+  });
+
+  it('keeps the Instruments toolbar slot while the panel is open', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = TestBed.inject(AppFacade);
+    app.uiConfig.update((c) => Object.assign({}, c, { toolbarButtons: true }));
+    app.config.display.plugins.instruments = '/@signalk/instrumentpanel';
+    fixture.detectChanges();
+
+    app.instrumentPanel.set({ open: true, activate: true });
+    fixture.detectChanges();
+
+    // Transient conditions hide the button but hold its place, so the buttons
+    // below it do not shift up and down as the user works.
+    expect(
+      fixture.debugElement.query(By.css('.instrumentPanelToggle'))
+    ).not.toBeNull();
+    expect(
+      fixture.debugElement.query(By.css('.instrumentPanelToggle button'))
+    ).toBeNull();
+  });
+
   it('sandboxes the instrument panel iframe with form submission allowed', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();


### PR DESCRIPTION
Settings → Display → Select Instruments App offers "None" so a user can say they
have no instrument app installed, but the toolbar button never consulted that
setting — it stayed on screen with nothing to open. The "open in window" link in
the panel header already guarded on the same value.

The guard wraps the whole `.buttonPanelItem` rather than just the button. That
slot is a fixed 48px, so hiding only the button would leave an empty gap and the
buttons below it would not move up. The transient conditions (panel open, info
panel up, drawing/measuring, vessel selected) stay on an inner `@if`, so they
continue to hide the button while holding its place — the toolbar should not
shift around as the user works.

Tested against a local Signal K server with the setting toggled both ways, and
with the panel opened/closed to confirm the remaining buttons stay put.

Closes #687

Reviewed by CodeRabbit on joelkoz/freeboard-sk#73 at the identical commit
(09c71bc) — no actionable comments. Skipping a duplicate review here.

@coderabbitai ignore
