### PR TITLE
feat(vessels): flag own vessel when its position goes stale

### DIFF
--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -865,6 +865,9 @@
     [activeId]="app.data.vessels.activeId"
     [iconScale]="app.config.vessels.iconScale"
     [fixedLocation]="app.config.vessels.fixedLocationMode"
+    [stale]="
+      skstream.selfPositionStale() && !app.config.vessels.fixedLocationMode
+    "
     [zIndex]="999"
   >
   </fb-vessel>

--- a/src/app/modules/map/ol/lib/vessel/layer-vessel.component.spec.ts
+++ b/src/app/modules/map/ol/lib/vessel/layer-vessel.component.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import Style from 'ol/style/Style';
+import {
+  VesselComponent,
+  STALE_VESSEL_OPACITY
+} from './layer-vessel.component';
+
+/**
+ * When self position stops updating, the own-vessel icon must say so on the
+ * chart rather than relying on the transient status message that prompted
+ * #672. `parseVessel()` reads only plain fields, so exercise it on a bare
+ * prototype instance (same approach as layer-aistargets.component.spec).
+ */
+function vessel(stale: boolean) {
+  const c = Object.create(VesselComponent.prototype) as VesselComponent;
+  Object.assign(c, {
+    position: [1, 2],
+    heading: 0,
+    stale,
+    mapImages: { getExternalSymbol: () => null }
+  });
+  return c;
+}
+
+/** Styles set on the feature, normalised to an array. */
+function styles(c: VesselComponent): Style[] {
+  const s = c.vessel.getStyle();
+  return (Array.isArray(s) ? s : [s]) as Style[];
+}
+
+describe('VesselComponent stale position indication (#672)', () => {
+  it('marks a stale vessel with a "?" badge and dims the icon', () => {
+    const c = vessel(true);
+    c.parseVessel();
+
+    const s = styles(c);
+    expect(s.length).toBe(2);
+    expect(s[1].getText().getText()).toBe('?');
+    expect(s[0].getImage().getOpacity()).toBe(STALE_VESSEL_OPACITY);
+  });
+
+  it('shows no badge and a fully opaque icon when position is current', () => {
+    const c = vessel(false);
+    c.parseVessel();
+
+    const s = styles(c);
+    expect(s.length).toBe(1);
+    expect(s[0].getImage().getOpacity()).toBe(1);
+  });
+
+  it('restores the icon when position resumes', () => {
+    const c = vessel(true);
+    c.parseVessel();
+    c.stale = false;
+    c.parseVessel();
+
+    const s = styles(c);
+    expect(s.length).toBe(1);
+    expect(s[0].getImage().getOpacity()).toBe(1);
+  });
+});

--- a/src/app/modules/map/ol/lib/vessel/layer-vessel.component.ts
+++ b/src/app/modules/map/ol/lib/vessel/layer-vessel.component.ts
@@ -13,7 +13,7 @@ import { Layer } from 'ol/layer';
 import { Feature } from 'ol';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
-import { Style, Stroke, Icon } from 'ol/style';
+import { Style, Stroke, Icon, Fill, Text } from 'ol/style';
 import { Geometry, Point } from 'ol/geom';
 import { fromLonLat } from 'ol/proj';
 import { MapComponent } from '../map.component';
@@ -59,6 +59,23 @@ const fixedVesselStyle = new Style({
   })
 });
 
+/** Opacity applied to the vessel icon while its position is stale. */
+export const STALE_VESSEL_OPACITY = 0.4;
+
+/** Drawn over the vessel when its position is no longer being updated.
+ * Deliberately unmissable: the whole point of #672 is that a transient
+ * message at the bottom of the screen is not. Centred on the vessel position
+ * so it reads as "this fix is unknown" rather than as a separate marker. */
+const staleVesselStyle = new Style({
+  text: new Text({
+    text: '?',
+    font: 'bold 44px Roboto, "Helvetica Neue", sans-serif',
+    fill: new Fill({ color: 'red' }),
+    // outlines the glyph itself, keeping it legible over a dark chart
+    stroke: new Stroke({ color: '#ffffff', width: 1 })
+  })
+});
+
 // ** Freeboard Vessel component **
 @Component({
   selector: 'ol-map > fb-vessel',
@@ -83,6 +100,8 @@ export class VesselComponent implements OnInit, OnDestroy, OnChanges {
   @Input() heading = 0;
   @Input() vesselStyles: { [key: string]: Style };
   @Input() fixedLocation: boolean;
+  /** Position is no longer being updated — dim the icon and flag it. */
+  @Input() stale = false;
   @Input() iconScale = 1;
   @Input() opacity: number;
   @Input() visible: boolean;
@@ -135,7 +154,8 @@ export class VesselComponent implements OnInit, OnDestroy, OnChanges {
           key === 'id' ||
           key === 'activeId' ||
           key === 'position' ||
-          key === 'heading'
+          key === 'heading' ||
+          key === 'stale'
         ) {
           if (this.source) {
             this.parseVessel();
@@ -192,8 +212,11 @@ export class VesselComponent implements OnInit, OnDestroy, OnChanges {
         } else {
           im.setRotation(this.heading);
         }
+        // set both ways: the styles are shared module-level instances, so a
+        // dimmed icon would otherwise stay dimmed after position resumes
+        im.setOpacity(this.stale ? STALE_VESSEL_OPACITY : 1);
       }
-      this.vessel.setStyle(s);
+      this.vessel.setStyle(this.stale ? [s, staleVesselStyle] : s);
     }
   }
 

--- a/src/app/modules/skresources/resource-classes.ts
+++ b/src/app/modules/skresources/resource-classes.ts
@@ -197,6 +197,10 @@ class SKTargetBase {
   position: Position = [0, 0];
   positionReceived = false;
   positionTimestamp: string = '';
+  /** Client-clock epoch ms at which the last position delta was received
+   * (0 = none yet). Stamped locally rather than derived from
+   * `positionTimestamp` so position age is immune to server clock skew. */
+  positionUpdatedAt = 0;
   state: string;
   type: { id: number; name: string } = { id: -1, name: '' };
   properties: { [key: string]: any } = {};

--- a/src/app/modules/skstream/skstream.facade.spec.ts
+++ b/src/app/modules/skstream/skstream.facade.spec.ts
@@ -1,5 +1,9 @@
 import { expect, describe, it } from 'vitest';
-import { SKStreamFacade } from './skstream.facade';
+import {
+  SKStreamFacade,
+  isPositionStale,
+  SELF_POSITION_STALE_AGE
+} from './skstream.facade';
 import { SKVessel } from '../skresources/resource-classes';
 
 // AIS icons rotate by `orientation`. A crabbing target's heading and COG differ,
@@ -33,5 +37,30 @@ describe('SKStreamFacade.parseVesselOther — AIS target orientation', () => {
         vessel({ headingTrue: null, headingMagnetic: null, cogTrue: 1.658 })
       )
     ).toBe(1.658);
+  });
+});
+
+/**
+ * Position age is measured against the client clock stamp applied when the
+ * position delta arrived (#672), so it reports "no data" whether the
+ * connection dropped or the server is still talking with no position source.
+ */
+describe('isPositionStale (#672)', () => {
+  const now = 1_000_000;
+
+  it('is not stale while updates are arriving', () => {
+    expect(isPositionStale(now - 1000, now)).toBe(false);
+  });
+
+  it('is not stale exactly at the threshold', () => {
+    expect(isPositionStale(now - SELF_POSITION_STALE_AGE, now)).toBe(false);
+  });
+
+  it('is stale once the threshold is passed', () => {
+    expect(isPositionStale(now - SELF_POSITION_STALE_AGE - 1, now)).toBe(true);
+  });
+
+  it('is not stale when no position has ever been received', () => {
+    expect(isPositionStale(0, now)).toBe(false);
   });
 });

--- a/src/app/modules/skstream/skstream.facade.ts
+++ b/src/app/modules/skstream/skstream.facade.ts
@@ -20,6 +20,25 @@ export enum SKSTREAM_MODE {
   PLAYBACK
 }
 
+/** Age (ms) beyond which the last received self position is considered stale.
+ * Comfortably longer than any realistic position update period, so it only
+ * trips when position data has genuinely stopped arriving. */
+export const SELF_POSITION_STALE_AGE = 30000;
+
+/** How often self position age is re-evaluated (ms). Staleness advances with
+ * wall time, so it cannot be derived from incoming messages alone — when the
+ * connection drops there are no messages left to derive it from. */
+const SELF_POSITION_STALE_CHECK_INTERVAL = 2000;
+
+/** Determine whether a position stamped at `positionUpdatedAt` is stale.
+ * A vessel that has never reported a position is not stale — there is no
+ * position to have gone out of date. */
+export const isPositionStale = (
+  positionUpdatedAt: number,
+  now: number,
+  maxAge: number = SELF_POSITION_STALE_AGE
+): boolean => !!positionUpdatedAt && now - positionUpdatedAt > maxAge;
+
 export interface StreamOptions {
   playbackRate: number;
   startTime: string;
@@ -77,6 +96,23 @@ export class SKStreamFacade {
   private watchDogAlarmSignal = signal<boolean>(false);
   readonly watchDogAlarm = this.watchDogAlarmSignal.asReadonly();
 
+  private positionStaleSignal = signal<boolean>(false);
+  /** True when self position has not been updated for
+   * SELF_POSITION_STALE_AGE — the vessel shown on the chart is no longer
+   * where the boat is. Covers both a dropped connection and a server that is
+   * still talking but has lost its position source. */
+  readonly selfPositionStale = this.positionStaleSignal.asReadonly();
+
+  /** Re-evaluate self position age against the current time. */
+  refreshSelfPositionStale(): void {
+    this.positionStaleSignal.set(
+      isPositionStale(
+        this.app.data.vessels.self?.positionUpdatedAt ?? 0,
+        Date.now()
+      )
+    );
+  }
+
   constructor(
     private app: AppFacade,
     private signalk: SignalKClient,
@@ -106,6 +142,11 @@ export class SKStreamFacade {
         this.onMessage.next(msg as UpdateMessage);
       }
     });
+
+    setInterval(
+      () => this.refreshSelfPositionStale(),
+      SELF_POSITION_STALE_CHECK_INTERVAL
+    );
 
     // ** Handle app.config$ / settings.change$ events
     this.settings.change$.subscribe(() => this.sendConfig());
@@ -380,6 +421,9 @@ export class SKStreamFacade {
     });
 
     this.refreshSelfNightMode();
+    // clear the indication as soon as position resumes, rather than on the
+    // next tick
+    this.refreshSelfPositionStale();
   }
 
   private parseSelfRacing(v: SKVessel) {

--- a/src/app/modules/skstream/skstream.worker.spec.ts
+++ b/src/app/modules/skstream/skstream.worker.spec.ts
@@ -1,5 +1,6 @@
 import { expect, describe, it, vi, afterEach } from 'vitest';
-import { apiGet } from './skstream.worker';
+import { apiGet, processVessel } from './skstream.worker';
+import { SKVessel } from '../skresources/resource-classes';
 
 // getVesselTrail() fetches the server-side "self" track with several apiGet()
 // calls fired in the same tick and awaited via Promise.all. A shared in-flight
@@ -29,5 +30,54 @@ describe('skstream.worker apiGet — concurrent requests', () => {
     const results = await Promise.all(urls.map((u) => apiGet(u)));
 
     expect(results).toEqual(urls.map((url) => ({ url })));
+  });
+});
+
+// The stale-position indication (#672) is driven by a receipt time stamped
+// here, in the worker, because only the worker sees per-path deltas. Stamping
+// on the delta rather than on a changed value is what makes a boat at anchor —
+// which reports the same position indefinitely — read as live rather than
+// stale, so the stamp must advance on every position delta.
+describe('skstream.worker processVessel — position receipt time (#672)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const positionDelta = {
+    path: 'navigation.position',
+    value: { latitude: 25.7, longitude: -80.2 }
+  };
+
+  it('stamps the local receipt time when a position delta arrives', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const vessel = new SKVessel();
+
+    processVessel(vessel, positionDelta, true);
+
+    expect(vessel.positionUpdatedAt).toBe(1_700_000_000_000);
+  });
+
+  it('advances the stamp when the reported position is unchanged', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const vessel = new SKVessel();
+    processVessel(vessel, positionDelta, true);
+
+    now.mockReturnValue(1_700_000_030_000);
+    processVessel(vessel, positionDelta, true);
+
+    expect(vessel.positionUpdatedAt).toBe(1_700_000_030_000);
+  });
+
+  it('leaves the stamp untouched for a non-position delta', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const vessel = new SKVessel();
+
+    processVessel(
+      vessel,
+      { path: 'navigation.speedOverGround', value: 3 },
+      true
+    );
+
+    expect(vessel.positionUpdatedAt).toBe(0);
   });
 });

--- a/src/app/modules/skstream/skstream.worker.ts
+++ b/src/app/modules/skstream/skstream.worker.ts
@@ -890,6 +890,7 @@ function processVessel(d: SKVessel, v: any, isSelf = false) {
     ]);
     d.positionReceived = true;
     d.positionTimestamp = $timestamp ?? '';
+    d.positionUpdatedAt = Date.now();
     d.lastUpdated = new Date();
     if (!isSelf) {
       appendTrack(d);

--- a/src/app/modules/skstream/skstream.worker.ts
+++ b/src/app/modules/skstream/skstream.worker.ts
@@ -791,7 +791,7 @@ function selectVessel(id: string): SKVessel {
 }
 
 // ** process common vessel data and true / magnetic preference **
-function processVessel(d: SKVessel, v: any, isSelf = false) {
+export function processVessel(d: SKVessel, v: any, isSelf = false) {
   if (isSelf) {
     d.lastUpdated = new Date();
     if (v.path.startsWith('resources.')) {


### PR DESCRIPTION
Closes #672

A dropped connection produced only a transient message near the bottom of the
screen. Once it faded, nothing on the chart indicated that the vessel position
being displayed had stopped updating.

Own vessel is now dimmed and overlaid with a red `?` once its position has not
been updated for 30s.

**Why position age rather than connection state.** When a wifi link disappears
silently the websocket close can lag by minutes — that is the exact repro in the
issue. Position age also covers the case the socket cannot see at all: a server
still streaming happily that has lost its position source.

**Why the stamp is applied in the stream worker.** Only the worker sees per-path
deltas. Deriving age in the facade would mean inferring "position updated" from a
changed value, which reports a boat at anchor as stale. The stamp uses the client
clock, so it is unaffected by skew between the browser device and the server.

Age is re-evaluated on a ticker rather than on incoming messages, because
staleness advances with wall time and there are no messages left to drive it once
the link drops.

The indication is suppressed in fixed-location mode, where position deltas may
never arrive and would otherwise pin a permanent `?`. The existing `watchDog`
status-bar icon is untouched.

<img width="1115" height="525" alt="Screenshot 2026-08-08 at 5 20 50 PM" src="https://github.com/user-attachments/assets/4f8e7d2f-0b33-4de4-98d3-73772ac76c7c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stale-position detection for self-vessel and other vessel locations.
  * Stale vessels now appear dimmed with a red question-mark indicator.
  * Vessel indicators automatically return to normal when fresh position data arrives.
  * Self-position freshness is reevaluated periodically and immediately after updates.

* **Tests**
  * Added coverage for stale, current, boundary, and recovered position states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->