### PR TITLE
fix(stream): alarm on a detected disconnect instead of disarming the watchdog

### DIFF
--- a/src/app/modules/skstream/skstream.worker.spec.ts
+++ b/src/app/modules/skstream/skstream.worker.spec.ts
@@ -1,5 +1,10 @@
-import { expect, describe, it, vi, afterEach } from 'vitest';
-import { apiGet, processVessel } from './skstream.worker';
+import { expect, describe, it, vi, afterEach, beforeEach } from 'vitest';
+import {
+  apiGet,
+  handleStreamEvent,
+  initVessels,
+  processVessel
+} from './skstream.worker';
 import { SKVessel } from '../skresources/resource-classes';
 
 // getVesselTrail() fetches the server-side "self" track with several apiGet()
@@ -79,5 +84,51 @@ describe('skstream.worker processVessel — position receipt time (#672)', () =>
     );
 
     expect(vessel.positionUpdatedAt).toBe(0);
+  });
+});
+
+// The status bar's "No server messages!" indicator is driven by the watchdog
+// alarm, which the interval timer raises after ~9s of silence. A detected close
+// used to *disarm* the watchdog instead of alarming — and since closeStream()
+// also stops that interval, the alarm became unreachable in exactly the case
+// where the server is known to be gone: a clean server shutdown or restart
+// (#695). The indicator only appeared for a silently-dead socket, the harder
+// case. Guard that a detected loss of connection reports itself immediately.
+describe('skstream.worker handleStreamEvent — watchdog on disconnect (#695)', () => {
+  let posted: Array<Record<string, unknown>>;
+
+  beforeEach(() => {
+    initVessels(); // openStream() does this before any stream event arrives
+    posted = [];
+    vi.stubGlobal(
+      'postMessage',
+      vi.fn((msg: Record<string, unknown>) => posted.push(msg))
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const alarmUpdates = () =>
+    posted.filter((m) => m.action === 'update' && m.watchDogAlarm === true);
+
+  it('raises the alarm on a detected close', () => {
+    handleStreamEvent({ action: 'onClose', msg: {} });
+
+    expect(alarmUpdates()).toHaveLength(1);
+  });
+
+  it('still posts the close message the app reconnects on', () => {
+    handleStreamEvent({ action: 'onClose', msg: {} });
+
+    expect(posted.some((m) => m.action === 'close')).toBe(true);
+  });
+
+  it('raises the alarm on a connection error', () => {
+    handleStreamEvent({ action: 'onError', msg: {} });
+
+    expect(alarmUpdates()).toHaveLength(1);
   });
 });

--- a/src/app/modules/skstream/skstream.worker.spec.ts
+++ b/src/app/modules/skstream/skstream.worker.spec.ts
@@ -104,6 +104,14 @@ describe('skstream.worker handleStreamEvent — watchdog on disconnect (#695)', 
       'postMessage',
       vi.fn((msg: Record<string, unknown>) => posted.push(msg))
     );
+    // The watchdog is module state that initVessels() does not touch, so an
+    // alarm raised by one test would leak into the next. Start every test from
+    // a live connection, via the same event that arms the watchdog for real.
+    handleStreamEvent({
+      action: 'onConnect',
+      msg: { target: { readyState: 1 } }
+    });
+    posted = [];
   });
 
   afterEach(() => {

--- a/src/app/modules/skstream/skstream.worker.ts
+++ b/src/app/modules/skstream/skstream.worker.ts
@@ -133,7 +133,8 @@ let apDeviceId = 'freeboard-sk';
 // *******************************************************************
 
 // ** Initialise message data structures **
-function initVessels() {
+// exported as a test seam: establishes the payload openStream() sets up
+export function initVessels() {
   vessels = {
     self: new SKVessel(),
     aisTargets: new Map(),
@@ -173,7 +174,7 @@ function initAisTargetStatus() {
     result: 'result / message'
 } 
 */
-function handleStreamEvent({ action, msg }) {
+export function handleStreamEvent({ action, msg }) {
   switch (action) {
     case 'onConnect':
       postMessage({
@@ -189,7 +190,7 @@ function handleStreamEvent({ action, msg }) {
     case 'onClose':
       //console.warn('streamEvent: ', msg);
       closeStream(false);
-      watchDog.active = false;
+      raiseWatchDogAlarm();
       break;
     case 'onError':
       //console.warn('streamEvent: ', msg);
@@ -198,15 +199,30 @@ function handleStreamEvent({ action, msg }) {
         playback: playbackMode,
         result: 'Connection error!'
       });
-      watchDog.msgCount = 0;
-      watchDog.intervalCount = 0;
-      watchDog.active = false;
+      raiseWatchDogAlarm();
       break;
     case 'onMessage':
       watchDog.msgCount++;
       parseStreamMessage(msg);
       break;
   }
+}
+
+/** Raise the watchdog alarm for a detected loss of connection.
+ *
+ * A close or error IS the "no server messages" condition the watchdog reports, so
+ * it must set the alarm rather than disarm the watchdog. Disarming made the alarm
+ * unreachable in exactly the case where the server is known to be gone: `onClose`
+ * runs `closeStream()`, which clears the interval that measures the silence, so
+ * the ~9s needed to trip the alarm could never elapse. The watchdog stays active
+ * so that on the error path — where the timers keep running — the next interval
+ * does not immediately clear the alarm again. `onConnect` re-arms and clears it. */
+function raiseWatchDogAlarm() {
+  watchDog.msgCount = 0;
+  watchDog.intervalCount = 0;
+  watchDog.active = true;
+  watchDog.alarm = true;
+  postUpdate(true);
 }
 
 // ******** MESSAGE FROM APP ************

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -289,8 +289,11 @@
                 >signal_wifi_statusbar_connected_no_internet_4</i
               >
               <b>No server messages:</b>
-              Indicates there may be an issue on the server as messages no have
-              been received over the open connection in the last 8-10 seconds.
+              Indicates messages are not being received from the server — either
+              the connection has closed (for example the server was stopped or
+              restarted), or nothing has arrived over an open connection for the
+              last 8-10 seconds. It clears when the connection is
+              re-established.
             </li>
             <li class="nobullet">
               <i class="material-icons">directions_boat</i>


### PR DESCRIPTION
The status bar's red "No server messages!" indicator was unreachable in exactly the case where the server is known to be gone — a clean shutdown or restart that sends a close frame. It appeared only for a socket that stayed open with nothing arriving, which is the harder case to detect, not the obvious one.

`onClose` ran `closeStream()`, which clears the interval that measures the silence, and then set the watchdog inactive — so the ~9s of quiet needed to trip the alarm could never elapse. `onError` disarmed the same way, and there the timers keep running, so the interval's reset branch would have cleared any alarm set on that path anyway.

A detected close or error *is* the no-messages condition the watchdog exists to report, so both branches now raise the alarm and post it to the app immediately, leaving the watchdog armed. `onConnect` already clears the alarm and re-arms on reconnect, so recovery is unchanged. A deliberate restart is unaffected: `cmd: 'close'` unsubscribes from the stream events before closing the socket, so it never re-enters `handleStreamEvent`.

The online help described the old trigger — "messages ... have been received over the open connection in the last 8-10 seconds" — which this change makes wrong, since the indicator now also appears immediately on a close. That passage is corrected here rather than left to a later docs pass (and a typo in the same sentence goes with it).

Regression tests cover both paths, plus a guard that the `close` message the app reconnects on is still posted. `handleStreamEvent` and `initVessels` are exported as test seams, following the existing pattern in this worker.

Closes #695


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection monitoring so alarms are raised when the server connection closes or encounters an error.
  - Preserved the reconnection message when a connection closes.
  - Ensured monitoring remains active and updates immediately when an alarm is raised.

- **Documentation**
  - Clarified the “No server messages” help text, including connection closures, inactivity lasting 8–10 seconds, and indicator clearing after reconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->