### PR TITLE
ci(test): widen the emulated-arm hook budget to 60s

### DIFF
--- a/vitest-base.config.ts
+++ b/vitest-base.config.ts
@@ -11,7 +11,23 @@ const TEST_TIMEOUT_MS = EMULATED_ARM ? 20_000 : 5_000;
 // Hooks need the same emulation allowance: a `beforeEach` that mounts a
 // component is as slow under QEMU as the test body it sets up. Native keeps
 // vitest's 10s default rather than inheriting the stricter 5s test budget.
-const HOOK_TIMEOUT_MS = EMULATED_ARM ? 20_000 : 10_000;
+//
+// The emulated budget is deliberately much wider than the emulated *test*
+// budget above, because a mount-heavy hook is the slowest thing in the suite
+// and 20s left too little margin (#689). Measured: `settings-dialog.spec.ts`'s
+// `beforeEach` costs ~285ms natively (`TestBed.createComponent` 168ms, first
+// `detectChanges` 99ms), so ~5.7s in a local armv7 container — and that
+// container completes the suite in ~15 min where the CI job takes ~25, putting
+// the same hook near 10s there. Against a 20s ceiling that is only 2x headroom
+// on a shared runner, and it was intermittently lost. 60s restores 4-6x.
+//
+// This is a wall-clock budget for a high-variance environment, not a hang
+// detector — real hangs still surface on the native legs, which keep the
+// strict defaults. Two things that look like fixes and are not, both measured
+// on #689: trimming the hook (tab rendering is 5% of the cost, and sharing one
+// fixture across tests breaks the spec), and capping vitest's worker pool
+// (~2%, inside noise).
+const HOOK_TIMEOUT_MS = EMULATED_ARM ? 60_000 : 10_000;
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## What problem does this solve?

The `test / armv7 (Cerbo GX) / Node 20` job intermittently loses a `beforeEach` against
the 20s hook ceiling — always the same one, `settings-dialog.spec.ts` (#689). It failed
on some PRs and passed on others with the spec untouched, so a check that blocks nothing
was red about half the time, which trains everyone to stop reading it.

## How does it work?

One constant:

```diff
-const HOOK_TIMEOUT_MS = EMULATED_ARM ? 20_000 : 10_000;
+const HOOK_TIMEOUT_MS = EMULATED_ARM ? 60_000 : 10_000;
```

Sized from measurement rather than guesswork. `settings-dialog`'s mount costs **~285ms
natively** (`TestBed.createComponent` 168ms, first `detectChanges` 99ms), so ~5.7s in a
local armv7 container — and that container finishes the suite in ~15 min where the CI job
takes ~25, putting the same hook near **10s on the runner**. Against a 20s ceiling that is
2× headroom on shared, high-variance infrastructure. 60s restores 4–6×.

Native platforms are untouched (10s), so real hangs still surface where the feedback is
fast.

**`TEST_TIMEOUT_MS` deliberately stays at 20s.** The expensive work is the mount, which
lives in the hook; the test bodies only switch tabs (~14ms natively). Only one budget is
under pressure.

**Two alternatives that look better and measured worse**, recorded in the comment so they
aren't retried:

- *Trimming the hook.* Tab rendering is 5% of the cost — the mount is the component graph,
  not the markup. And the obvious "mount once in `beforeAll`" **breaks the spec**: the
  fixture survives the test boundary but goes inert, so tab bodies stop attaching while
  labels still query, and assertions silently pass against markup that never appears.
- *Capping vitest's worker pool.* `os.cpus()` ignores cgroup limits, so vitest oversizes
  its pool under emulation — real, but capping it moved a 14m50s emulated run to 14m34s.
  Noise.

Both are written up in `DEV-LESSONS-LEARNED.md` (#698), along with the Docker recipe for
reproducing the armv7 leg locally.

## What changes for the user?

Nothing — test configuration only.

## How was this tested?

`npm run test:ci` green natively (66 files, 596 tests); native behaviour is unchanged
since only the `EMULATED_ARM` branch moved. The emulated suite was run twice during the
#689 investigation (uncapped and pool-capped, both 65/65 green); a third run was not
repeated here because widening a timeout cannot fail a hook that already completed inside
the narrower one.

Honest caveat: the original failure never reproduced locally — my best emulated
reproduction runs ~1.7× faster than CI. This is a reasoned change sized from
measurements, not a verified fix, and #689 stays open until the job has been green for a
while.

## Checklist

- [x] One logical change; version numbers untouched.
- [x] `features/` untouched — no user-facing change.
- [x] Skimmed `DEV-LESSONS-LEARNED.md` (and added to it in #698).
- [x] Test-configuration change; no behaviour to test.

@coderabbitai ignore
