### PR TITLE
fix(lint): clear the possible-real-defect rules from #686

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -451,7 +451,9 @@ export function cleanConfig(
   }
 
   // ensure legacy notes selections section is removed
-  delete (settings as any).selections.notes;
+  delete (
+    settings.selections as typeof settings.selections & { notes?: unknown }
+  ).notes;
 
   // apply url params
   if (typeof hostParams.northup !== 'undefined') {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -451,9 +451,7 @@ export function cleanConfig(
   }
 
   // ensure legacy notes selections section is removed
-  if (typeof (settings as any).selections.notes) {
-    delete (settings as any).selections.notes;
-  }
+  delete (settings as any).selections.notes;
 
   // apply url params
   if (typeof hostParams.northup !== 'undefined') {

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -1096,14 +1096,11 @@ export class AppFacade extends InfoService {
    * @param err Error response
    */
   parseHttpErrorResponse(err: HttpErrorResponse) {
-    let msg: string = '';
-    if (err.status && [401, 403].includes(err.status)) {
-      // unauthorised / forbidden
-      msg =
-        'Signal K server requires authentication to update resources.\nPlease login and try again.\n';
-    } else {
-      msg = 'Operation could not be completed!\n';
-    }
+    const msg =
+      err.status && [401, 403].includes(err.status)
+        ? // unauthorised / forbidden
+          'Signal K server requires authentication to update resources.\nPlease login and try again.\n'
+        : 'Operation could not be completed!\n';
     this.showAlert(
       `${err.status ?? 'Error'}`,
       msg + `${err.error?.message ?? ''}`
@@ -1330,9 +1327,8 @@ export class AppFacade extends InfoService {
       );
     } catch {
       value = null;
-    } finally {
-      return asString ? this.formatNumericDisplay(value) : value;
     }
+    return asString ? this.formatNumericDisplay(value) : value;
   }
 
   formattedSpeedUnits = Convert.getSymbol('kn');

--- a/src/app/lib/components/dialogs/trail2route-dialog.ts
+++ b/src/app/lib/components/dialogs/trail2route-dialog.ts
@@ -132,11 +132,10 @@ export class Trail2RouteDialog implements OnInit {
   // get server trail event handler
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onServerResource(value: any) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let serverTrail: Array<any> = [];
     if (this.fetching && value.action === 'get' && value.mode === 'trail') {
       this.fetching = false;
-      serverTrail = value.data;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const serverTrail: Array<any> = value.data;
       this.serverCoords = [];
       serverTrail.forEach((line) => {
         this.serverCoords = this.serverCoords.concat(line);

--- a/src/app/lib/components/measurements.component.ts
+++ b/src/app/lib/components/measurements.component.ts
@@ -224,11 +224,11 @@ export class Measurements {
           this._index.set(this.coords().length - 3);
         }
       } else if (this._index() > 0) {
-        this._index.update((current) => --current);
+        this._index.update((current) => current - 1);
       }
     } else {
       if (this._index() !== -1 || this._index() < this.coords().length - 2) {
-        this._index.update((current) => ++current);
+        this._index.update((current) => current + 1);
       }
     }
     this.setButtonState();

--- a/src/app/lib/geoutils.ts
+++ b/src/app/lib/geoutils.ts
@@ -217,7 +217,7 @@ export class GeoUtils {
       }
       return coords;
     } else if (Array.isArray(coords[0])) {
-      coords.forEach((c) => (c = this.normaliseCoords(c)));
+      coords.forEach((c) => this.normaliseCoords(c));
       return coords;
     }
   }

--- a/src/app/modules/alarms/components/timer-button.component.ts
+++ b/src/app/modules/alarms/components/timer-button.component.ts
@@ -56,7 +56,7 @@ export class TimerButtonComponent {
     this.label = this.label ?? 'Action in ';
     this.cancelledLabel = this.cancelledLabel ?? 'OK';
     this.timer = setInterval(() => {
-      this.timeLeft.update((current) => --current);
+      this.timeLeft.update((current) => current - 1);
       if (this.timeLeft() === 0) {
         this.disabled = true;
         this.action();

--- a/src/app/modules/course/course-settings.ts
+++ b/src/app/modules/course/course-settings.ts
@@ -368,11 +368,10 @@ export class CourseSettingsModal implements OnInit {
   }
 
   formatArrivalTime(): string {
-    let ts = '';
     this.arrivalData.datetime.setHours(parseInt(this.arrivalData.hour));
     this.arrivalData.datetime.setMinutes(parseInt(this.arrivalData.minutes));
     this.arrivalData.datetime.setSeconds(parseInt(this.arrivalData.seconds));
-    ts = this.arrivalData.datetime.toISOString();
+    const ts = this.arrivalData.datetime.toISOString();
     return ts.slice(0, ts.indexOf('.')) + 'Z';
   }
 

--- a/src/app/modules/gpx/gpxlib.spec.ts
+++ b/src/app/modules/gpx/gpxlib.spec.ts
@@ -1,5 +1,30 @@
-import { expect, describe, it, beforeEach } from 'vitest';
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import { GPX, finiteOr } from './gpxlib';
+
+/**
+ * GPX.parse() delegates the XML to a web worker. jsdom provides no Worker, and
+ * vi.mock cannot substitute the module under the Angular unit-test system, so
+ * stand in a Worker that answers with the JSON the real worker would produce.
+ * That keeps these tests on the public API instead of a private seam.
+ */
+class StubWorker {
+  static reply: unknown = null;
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  postMessage() {
+    queueMicrotask(() => this.onmessage?.({ data: StubWorker.reply }));
+  }
+  terminate() {
+    /* nothing to release */
+  }
+}
+
+const gpxWithBounds = (attr: Record<string, string> | null) => ({
+  gpx: {
+    metadata: [attr ? { bounds: [{ $: attr }] } : {}],
+    wpt: [{ $: { lat: '25.77', lon: '-80.19' }, name: ['Miami'] }]
+  }
+});
 
 describe('finiteOr', () => {
   it('parses a well-formed attribute', () => {
@@ -8,20 +33,12 @@ describe('finiteOr', () => {
     expect(finiteOr('0', 90)).toBe(0);
   });
 
+  // Number() answers NaN or 0 for all of these, never a nullish value, which is
+  // why the `Number(x) ?? null` guard this replaced could never fire.
   it('falls back for a missing, empty or malformed attribute', () => {
     for (const bad of [undefined, null, '', '   ', 'abc', {}]) {
       expect(finiteOr(bad, 90)).toBe(90);
     }
-  });
-
-  it('covers what the previous `Number(x) ?? null` guard could not', () => {
-    // Number() returns NaN or 0 for bad input, never null or undefined, so the
-    // nullish fallback never fired. A malformed attribute became NaN, and a
-    // null or empty one silently became a valid-looking latitude of 0.
-    expect(Number(undefined as never)).toBeNaN();
-    expect(Number('abc')).toBeNaN();
-    expect(Number(null as never)).toBe(0);
-    expect(Number('')).toBe(0);
   });
 
   it('falls back for a non-finite attribute', () => {
@@ -30,29 +47,35 @@ describe('finiteOr', () => {
   });
 });
 
-// A NaN reaching the bounds is unrecoverable: every comparison in
-// updateBounds() against NaN is false, so the accumulator can never narrow and
-// the file exports as minlat="NaN".
-describe('GPX.applyBounds', () => {
+describe('GPX.parse — metadata bounds', () => {
   let gpx: GPX;
-  // applyBounds is private; exercise the real code path rather than faking it.
-  const apply = (attr: Record<string, unknown> | null) =>
-    (gpx as unknown as { applyBounds: (b: unknown) => void }).applyBounds(
-      attr === null ? undefined : { $: attr }
-    );
+  const originalWorker = globalThis.Worker;
 
   beforeEach(() => {
     gpx = new GPX();
+    (globalThis as { Worker?: unknown }).Worker = StubWorker;
   });
 
-  it('reads a well-formed bounds element', () => {
-    apply({
-      minlat: '25.70',
-      minlon: '-80.25',
-      maxlat: '25.80',
-      maxlon: '-80.10'
-    });
-    expect({ ...gpx.metadata.bounds }).toEqual({
+  afterEach(() => {
+    (globalThis as { Worker?: unknown }).Worker = originalWorker;
+  });
+
+  const parse = async (attr: Record<string, string> | null) => {
+    StubWorker.reply = gpxWithBounds(attr);
+    const ok = await gpx.parse('<gpx></gpx>');
+    expect(ok).not.toBe(false);
+    return { ...gpx.metadata.bounds };
+  };
+
+  it('reads a well-formed bounds element', async () => {
+    expect(
+      await parse({
+        minlat: '25.70',
+        minlon: '-80.25',
+        maxlat: '25.80',
+        maxlon: '-80.10'
+      })
+    ).toEqual({
       minLat: 25.7,
       minLon: -80.25,
       maxLat: 25.8,
@@ -60,37 +83,44 @@ describe('GPX.applyBounds', () => {
     });
   });
 
-  it('keeps the accumulator sentinels for attributes that are missing', () => {
-    apply({ minlat: '25.70' });
-    expect({ ...gpx.metadata.bounds }).toEqual({
+  it('keeps the accumulator sentinels for attributes that are missing', async () => {
+    // minLat comes from the header; the rest fall back to the sentinels and are
+    // then narrowed by the file's own waypoint.
+    expect(await parse({ minlat: '25.70' })).toEqual({
       minLat: 25.7,
-      minLon: 180,
-      maxLat: -90,
-      maxLon: -180
+      minLon: -80.19,
+      maxLat: 25.77,
+      maxLon: -80.19
     });
   });
 
-  it('tolerates an absent bounds element', () => {
-    apply(null);
-    expect({ ...gpx.metadata.bounds }).toEqual({
-      minLat: 90,
-      minLon: 180,
-      maxLat: -90,
-      maxLon: -180
+  it('tolerates a metadata element with no bounds', async () => {
+    expect(await parse(null)).toEqual({
+      minLat: 25.77,
+      minLon: -80.19,
+      maxLat: 25.77,
+      maxLon: -80.19
     });
   });
 
-  it('never writes NaN into the bounds', () => {
-    apply({ minlat: 'abc', minlon: '', maxlat: 'Infinity', maxlon: 'xyz' });
-    for (const v of Object.values(gpx.metadata.bounds)) {
+  it('never writes NaN into the bounds', async () => {
+    const bounds = await parse({
+      minlat: 'abc',
+      minlon: '',
+      maxlat: 'Infinity',
+      maxlon: 'xyz'
+    });
+    for (const v of Object.values(bounds)) {
       expect(Number.isNaN(v)).toBe(false);
     }
   });
 
-  it('still derives bounds from points after a malformed bounds element', () => {
-    apply({ minlat: 'abc', minlon: '', maxlat: 'abc', maxlon: '' });
-    gpx.updateBounds({ lat: 25.77, lon: -80.19 });
-    expect({ ...gpx.metadata.bounds }).toEqual({
+  it('still derives bounds from points after a malformed bounds element', async () => {
+    // The whole point of the fix: a NaN here would make every updateBounds()
+    // comparison false, so the file's own points could never narrow the box.
+    expect(
+      await parse({ minlat: 'abc', minlon: '', maxlat: 'abc', maxlon: '' })
+    ).toEqual({
       minLat: 25.77,
       minLon: -80.19,
       maxLat: 25.77,

--- a/src/app/modules/gpx/gpxlib.spec.ts
+++ b/src/app/modules/gpx/gpxlib.spec.ts
@@ -1,0 +1,100 @@
+import { expect, describe, it, beforeEach } from 'vitest';
+import { GPX, finiteOr } from './gpxlib';
+
+describe('finiteOr', () => {
+  it('parses a well-formed attribute', () => {
+    expect(finiteOr('25.77', 90)).toBe(25.77);
+    expect(finiteOr('-80.19', 180)).toBe(-80.19);
+    expect(finiteOr('0', 90)).toBe(0);
+  });
+
+  it('falls back for a missing, empty or malformed attribute', () => {
+    for (const bad of [undefined, null, '', '   ', 'abc', {}]) {
+      expect(finiteOr(bad, 90)).toBe(90);
+    }
+  });
+
+  it('covers what the previous `Number(x) ?? null` guard could not', () => {
+    // Number() returns NaN or 0 for bad input, never null or undefined, so the
+    // nullish fallback never fired. A malformed attribute became NaN, and a
+    // null or empty one silently became a valid-looking latitude of 0.
+    expect(Number(undefined as never)).toBeNaN();
+    expect(Number('abc')).toBeNaN();
+    expect(Number(null as never)).toBe(0);
+    expect(Number('')).toBe(0);
+  });
+
+  it('falls back for a non-finite attribute', () => {
+    expect(finiteOr('Infinity', 90)).toBe(90);
+    expect(finiteOr('NaN', 90)).toBe(90);
+  });
+});
+
+// A NaN reaching the bounds is unrecoverable: every comparison in
+// updateBounds() against NaN is false, so the accumulator can never narrow and
+// the file exports as minlat="NaN".
+describe('GPX.applyBounds', () => {
+  let gpx: GPX;
+  // applyBounds is private; exercise the real code path rather than faking it.
+  const apply = (attr: Record<string, unknown> | null) =>
+    (gpx as unknown as { applyBounds: (b: unknown) => void }).applyBounds(
+      attr === null ? undefined : { $: attr }
+    );
+
+  beforeEach(() => {
+    gpx = new GPX();
+  });
+
+  it('reads a well-formed bounds element', () => {
+    apply({
+      minlat: '25.70',
+      minlon: '-80.25',
+      maxlat: '25.80',
+      maxlon: '-80.10'
+    });
+    expect({ ...gpx.metadata.bounds }).toEqual({
+      minLat: 25.7,
+      minLon: -80.25,
+      maxLat: 25.8,
+      maxLon: -80.1
+    });
+  });
+
+  it('keeps the accumulator sentinels for attributes that are missing', () => {
+    apply({ minlat: '25.70' });
+    expect({ ...gpx.metadata.bounds }).toEqual({
+      minLat: 25.7,
+      minLon: 180,
+      maxLat: -90,
+      maxLon: -180
+    });
+  });
+
+  it('tolerates an absent bounds element', () => {
+    apply(null);
+    expect({ ...gpx.metadata.bounds }).toEqual({
+      minLat: 90,
+      minLon: 180,
+      maxLat: -90,
+      maxLon: -180
+    });
+  });
+
+  it('never writes NaN into the bounds', () => {
+    apply({ minlat: 'abc', minlon: '', maxlat: 'Infinity', maxlon: 'xyz' });
+    for (const v of Object.values(gpx.metadata.bounds)) {
+      expect(Number.isNaN(v)).toBe(false);
+    }
+  });
+
+  it('still derives bounds from points after a malformed bounds element', () => {
+    apply({ minlat: 'abc', minlon: '', maxlat: 'abc', maxlon: '' });
+    gpx.updateBounds({ lat: 25.77, lon: -80.19 });
+    expect({ ...gpx.metadata.bounds }).toEqual({
+      minLat: 25.77,
+      minLon: -80.19,
+      maxLat: 25.77,
+      maxLon: -80.19
+    });
+  });
+});

--- a/src/app/modules/gpx/gpxlib.spec.ts
+++ b/src/app/modules/gpx/gpxlib.spec.ts
@@ -1,11 +1,15 @@
-import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest';
 import { GPX, finiteOr } from './gpxlib';
 
 /**
- * GPX.parse() delegates the XML to a web worker. jsdom provides no Worker, and
- * vi.mock cannot substitute the module under the Angular unit-test system, so
- * stand in a Worker that answers with the JSON the real worker would produce.
- * That keeps these tests on the public API instead of a private seam.
+ * GPX.parse() delegates the XML to a web worker. `@vitest/web-worker` (in the
+ * vitest setupFiles) does supply a `Worker` global, so the feature check in
+ * xml2JsonInWorker passes — but the worker module itself does not load here, so
+ * the promise rejects and parse() reports failure by returning false. Stub the
+ * global with a Worker that answers directly, which keeps these tests on the
+ * public API rather than a private seam. Every case asserts parse() did not
+ * return false, so a broken stub fails loudly instead of silently testing
+ * nothing.
  */
 class StubWorker {
   static reply: unknown = null;
@@ -49,15 +53,14 @@ describe('finiteOr', () => {
 
 describe('GPX.parse — metadata bounds', () => {
   let gpx: GPX;
-  const originalWorker = globalThis.Worker;
 
   beforeEach(() => {
     gpx = new GPX();
-    (globalThis as { Worker?: unknown }).Worker = StubWorker;
+    vi.stubGlobal('Worker', StubWorker);
   });
 
   afterEach(() => {
-    (globalThis as { Worker?: unknown }).Worker = originalWorker;
+    vi.unstubAllGlobals();
   });
 
   const parse = async (attr: Record<string, string> | null) => {

--- a/src/app/modules/gpx/gpxlib.ts
+++ b/src/app/modules/gpx/gpxlib.ts
@@ -15,6 +15,9 @@ import { xml2JsonInWorker } from 'src/app/lib/file-xml2json';
  * `minlat="NaN"`. Falling back to the caller's current value keeps the
  * accumulate-from-points sentinels intact instead.
  */
+/** A parsed GPX `<bounds>` element as xml2js emits it: attributes under `$`. */
+export type GPXBoundsElement = { $?: Record<string, unknown> } | undefined;
+
 export function finiteOr(value: unknown, fallback: number): number {
   if (typeof value !== 'string' || value.trim() === '') {
     return fallback;
@@ -287,8 +290,7 @@ export class GPX {
    * Attributes that are absent or unparseable leave the corresponding
    * GPXBoundsType sentinel in place, so updateBounds() can still derive the
    * bounds from the file's own points. **/
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private applyBounds(bounds: any) {
+  private applyBounds(bounds: GPXBoundsElement) {
     const attr = bounds?.['$'] ?? {};
     const b = this.metadata.bounds;
     b.minLat = finiteOr(attr.minlat, b.minLat);

--- a/src/app/modules/gpx/gpxlib.ts
+++ b/src/app/modules/gpx/gpxlib.ts
@@ -4,6 +4,25 @@
 
 import { xml2JsonInWorker } from 'src/app/lib/file-xml2json';
 
+/**
+ * Parse a GPX XML attribute as a finite number, falling back when it is
+ * absent, empty or malformed.
+ *
+ * `Number()` returns `NaN` — never `null` or `undefined` — for such input, so a
+ * `?? null` guard on it never fires. A `NaN` reaching `GPXBoundsType` is worse
+ * than a missing value: every comparison in `updateBounds()` against `NaN` is
+ * false, so the bounds can never recover and the file exports as
+ * `minlat="NaN"`. Falling back to the caller's current value keeps the
+ * accumulate-from-points sentinels intact instead.
+ */
+export function finiteOr(value: unknown, fallback: number): number {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return fallback;
+  }
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 /************************
  ** GPX File Class **
  ************************/
@@ -264,6 +283,20 @@ export class GPX {
     }
   }
 
+  /** apply a parsed GPX `<bounds>` element to the metadata accumulator.
+   * Attributes that are absent or unparseable leave the corresponding
+   * GPXBoundsType sentinel in place, so updateBounds() can still derive the
+   * bounds from the file's own points. **/
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private applyBounds(bounds: any) {
+    const attr = bounds?.['$'] ?? {};
+    const b = this.metadata.bounds;
+    b.minLat = finiteOr(attr.minlat, b.minLat);
+    b.minLon = finiteOr(attr.minlon, b.minLon);
+    b.maxLat = finiteOr(attr.maxlat, b.maxLat);
+    b.maxLon = finiteOr(attr.maxlon, b.maxLon);
+  }
+
   /** parse GPX string contents and fill this.data  **/
   public async parse(gpxstr: string): Promise<boolean> {
     // ** check for valid file contents **
@@ -284,11 +317,7 @@ export class GPX {
         this.metadata.keywords = meta.keywords ? meta.keywords : null;
 
         if (meta.bounds) {
-          const bounds = this.xValue(meta.bounds);
-          this.metadata.bounds.minLat = Number(bounds['$'].minlat) ?? null;
-          this.metadata.bounds.minLon = Number(bounds['$'].minlon) ?? null;
-          this.metadata.bounds.maxLat = Number(bounds['$'].maxlat) ?? null;
-          this.metadata.bounds.maxLon = Number(bounds['$'].maxlon) ?? null;
+          this.applyBounds(this.xValue(meta.bounds));
         }
         this.metadata.extensions = meta.extensions
           ? this.parseExtensions(meta.extensions)

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -1739,7 +1739,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
       isSelf: false
     };
 
-    let item = null;
+    let item;
     const t = id.split('.');
     let aid: string;
 
@@ -2159,15 +2159,12 @@ export class FBMapComponent implements OnInit, OnDestroy {
       const cog = this.dfeat.active.vectors.cog ?? [];
 
       const sog = this.dfeat.active.sog || 0;
-      let hl = 0;
-      if (this.app.config.vessels.selfLines.heading.length === -1) {
-        hl = (sog > wMax ? wMax : sog) * offset;
-      } else {
-        hl =
-          Convert.nauticalMilesToKm(
-            this.app.config.vessels.selfLines.heading.length
-          ) * 1000;
-      }
+      const hl =
+        this.app.config.vessels.selfLines.heading.length === -1
+          ? (sog > wMax ? wMax : sog) * offset
+          : Convert.nauticalMilesToKm(
+              this.app.config.vessels.selfLines.heading.length
+            ) * 1000;
       const heading = [
         this.dfeat.active.position,
         GeoUtils.rhumbDestination(

--- a/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-wmts-chart.component.ts
@@ -139,7 +139,9 @@ export class WmtsChartLayerComponent implements OnDestroy {
       return capabilities;
     } catch (err) {
       clearTimeout(abortTimer);
-      throw new Error(err.message ?? 'Unable to retrieve capabilities!');
+      throw new Error(err.message ?? 'Unable to retrieve capabilities!', {
+        cause: err
+      });
     }
   }
 }

--- a/src/app/modules/map/ol/lib/charts/s57Style.spec.ts
+++ b/src/app/modules/map/ol/lib/charts/s57Style.spec.ts
@@ -1,0 +1,56 @@
+import { expect, describe, it } from 'vitest';
+import { Feature } from 'ol';
+import { S57Style } from './s57Style';
+import { S57Service } from './s57.service';
+
+// GetCSQQUALIN01 reads only feature properties, so an empty service is enough.
+const style = () => new S57Style({} as S57Service);
+
+const coastline = (props: Record<string, string>) =>
+  ({
+    getProperties: () => props
+  }) as unknown as Feature;
+
+const qualin = (feature: Feature): string[] =>
+  (
+    style() as unknown as {
+      GetCSQQUALIN01: (f: Feature) => string[];
+    }
+  ).GetCSQQUALIN01(feature);
+
+// A copy/paste slip assigned the CONRAD value to `quapos`/`bquapos` — variables
+// belonging to the enclosing QUAPOS branch — leaving `bconrad` permanently false.
+// The whole radar-conspicuous coastline branch was therefore unreachable, and
+// every COALNE feature rendered as a plain coastline.
+describe('S57Style.GetCSQQUALIN01 — COALNE radar conspicuity (CONRAD)', () => {
+  it('adds the magenta highlight for a radar-conspicuous coastline', () => {
+    expect(qualin(coastline({ layer: 'COALNE', CONRAD: '1' }))).toEqual([
+      'LS(SOLD,3,CHMGF)',
+      'LS(SOLD,1,CSTLN)'
+    ]);
+  });
+
+  it('draws a plain coastline when CONRAD is present but not radar-conspicuous', () => {
+    expect(qualin(coastline({ layer: 'COALNE', CONRAD: '2' }))).toEqual([
+      'LS(SOLD,1,CSTLN)'
+    ]);
+  });
+
+  it('draws a plain coastline when CONRAD is absent', () => {
+    expect(qualin(coastline({ layer: 'COALNE' }))).toEqual([
+      'LS(SOLD,1,CSTLN)'
+    ]);
+  });
+
+  it('leaves the CONRAD branch alone when QUAPOS applies', () => {
+    expect(
+      qualin(coastline({ layer: 'COALNE', QUAPOS: '4', CONRAD: '1' }))
+    ).toEqual(['LC(LOWACC21']);
+  });
+
+  it('draws a plain coastline for a non-COALNE layer', () => {
+    expect(qualin(coastline({ layer: 'DEPCNT', CONRAD: '1' }))).toEqual([
+      'LS(SOLD,1,CSTLN)'
+    ]);
+  });
+});

--- a/src/app/modules/map/ol/lib/charts/s57Style.ts
+++ b/src/app/modules/map/ol/lib/charts/s57Style.ts
@@ -202,8 +202,8 @@ export class S57Style {
         let conrad = 0;
         let bconrad = false;
         if (featureProperties['CONRAD']) {
-          quapos = parseFloat(featureProperties['CONRAD']);
-          bquapos = true;
+          conrad = parseFloat(featureProperties['CONRAD']);
+          bconrad = true;
         }
         if (bconrad) {
           if (conrad === 1) {
@@ -340,7 +340,7 @@ export class S57Style {
 
   //https://github.com/OpenCPN/OpenCPN/blob/20a781ecc507443e5aaa1d33d0cb91852feb07ee/libs/s52plib/src/s52cnsy.cpp#L5809
   private GetCSTOPMAR01(feature: Feature): string[] {
-    let rulestring: string = null;
+    let rulestring: string;
     const featureProperties = feature.getProperties();
     if (!featureProperties['TOPSHP']) {
       rulestring = 'SY(QUESMRK1)';
@@ -655,8 +655,8 @@ export class S57Style {
     //const safe = false;
     let drval1 = 0;
     let depth_value = -1;
-    let valdco = 0;
-    let quapos = 0;
+    let valdco: number;
+    let quapos: number;
     let objl = 0;
 
     if (featureProperties['OBJL']) {
@@ -701,7 +701,7 @@ export class S57Style {
 
   //https://github.com/OpenCPN/OpenCPN/blob/c2ffb36ebca8c3777f03ea4d42e24f897aa62609/libs/s52plib/src/s52cnsy.cpp#L4247
   private getCSDEPARE01(feature: Feature): string[] {
-    let retval: string[] = [];
+    let retval: string[];
 
     const featureProperties = feature.getProperties();
 

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets-track.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets-track.component.ts
@@ -150,9 +150,7 @@ export class AISTargetsTrackLayerComponent extends AISBaseLayerComponent {
   // build track style
   buildStyle(id: string): Style {
     const rgb = id.indexOf('aircraft') !== -1 ? '0, 0, 255' : '255, 0, 255';
-    let color =
-      this.mapZoom < this.tracksMinZoom ? `rgba(${rgb},0)` : `rgba(${rgb},1)`;
-    color = this.showTracks ? `rgba(${rgb},1)` : `rgba(${rgb},0)`;
+    const color = this.showTracks ? `rgba(${rgb},1)` : `rgba(${rgb},0)`;
     if (this.layerProperties && this.layerProperties.style) {
       const cs = this.layerProperties.style.clone();
       const ls = cs.getStroke();

--- a/src/app/modules/plotterext/map-view-event.spec.ts
+++ b/src/app/modules/plotterext/map-view-event.spec.ts
@@ -41,17 +41,17 @@ describe('PlotterExtensionService map.view event', () => {
     TestBed.tick();
   };
 
-  const getView = () =>
-    (
+  const getView = () => {
+    const methods = (
       service as unknown as {
         mapMethods: () => Record<
           string,
           (p: unknown, c: unknown) => Promise<unknown>
         >;
       }
-    )
-      .mapMethods()
-      ['map.getView']({}, {});
+    ).mapMethods();
+    return methods['map.getView']({}, {});
+  };
 
   beforeEach(() => {
     published = [];

--- a/src/app/modules/radar/radar-api.service.ts
+++ b/src/app/modules/radar/radar-api.service.ts
@@ -131,12 +131,11 @@ export class RadarAPIService {
       );
       return false;
     }
-    let gl = new OffscreenCanvas(10, 10).getContext('webgl2');
+    const gl = new OffscreenCanvas(10, 10).getContext('webgl2');
     const result = gl ? true : false;
     if (gl) {
       const ext = gl.getExtension('WEBGL_lose_context');
       if (ext) ext.loseContext();
-      gl = null;
     }
     return result;
   }

--- a/src/app/modules/skresources/components/charts/maplib.worker.ts
+++ b/src/app/modules/skresources/components/charts/maplib.worker.ts
@@ -450,7 +450,7 @@ const parseIsoTimeValue = (value: string): string => {
     }
     return new Date(value).toISOString();
   } catch (err) {
-    throw new Error(`Unhandled Date format (${value})`);
+    throw new Error(`Unhandled Date format (${value})`, { cause: err });
   }
 };
 


### PR DESCRIPTION
Phase 1 of #686 — the "possible real defects" group. These six rules
(`no-unsafe-finally`, `no-constant-binary-expression`, `no-constant-condition`,
`no-unexpected-multiline`, `preserve-caught-error`, `no-useless-assignment`)
exist because they catch genuine bugs, so each of the 26 hits was reviewed
individually rather than blanket-fixed. Two turned out to be real; the other 24
are provably behaviour-neutral.

Deliberately scoped to this one group. The mechanical bulk (`prefer-const`,
`no-case-declarations`), `no-unused-vars`, `eqeqeq` and `no-explicit-any` are
later phases, and gating CI on `lint` comes after those.

### The two real defects

**S-57 radar-conspicuous coastlines have never rendered.** `GetCSQQUALIN01`
assigned the CONRAD value to `quapos`/`bquapos` — the variables belonging to the
enclosing QUAPOS branch — instead of the `conrad`/`bconrad` pair declared
immediately above. `bconrad` stayed false, so the whole branch was unreachable
and every COALNE feature drew as a plain coastline, never the
`LS(SOLD,3,CHMGF)` highlight. The slip also clobbered the outer QUAPOS state.
Now matches the cited OpenCPN `s52cnsy.cpp` reference.

**A malformed GPX `<bounds>` attribute poisoned the metadata irrecoverably.**
`Number(x) ?? null` can never fall back — `Number()` returns `NaN` or `0` for bad
input, never a nullish value. The resulting `NaN` is worse than a missing value,
because every comparison in `updateBounds()` against `NaN` is false: the
accumulator can never narrow afterwards and the file exports as `minlat="NaN"`.
Attributes now parse through `finiteOr()`, so an absent or unparseable one leaves
the `GPXBoundsType` sentinel in place and the file's own points still derive the
bounds.

### Behaviour-neutral, but worth a look

- `formatSpeed` returned from inside a `finally`, which discards an in-flight
  completion. Equivalent here only because the `catch` it wrapped cannot throw.
- `if (typeof x)` in `app.config` is always true — `typeof` yields a non-empty
  string. The legacy `selections.notes` key was already being deleted
  unconditionally.
- `geoutils`: assigning to a `forEach` parameter does nothing. Nested coordinates
  were unaffected because the recursion normalises each entry in place.

### Tests

`gpxlib.spec.ts` and `s57Style.spec.ts` are new; 5 of their tests fail against
the pre-fix code and pass after. The GPX header mapping moved into
`applyBounds()` to make it reachable — `parse()` only gets there through a web
worker, and `vi.mock` cannot substitute that module under the Angular unit-test
system (it silently no-ops on the `src/` alias and hard-errors on a relative
path).

Full suite 613 passing / 68 files, `build:all` clean, Prettier clean.
ESLint 413 → 383; this group 26 → 0.

### Noticed in passing, not addressed here

- `layer-aistargets-track`: the zoom gate is broken a second time — the guards in
  `reloadTracks()` and `onUpdateTargets()` test the method reference rather than
  calling it, so the zoom-10 minimum never applies. The dead style line is simply
  removed here; the gate is filed as #706 because restoring it is a user-visible
  behaviour change that deserves its own review.
- `fb-map.component.ts` lines ~1870/1922/1940: `item = [this.skres.fromCache(...)]`
  followed by `if (!item)` — an array literal is always truthy, so the not-found
  guard is dead. Not an ESLint finding.

Reviewed by CodeRabbit on a stand-in PR before opening here: two findings, one
applied (the `any` cast on the touched `delete` line) and one rebutted and filed
as #706.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPX import handling for missing, empty, or invalid numeric values, preventing corrupted map bounds.
  * Corrected coastline radar conspicuity interpretation in chart data.
  * Track lines now remain visible according to the track display setting, regardless of map zoom.
  * Fixed coordinate normalization for nested geographic data.
  * Corrected speed formatting when conversion fails.
  * Improved error reporting by preserving underlying causes for several failed operations.

* **Tests**
  * Added coverage for GPX bounds, invalid values, and coastline radar handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->