### PR TITLE
fix(course): keep the AM/PM indicator in the route bar ETA

### DIFF
--- a/src/app/lib/components/dial-text.spec.ts
+++ b/src/app/lib/components/dial-text.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ETADialComponent } from './dial-text';
+
+/**
+ * Issue #443: the ETA dial built its display string by slicing the
+ * ':'-separated parts of a full `toLocaleTimeString()`. That drops the seconds,
+ * but in a 12-hour locale it also drops the day period, so an ETA of 6:16 PM
+ * rendered as an ambiguous "6:16".
+ *
+ * The host's own locale and time zone are not knowable in CI, so these pin both
+ * by delegating `toLocaleTimeString` to a fixed `Intl.DateTimeFormat`, faithfully
+ * reproducing the no-options default (hour/minute/second) that the old code
+ * relied on.
+ */
+describe('ETADialComponent — locale time formatting', () => {
+  const realToLocaleTimeString = Date.prototype.toLocaleTimeString;
+
+  const pinLocale = (locale: string) => {
+    Date.prototype.toLocaleTimeString = function (
+      this: Date,
+      locales?: Intl.LocalesArgument,
+      options?: Intl.DateTimeFormatOptions
+    ) {
+      const opts =
+        options && Object.keys(options).length !== 0
+          ? options
+          : { hour: 'numeric', minute: '2-digit', second: '2-digit' };
+      return new Intl.DateTimeFormat(locales ?? locale, {
+        timeZone: 'UTC',
+        ...(opts as Intl.DateTimeFormatOptions)
+      }).format(this);
+    };
+  };
+
+  afterEach(() => {
+    Date.prototype.toLocaleTimeString = realToLocaleTimeString;
+  });
+
+  /** 18:16:45 UTC — 6:16:45 PM in a 12-hour locale. */
+  const eta = new Date('2026-08-23T18:16:45Z');
+
+  const renderETA = (locale: string): string => {
+    pinLocale(locale);
+    const fixture = TestBed.createComponent(ETADialComponent);
+    fixture.componentRef.setInput('value', eta);
+    fixture.detectChanges();
+    // `etaTime` is protected; the template is what a user reads.
+    return (fixture.nativeElement as HTMLElement)
+      .querySelector('.dial-text-value')!
+      .textContent!.trim();
+  };
+
+  it('keeps the day period in a 12-hour locale', () => {
+    // Not "6:16" — that is unreadable as an ETA (issue #443).
+    expect(renderETA('en-US')).toMatch(/^6:16\s?PM$/);
+  });
+
+  it('shows hours and minutes only in a 24-hour locale', () => {
+    expect(renderETA('en-GB')).toBe('18:16');
+  });
+});

--- a/src/app/lib/components/dial-text.ts
+++ b/src/app/lib/components/dial-text.ts
@@ -108,13 +108,16 @@ export class ETADialComponent {
 
   constructor() {
     effect(() => {
-      if (this.value()) {
-        this.etaTime = this.value()
-          .toLocaleTimeString()
-          .split(':')
-          .slice(0, 2)
-          .join(':');
-        this.etaDate = this.value().toLocaleDateString();
+      const v = this.value();
+      if (v) {
+        // Let Intl drop the seconds. Slicing the ':'-separated parts of a full
+        // toLocaleTimeString() also discarded the locale's day period, showing
+        // an ambiguous '6:16' instead of '6:16 PM' in 12-hour locales.
+        this.etaTime = v.toLocaleTimeString(undefined, {
+          hour: 'numeric',
+          minute: '2-digit'
+        });
+        this.etaDate = v.toLocaleDateString();
       }
     });
   }


### PR DESCRIPTION
Fixes the ambiguous ETA reported in #443.

### The bug

`ETADialComponent` dropped the seconds from the ETA by slicing the
`:`-separated parts of a full `toLocaleTimeString()`:

```ts
this.value().toLocaleTimeString().split(':').slice(0, 2).join(':');
```

In a 12-hour locale that string is `"6:16:45 PM"` — the day period lives in the
**third** part, so keeping only the first two discarded it and the route bar
rendered a bare `6:16`, which cannot be read as an ETA.

### The fix

Ask `Intl` for hours and minutes instead of slicing its output:

```ts
v.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
```

`6:16 PM` in 12-hour locales, unchanged `18:16` in 24-hour ones.

### Test

New co-located `dial-text.spec.ts` asserts the rendered dial value in both a
12-hour and a 24-hour locale. It pins the locale and time zone by delegating
`toLocaleTimeString` to a fixed `Intl.DateTimeFormat` — reproducing the
no-options default faithfully — so the result does not depend on the CI host.

Verified red before / green after: without the fix it reports
`expected '6:16' to match /^6:16\s?PM$/`.

### Scope

The other half of the report — that desktop browsers on Windows do not follow
the OS *Regional format* — is browser locale resolution rather than a Freeboard
bug, and is not addressed here. Browsers deliberately withhold the OS regional
override from web content; the explanation and the workaround are written up in
a comment on #443.

Closes #443


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ETA time display in 12-hour locales by preserving the AM/PM indicator.
  - Continued displaying only hours and minutes in 24-hour locales.
  - Maintained existing date formatting and handling for unavailable ETA values.

- **Tests**
  - Added coverage for locale-specific ETA formatting and display output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->