### PR TITLE
docs(lessons): record the locale-pinning and Prettier-scope traps

### DIFF
--- a/docs/freeboard/DEV-LESSONS-LEARNED.md
+++ b/docs/freeboard/DEV-LESSONS-LEARNED.md
@@ -802,7 +802,7 @@ status check means "the integration ran", not "a review happened" — it is gree
 for a rate-limited non-review too, with the description reading *Review rate
 limited*.
 
-### The Prettier CI gate covers only `ts|html` — don't `prettier --write` the CSS
+### The Prettier CI gate covers only `ts|html` — don't `prettier --write` the CSS or the docs
 
 **The trap.** CI's format check runs `format:check` =
 `prettier --check "src/**/*.+(ts|html)"`, so **CSS/SCSS are out of scope**, and the
@@ -811,8 +811,16 @@ repo's `.css` files use **4-space** indent (not Prettier's 2). Run a bare
 Prettier reformats the *entire* file to 2-space, burying your one-line change in a
 whole-file diff CI never asked for.
 
-**What to do instead.** Edit `.css` by hand in the file's existing 4-space style;
-don't run Prettier on it. Only `ts`/`html` go through Prettier (`npm run format`).
+**Markdown is out of scope too, and bites harder.** The docs here are hand-wrapped
+and use `*emphasis*` and compact tables. Running Prettier over one — say to tidy an
+entry you just added to this file — rewrites the **whole** document: every `*` becomes
+`_` and every table is re-padded, turning a 50-line addition into a many-hundred-line
+diff. `prettier --check` *will* flag these files; that is not a CI failure, it is
+Prettier being run somewhere CI never looks.
+
+**What to do instead.** Edit `.css` and `.md` by hand in each file's existing style;
+don't run Prettier on them, and don't treat a `--check` warning on one as something to
+fix. Only `ts`/`html` go through Prettier (`npm run format`).
 
 ---
 

--- a/docs/freeboard/DEV-LESSONS-LEARNED.md
+++ b/docs/freeboard/DEV-LESSONS-LEARNED.md
@@ -659,6 +659,57 @@ that state through the resource list's **select-all** toggle, which calls
 an all-inclusive array behind, which still counts as filtered and silently masks
 the bug. Confirm the config value before concluding anything from a manual repro.
 
+### Asserting on `toLocaleString` output — pin the locale, and reproduce its default
+
+**The trap.** The CI matrix runs on Linux, macOS, Windows and armv7, and each leg
+brings its own default locale and time zone. Any spec that asserts on the output of
+`toLocaleTimeString()` / `toLocaleDateString()` therefore passes locally and is a
+coin flip in CI.
+
+The obvious fix — pass an explicit locale into the code under test — is usually
+wrong here, because the behaviour you want to keep is precisely that the app calls
+these with **no** locale so it follows the user's. Pinning the locale in the
+*source* would delete the thing the test exists to protect.
+
+**What to do instead.** Pin the environment rather than the call. Delegate
+`Date.prototype.toLocaleTimeString` to a fixed `Intl.DateTimeFormat` for the
+duration of the spec, and restore it afterwards:
+
+```ts
+const real = Date.prototype.toLocaleTimeString;
+afterEach(() => { Date.prototype.toLocaleTimeString = real; });
+
+Date.prototype.toLocaleTimeString = function (locales?, options?) {
+  const opts =
+    options && Object.keys(options).length !== 0
+      ? options
+      : { hour: 'numeric', minute: '2-digit', second: '2-digit' }; // the real default
+  return new Intl.DateTimeFormat(locales ?? locale, {
+    timeZone: 'UTC',
+    ...opts
+  }).format(this);
+};
+```
+
+Fixing `timeZone` matters as much as the locale — without it the assertion still
+depends on the CI host.
+
+**The half that is easy to get wrong: reproduce the no-options default.**
+`toLocaleTimeString()` called with no options means hour + minute + second, but
+`new Intl.DateTimeFormat(locale, { timeZone: 'UTC' })` with no component options
+formats a **date** and no time at all. A stub that forwards `undefined` straight
+through therefore feeds the pre-fix code a string it never would have seen, and the
+red run either fails for the wrong reason or — worse — passes, leaving a test that
+looks like a regression guard and is not. Always confirm the red run fails with the
+*reported* symptom (for #443: `expected '6:16' to match /^6:16\s?PM$/`).
+
+**Match the day-period separator loosely.** ICU versions disagree on whether the
+space before `AM`/`PM` is a plain space or U+202F (narrow no-break space), and the
+matrix spans several Node versions. Asserting `'6:16 PM'` with a hard-coded space is
+a latent cross-version failure; `/^6:16\s?PM$/` matches both, since JS `\s`
+includes U+202F.
+
+
 ---
 
 ## When building & running locally


### PR DESCRIPTION
Adds two entries to `DEV-LESSONS-LEARNED.md`, both from the work on #443 / #708.

### Pinning locale and time zone in formatting specs (*When testing*)

Asserting on `toLocaleTimeString()` output is host-dependent across the CI
matrix, and the obvious fix — passing an explicit locale into the code under
test — is wrong when the behaviour under test is precisely that the app follows
the user's locale. The entry records the technique that works (delegate
`Date.prototype.toLocaleTimeString` to a fixed `Intl.DateTimeFormat`, pinning
time zone as well as locale), plus two traps that make a regression test
silently worthless:

- the no-options default is hour + minute + **second**, while a bare
  `Intl.DateTimeFormat` with no component options formats a **date** — get this
  wrong and the red run fails for the wrong reason, or passes;
- ICU versions disagree on whether the separator before `AM`/`PM` is a space or
  U+202F, so hard-coded assertions are a latent cross-version failure.

### Prettier's scope also excludes Markdown (*When submitting a PR*)

Extends the existing "Prettier CI gate covers only `ts|html`" entry. The gate
checks `src/**/*.+(ts|html)`, so `.md` is as out of scope as `.css` — and
running Prettier over a hand-wrapped doc rewrites the entire file (`*` → `_` on
every emphasis, every table re-padded), burying the entry you came to add. Hit
while adding the first entry above.

Documentation only — no source or behaviour changes.

@coderabbitai ignore
