### PR TITLE
refactor(lint): clear the mechanical rule group from #686

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1883,13 +1883,14 @@ export class AppComponent {
     // visibility checkboxes don't stay disabled.
     this.app.data.editingId = '';
     switch (this.mapInteract.draw.resourceType) {
-      case 'note':
+      case 'note': {
         const params = { position: e.coordinates };
         if (this.mapInteract.draw.properties['group']) {
           params['group'] = this.mapInteract.draw.properties['group'];
         }
         this.skres.showNoteEditor(params);
         break;
+      }
       case 'waypoint':
         this.skres.newWaypointAt(e.coordinates as Position);
         break;
@@ -1905,13 +1906,14 @@ export class AppComponent {
           }))
         });
         break;
-      case 'region':
+      case 'region': {
         const region = new SKRegion();
         region.feature.geometry.coordinates = [
           GeoUtils.normaliseCoords(e.coordinates as Polygon)
         ];
         this.skres.newRegion(region);
         break;
+      }
     }
   }
 

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -837,16 +837,10 @@ export class AppFacade extends InfoService {
   /** Start watching for change in skLoginInfo cookie */
   watchSKLogin() {
     if (this.watchingSKLogin) return;
-    this.watchingSKLogin = window.setInterval(
-      (() => {
-        const lastCookie = this.getCookie(document.cookie, 'skLoginInfo');
-        return () => {
-          const currentCookie = this.getCookie(document.cookie, 'skLoginInfo');
-          this.skAuthChange.set(currentCookie);
-        };
-      })(),
-      2000
-    );
+    this.watchingSKLogin = window.setInterval(() => {
+      const currentCookie = this.getCookie(document.cookie, 'skLoginInfo');
+      this.skAuthChange.set(currentCookie);
+    }, 2000);
   }
 
   /** return FB auth token for session */

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -839,7 +839,7 @@ export class AppFacade extends InfoService {
     if (this.watchingSKLogin) return;
     this.watchingSKLogin = window.setInterval(
       (() => {
-        let lastCookie = this.getCookie(document.cookie, 'skLoginInfo');
+        const lastCookie = this.getCookie(document.cookie, 'skLoginInfo');
         return () => {
           const currentCookie = this.getCookie(document.cookie, 'skLoginInfo');
           this.skAuthChange.set(currentCookie);

--- a/src/app/lib/components/pip.component.ts
+++ b/src/app/lib/components/pip.component.ts
@@ -88,7 +88,6 @@ export class PiPVideoComponent implements OnInit {
       this.change.emit(this.pipMode);
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.pipVideo.addEventListener('leavepictureinpicture', () => {
       this.pipMode = false;
       this.pipVideo.pause();

--- a/src/app/lib/services/indexeddb.ts
+++ b/src/app/lib/services/indexeddb.ts
@@ -9,7 +9,6 @@ export class IndexedDB {
     this.dbWrapper = new DbWrapper(dbName, version);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   openDatabase(
     version: number,
     upgradeCallback?: (evt: any, db: IDBDatabase) => void

--- a/src/app/modules/alarms/components/alert-list.component.ts
+++ b/src/app/modules/alarms/components/alert-list.component.ts
@@ -189,7 +189,6 @@ import { NotificationManager } from '../notification-manager';
 export class AlertListComponent {
   alerts = input([]);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   @Output() closed: EventEmitter<void> = new EventEmitter();
 
   protected app = inject(AppFacade);

--- a/src/app/modules/course/course.service.ts
+++ b/src/app/modules/course/course.service.ts
@@ -360,7 +360,7 @@ export class CourseService {
    * @param v self vessel
    */
   private processCourseCalcs(v: SKVessel) {
-    let c = Object.assign({}, this._courseData());
+    const c = Object.assign({}, this._courseData());
 
     // ** process preferred course data **
     if (typeof v.courseCalcs.crossTrackError !== 'undefined') {
@@ -424,7 +424,7 @@ export class CourseService {
 
     if (typeof v.courseCalcs.estimatedTimeOfArrival !== 'undefined') {
       if (v.courseCalcs.estimatedTimeOfArrival !== null) {
-        let d: Date | null = new Date(v.courseCalcs.estimatedTimeOfArrival);
+        const d: Date | null = new Date(v.courseCalcs.estimatedTimeOfArrival);
         c.eta = d instanceof Date && !isNaN(d as any) ? d : null;
       } else {
         c.eta = null;
@@ -433,7 +433,7 @@ export class CourseService {
 
     if (typeof v.courseCalcs['route.estimatedTimeOfArrival'] !== 'undefined') {
       if (v.courseCalcs['route.estimatedTimeOfArrival'] !== null) {
-        let d: Date | null = new Date(
+        const d: Date | null = new Date(
           v.courseCalcs['route.estimatedTimeOfArrival']
         );
         c.route.eta = d instanceof Date && !isNaN(d as any) ? d : null;

--- a/src/app/modules/icons/app.icons.ts
+++ b/src/app/modules/icons/app.icons.ts
@@ -135,7 +135,7 @@ export const getResourceIcon = (
     return { class: 'icon-route', svgIcon: 'route', name: undefined };
   }
   if (resourceType === 'regions') {
-    let iconDef = {
+    const iconDef = {
       class: 'icon-region',
       svgIcon: undefined,
       name: 'tab_unselected'
@@ -158,7 +158,7 @@ export const getResourceIcon = (
     return { class: undefined, svgIcon: `${icon}`, name: undefined };
   }
   if (resourceType === 'notes') {
-    let iconDef = {
+    const iconDef = {
       class: 'icon-accent',
       svgIcon: undefined,
       name: 'local_offer'

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -1539,7 +1539,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
             };
             text = 'Destination';
             break;
-          case 'note':
+          case 'note': {
             icon = {
               svgIcon: feature.get('icon'),
               name: undefined
@@ -1548,7 +1548,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
             const n = this.skres.fromCache('notes', t[1]);
             text = n[1].name ?? '';
             break;
-          case 'route':
+          }
+          case 'route': {
             icon = {
               svgIcon: 'route',
               name: undefined,
@@ -1563,7 +1564,8 @@ export class FBMapComponent implements OnInit, OnDestroy {
               text = r[1].name;
             }
             break;
-          case 'waypoint':
+          }
+          case 'waypoint': {
             icon = {
               name: 'location_on',
               svgIcon: undefined,
@@ -1573,6 +1575,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
             const w = this.skres.fromCache('waypoints', t[1]);
             text = w[1].name ?? '';
             break;
+          }
           case 'atons':
           case 'aton':
           case 'shore':
@@ -1756,7 +1759,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
       case 'anchor':
         this.modifyFeature('anchor');
         return;
-      case 'bearing_dist':
+      case 'bearing_dist': {
         const d =
           GeoUtils.distanceTo(this.app.data.vessels.self.position, coord) ?? 0;
         const b =
@@ -1767,6 +1770,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.position = coord;
         poData.show = true;
         break;
+      }
       case 'list':
         poData.type = t[0];
         poData.title = 'Features';
@@ -1780,7 +1784,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         featureList.forEach((f) => poData.content.push(f));
         poData.show = true;
         break;
-      case 'alarm':
+      case 'alarm': {
         aid = id.split('.').slice(1).join('.');
         const alm = this.notiMgr.getAlert(aid) as any;
         if (!alm) {
@@ -1791,6 +1795,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         poData.id = aid;
         poData.show = true;
         break;
+      }
       case 'vessels':
         poData.type = 'ais';
         poData.isSelf = true;

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -968,13 +968,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
 
   /** Handle OL interaction start event */
   protected onDragBoxStart(e: DragBoxEvent) {
-    let c = toLonLat(e.coordinate);
+    const c = toLonLat(e.coordinate);
     this.mapInteract.initBoxCoord(c as Position);
   }
 
   /** Handle OL interaction end event */
   protected onDragBoxEnd(e: DragBoxEvent) {
-    let c = toLonLat(e.coordinate);
+    const c = toLonLat(e.coordinate);
     this.mapInteract.stopBoxSelection(c as Position);
   }
 
@@ -1711,7 +1711,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
    * @param coord Position to display the popover
    * @param featureList list of map features at the supplied position
    * */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   protected formatPopover(
     id: string,
     coord: Position,

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -298,13 +298,16 @@ export class FBMapInteractService {
             (feature.getGeometry() as any).getCoordinates()
           );
           break;
-        case 'LineString': // route
+        case 'LineString': {
+          // route
           const rc = (feature.getGeometry() as any).getCoordinates();
           this.draw.coordinates = rc.map((i: Coordinate) => {
             return toLonLat(i);
           });
           break;
-        case 'Polygon': // region
+        }
+        case 'Polygon': {
+          // region
           const p = (feature.getGeometry() as any).getCoordinates();
           if (p.length === 0) {
             this.draw.coordinates = [];
@@ -313,6 +316,7 @@ export class FBMapInteractService {
             return toLonLat(i);
           });
           break;
+        }
       }
     }
     this.interactionEnded();

--- a/src/app/modules/map/ol/lib/charts/s57.service.ts
+++ b/src/app/modules/map/ol/lib/charts/s57.service.ts
@@ -203,8 +203,6 @@ export class S57Service {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private processColors(symbolsJson: any) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (
       symbolsJson['CHARTSYMBOLS']['COLOR-TABLES'][0]['COLOR-TABLE'] as any[]
     ).forEach((colortable) => {

--- a/src/app/modules/map/ol/lib/charts/s57Style.ts
+++ b/src/app/modules/map/ol/lib/charts/s57Style.ts
@@ -1055,7 +1055,7 @@ export class S57Style {
     switch (layer) {
       case 'SEAARE':
         return 2;
-      case 'DEPARE':
+      case 'DEPARE': {
         // S-52 assigns DEPARE and LNDARE the same display priority ('Area 1' = 2),
         // so the spec doesn't mandate which paints on top. We split DEPARE into
         // two cases:
@@ -1069,6 +1069,7 @@ export class S57Style {
         //     is correct per S-52 convention for such areas.
         const drval2 = properties['DRVAL2'];
         return typeof drval2 === 'number' && drval2 > 0 ? 5.5 : 3;
+      }
       case 'DEPCNT':
         return 4;
       case 'LNDARE':

--- a/src/app/modules/map/ol/lib/charts/s57Style.ts
+++ b/src/app/modules/map/ol/lib/charts/s57Style.ts
@@ -701,8 +701,6 @@ export class S57Style {
 
   //https://github.com/OpenCPN/OpenCPN/blob/c2ffb36ebca8c3777f03ea4d42e24f897aa62609/libs/s52plib/src/s52cnsy.cpp#L4247
   private getCSDEPARE01(feature: Feature): string[] {
-    let retval: string[];
-
     const featureProperties = feature.getProperties();
 
     let drval1 = -1;
@@ -718,7 +716,7 @@ export class S57Style {
       drval2 = dv2;
     }
 
-    retval = this.GetSeabed01(drval1, drval2);
+    const retval = this.GetSeabed01(drval1, drval2);
 
     const objl = featureProperties['OBJL'];
     if (parseInt(objl) === DRGARE) {

--- a/src/app/modules/map/ol/lib/navigation/layer-target-angle.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-target-angle.component.ts
@@ -41,7 +41,7 @@ export class TargetAngleComponent implements OnInit, OnDestroy, OnChanges {
 
   @Input() line: Coordinate[];
   @Input() mapZoom = 10;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   @Input() lineStyle: Style;
   @Input() position: Position; // (change trigger)
   @Input() twd: number; //(change trigger)

--- a/src/app/modules/map/ol/lib/racing/layer-racing-startline.component.ts
+++ b/src/app/modules/map/ol/lib/racing/layer-racing-startline.component.ts
@@ -49,7 +49,6 @@ export class RacingStartLineLayerComponent
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parseCourse() {
     if (!this.source) {
       return;

--- a/src/app/modules/map/ol/lib/racing/layer-racing-startline.component.ts
+++ b/src/app/modules/map/ol/lib/racing/layer-racing-startline.component.ts
@@ -74,8 +74,6 @@ export class RacingStartLineLayerComponent
   buildStyle(feature: Feature) {
     const geometry = feature.getGeometry() as LineString;
     const styles = [];
-    let ptFill: Fill;
-    let bgWidth: number;
 
     if (typeof this.racecourseStyles === 'undefined') {
       if (this.layerProperties && this.layerProperties.style) {
@@ -91,9 +89,9 @@ export class RacingStartLineLayerComponent
           this.racecourseStyles.startLine.length - 1
         ]
       : this.racecourseStyles.startLine;
-    bgWidth = s.getStroke().getWidth() + 1;
+    const bgWidth = s.getStroke().getWidth() + 1;
     const bgColor = 'white';
-    ptFill = new Fill({
+    const ptFill = new Fill({
       color: s?.getStroke().getColor()
     });
 

--- a/src/app/modules/map/ol/lib/radar/layer-radar.component.ts
+++ b/src/app/modules/map/ol/lib/radar/layer-radar.component.ts
@@ -98,7 +98,7 @@ export class RadarComponent implements OnInit, OnChanges, OnDestroy {
       }
       if (changes['position'] || changes['heading']) {
         if (changes['position']) {
-          let position = changes['position'].currentValue;
+          const position = changes['position'].currentValue;
           this.state.location = position;
         }
         if (changes['heading']) {

--- a/src/app/modules/map/ol/lib/radar/radar-gl.worker.ts
+++ b/src/app/modules/map/ol/lib/radar/radar-gl.worker.ts
@@ -215,12 +215,12 @@ addEventListener('message', (event) => {
       socket.binaryType = 'arraybuffer';
 
       socket.onmessage = (event) => {
-        let message = RadarMessage.deserialize(event.data);
+        const message = RadarMessage.deserialize(event.data);
         let vertexCount = 0;
         let colorCount = 0;
 
         for (let si = 0; si < message.spokes.length; si++) {
-          let spoke = message.spokes[si];
+          const spoke = message.spokes[si];
 
           if (lastRange !== spoke.range) {
             radarContext.clear(radarContext.COLOR_BUFFER_BIT);

--- a/src/app/modules/map/ol/lib/radar/radar-render.service.ts
+++ b/src/app/modules/map/ol/lib/radar/radar-render.service.ts
@@ -91,11 +91,11 @@ export class RadarRenderService {
   ): ImageSource {
     let range = 0;
     let location: Coordinate = [0, 0];
-    let rangeExtent = createEmpty();
+    const rangeExtent = createEmpty();
 
     const updateExtent = (location: Coordinate, range: number) => {
       const radius = range > 0 ? range : 25465; // fallback for initial render
-      let extent = circular(location, radius)
+      const extent = circular(location, radius)
         .transform('EPSG:4326', 'EPSG:3857')
         .getExtent();
       rangeExtent[0] = extent[0];
@@ -117,7 +117,7 @@ export class RadarRenderService {
 
     const offscreenRadarCanvas = radarCanvas.transferControlToOffscreen();
 
-    let radarSource = new ImageSource({
+    const radarSource = new ImageSource({
       projection: projection,
       loader: createLoader({
         imageExtent: rangeExtent,

--- a/src/app/modules/map/ol/lib/resources/ais-base.component.ts
+++ b/src/app/modules/map/ol/lib/resources/ais-base.component.ts
@@ -157,7 +157,7 @@ export class AISBaseLayerComponent
       return false;
     }
     const now = new Date().valueOf();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     return target.lastUpdated.valueOf() < now - this.inactiveTime;
   }
 

--- a/src/app/modules/map/ol/lib/resources/layer-resourceset.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-resourceset.component.ts
@@ -68,7 +68,7 @@ export class ResourceSetLayerComponent extends FBFeatureLayerComponent {
   }
 
   // process a resource set
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   parseResources(rSet: SKResourceSet) {
     const fa: Feature[] = [];
     let count = 0;

--- a/src/app/modules/settings/components/linestyle-select.component.ts
+++ b/src/app/modules/settings/components/linestyle-select.component.ts
@@ -174,7 +174,7 @@ export class LineStyleSelectComponent {
   ngOnInit() {}
 
   onSelectChange(opt: { key: string; value: any }) {
-    let d = this.app.formatLineDashArray(this._dash());
+    const d = this.app.formatLineDashArray(this._dash());
 
     this.selectionChange.emit({
       lineStyle: {

--- a/src/app/modules/skresources/components/ais/aton-properties-modal.ts
+++ b/src/app/modules/skresources/components/ais/aton-properties-modal.ts
@@ -137,7 +137,7 @@ export class AtoNPropertiesModal implements OnInit {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private parseMeteo(data: any) {
-    let res = {};
+    const res = {};
 
     if (data.navigation && data.navigation.position) {
       res['navigation.position'] = data.navigation.position.value;

--- a/src/app/modules/skresources/components/charts/maplib.ts
+++ b/src/app/modules/skresources/components/charts/maplib.ts
@@ -70,7 +70,7 @@ export const getLayerNodeByName = (
     }
   };
 
-  for (let node of data) {
+  for (const node of data) {
     parseNode(node);
     if (result) {
       break;

--- a/src/app/modules/skresources/components/charts/maplib.worker.ts
+++ b/src/app/modules/skresources/components/charts/maplib.worker.ts
@@ -97,7 +97,7 @@ const parseWMSCapabilities = async (
    * @param parent Parent LayerNode
    * @param depth Index of the depth of the layer in the tree
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const processWMSLayer = (
     layer: any,
     cList: LayerNode[],
@@ -119,7 +119,7 @@ const parseWMSCapabilities = async (
       node.title = getValue(layer.Title[0]);
     }
     if (Array.isArray(layer.Dimension)) {
-      for (let d of layer.Dimension) {
+      for (const d of layer.Dimension) {
         if (d.$?.name.toLowerCase() === 'time' && d.$?.units === 'ISO8601') {
           node.time = Object.assign(
             { current: d.$?.default ?? null },
@@ -141,7 +141,7 @@ const parseWMSCapabilities = async (
   if (xml.indexOf('<Capability') === -1) {
     throw new Error('Error: Invalid response received!');
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   const json = await parseStringPromise(xml);
   if (!json.WMS_Capabilities && !json.WMT_MS_Capabilities) {
     throw new Error('Error: No Capabilities found!');

--- a/src/app/modules/skresources/components/charts/wmts-dialog.ts
+++ b/src/app/modules/skresources/components/charts/wmts-dialog.ts
@@ -137,9 +137,8 @@ export class WMTSDialog {
   }
 
   handleSave() {
-    let l: SKInfoLayer;
     const layer = this.wmtsLayers[this.selections[0]];
-    l = new SKInfoLayer();
+    const l = new SKInfoLayer();
     l.name = layer.name ?? 'Untitled layer';
     l.description = layer.description ?? '';
     l.values.layers = [layer.id];

--- a/src/app/modules/skresources/components/routes/build-route.component.ts
+++ b/src/app/modules/skresources/components/routes/build-route.component.ts
@@ -183,7 +183,6 @@ export class BuildRouteComponent {
     this.rtepts.splice(index, 1);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dropEventHandler(event: CdkDragDrop<string[]>) {
     if (event.previousContainer === event.container) {
       moveItemInArray(

--- a/src/app/modules/skresources/custom-resources-service.ts
+++ b/src/app/modules/skresources/custom-resources-service.ts
@@ -330,7 +330,7 @@ export class FBCustomResourceService {
         query,
         true
       );
-      let flist = layers.filter((layer: FBInfoLayer) => layer[2]);
+      const flist = layers.filter((layer: FBInfoLayer) => layer[2]);
       //flist = this.arrangeLayers(flist);
       this.infoLayerCacheSignal.set(flist);
     } catch (err) {

--- a/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
+++ b/src/app/modules/skresources/resources-open-image-adjustment.spec.ts
@@ -11,7 +11,7 @@ import { ImageAdjustmentDialogResult } from 'src/app/lib/components';
  * touches `app`, `dialog` and `chartSetImageAdjustment`, so exercise it on a bare
  * prototype instance with those three stubbed — no Angular DI needed.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 function svcWithResult(result: ImageAdjustmentDialogResult | undefined) {
   const svc = Object.create(SKResourceService.prototype) as SKResourceService;
   const saveConfig = vi.fn();

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -791,7 +791,7 @@ export class SKResourceService {
     const refList = chartOrder.filter((i: string) => chtIds.includes(i));
 
     for (let destidx = 0; destidx < refList.length; destidx++) {
-      let srcidx = chartList.findIndex(
+      const srcidx = chartList.findIndex(
         (c: FBChart) => c[0] === refList[destidx]
       );
       if (srcidx !== -1) {
@@ -1459,7 +1459,7 @@ export class SKResourceService {
         this.selectionAdd('routes', this.app.data.activeRoute);
       }
       const rtes = await this.listFromServer<FBRoute>('routes', query);
-      let flist = rtes.filter((route: FBRoute) => route[2]);
+      const flist = rtes.filter((route: FBRoute) => route[2]);
       this.routeCacheSignal.set(flist);
     } catch (err) {
       this.app.debug('** refreshRoutes:', err);
@@ -1829,7 +1829,7 @@ export class SKResourceService {
         this.selectionAdd('waypoints', this.app.data.activeWaypoint);
       }
       const wpts = await this.listFromServer<FBWaypoint>('waypoints', query);
-      let flist = wpts.filter((waypoint: FBWaypoint) => waypoint[2]);
+      const flist = wpts.filter((waypoint: FBWaypoint) => waypoint[2]);
       this.waypointCacheSignal.set(flist);
     } catch (err) {
       this.app.debug('** refreshWaypoints:', err);
@@ -2807,7 +2807,7 @@ export class SKResourceService {
     this.app.debug(`** refreshTracks(): ${query}`);
     try {
       const trks = await this.listFromServer<FBTrack>('tracks', query);
-      let flist = trks.filter((track: FBTrack) => track[2]);
+      const flist = trks.filter((track: FBTrack) => track[2]);
       this.trackCacheSignal.set(flist);
     } catch (err) {
       this.app.debug('** refreshTracks:', err);

--- a/src/app/modules/skstream/skstream.worker.ts
+++ b/src/app/modules/skstream/skstream.worker.ts
@@ -318,7 +318,6 @@ function handleCommand(data: MsgFromApp) {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function applySettings(
   opt: {
     config: { [key: string]: any };

--- a/src/app/modules/skstream/stream-api.ts
+++ b/src/app/modules/skstream/stream-api.ts
@@ -171,7 +171,7 @@ export class SKStreamAPI {
     if (typeof value !== 'object') {
       return '';
     }
-    const msg: any = Message.request();
+    const msg = Message.request();
     if (typeof value.login === 'undefined' && this._token) {
       msg['token'] = this._token;
     }
@@ -218,7 +218,7 @@ export class SKStreamAPI {
     path: string | Array<any>,
     value?: any
   ): void {
-    const val: any = Message.updates();
+    const val = Message.updates();
     if (this._token) {
       val['token'] = this._token;
     }
@@ -253,7 +253,7 @@ export class SKStreamAPI {
     path: string | Array<any> = '*',
     options?: any
   ): void {
-    const val: any = Message.subscribe();
+    const val = Message.subscribe();
     if (this._token) {
       val['token'] = this._token;
     }
@@ -297,7 +297,7 @@ export class SKStreamAPI {
 
   // ** Unsubscribe from Delta stream messages **
   unsubscribe(context: string = '*', path: any = '*') {
-    const val: any = Message.unsubscribe();
+    const val = Message.unsubscribe();
     if (this._token) {
       val['token'] = this._token;
     }

--- a/src/app/modules/skstream/stream-api.ts
+++ b/src/app/modules/skstream/stream-api.ts
@@ -100,7 +100,7 @@ export class SKStreamAPI {
     if (!url) {
       return;
     }
-    let q = url.indexOf('?') == -1 ? '?' : '&';
+    const q = url.indexOf('?') == -1 ? '?' : '&';
     if (subscribe) {
       url += `${q}subscribe=${subscribe}`;
     }
@@ -171,11 +171,11 @@ export class SKStreamAPI {
     if (typeof value !== 'object') {
       return '';
     }
-    let msg: any = Message.request();
+    const msg: any = Message.request();
     if (typeof value.login === 'undefined' && this._token) {
       msg['token'] = this._token;
     }
-    let keys = Object.keys(value);
+    const keys = Object.keys(value);
     keys.forEach((k) => {
       msg[k] = value[k];
     });
@@ -185,7 +185,7 @@ export class SKStreamAPI {
 
   /** send put request via Delta stream */
   put(context: string, path: string, value: any): string {
-    let msg = {
+    const msg = {
       context: context == 'self' ? 'vessels.self' : context,
       put: { path: path, value: value }
     };
@@ -194,7 +194,7 @@ export class SKStreamAPI {
 
   /** get auth token for supplied user details */
   login(username: string, password: string) {
-    let msg = {
+    const msg = {
       login: { username: username, password: password }
     };
     return this.sendRequest(msg);
@@ -218,7 +218,7 @@ export class SKStreamAPI {
     path: string | Array<any>,
     value?: any
   ): void {
-    let val: any = Message.updates();
+    const val: any = Message.updates();
     if (this._token) {
       val['token'] = this._token;
     }
@@ -234,7 +234,7 @@ export class SKStreamAPI {
     if (typeof path === 'object' && Array.isArray(path)) {
       uValues = path;
     }
-    let u: any = {
+    const u: any = {
       timestamp: new Date().toISOString(),
       values: uValues
     };
@@ -253,7 +253,7 @@ export class SKStreamAPI {
     path: string | Array<any> = '*',
     options?: any
   ): void {
-    let val: any = Message.subscribe();
+    const val: any = Message.subscribe();
     if (this._token) {
       val['token'] = this._token;
     }
@@ -266,7 +266,7 @@ export class SKStreamAPI {
       val.subscribe = path;
     }
     if (typeof path === 'string') {
-      let sValue: any = {};
+      const sValue: any = {};
       sValue['path'] = path;
       if (options && typeof options === 'object') {
         if (options['period']) {
@@ -297,7 +297,7 @@ export class SKStreamAPI {
 
   // ** Unsubscribe from Delta stream messages **
   unsubscribe(context: string = '*', path: any = '*') {
-    let val: any = Message.unsubscribe();
+    const val: any = Message.unsubscribe();
     if (this._token) {
       val['token'] = this._token;
     }
@@ -333,7 +333,7 @@ export class SKStreamAPI {
 
   /** raise alarm for path */
   clearAlarm(context: string = '*', name: string) {
-    let path =
+    const path =
       name.indexOf('notifications.') == -1 ? `notifications.${name}` : name;
     this.put(context, path, null);
   }


### PR DESCRIPTION
Phase 2 of #686 — the mechanical group: `prefer-const`, `no-case-declarations`
and unused `eslint-disable` directives. 64 violations across 29 files, 382 → 318.

Split into three commits because "mechanical" only describes two thirds of it,
and the diff is large enough that a reviewer needs to know which parts were
machine-applied and which were judged.

### 1. The autofix (34 `prefer-const`, 15 directives, 25 files)

Run as `eslint --fix --rule '{"eqeqeq":"off"}'`. **The override is the point**: a
bare `--fix` also rewrites 7 `eqeqeq` occurrences, and every `==` → `===` is a
behaviour change where either side may be `null`/`undefined`. That is phase 4 and
wants reading case by case — left in, those 7 would have ridden along unreviewed
inside a commit labelled mechanical. `eqeqeq` is still 57 after this PR.

Every removed directive was an `eslint-disable-next-line
@typescript-eslint/no-explicit-any` that had been placed above a method signature
while the actual `any` sat two lines down in a parameter list, so it never
covered anything. **`no-explicit-any` is unchanged at 159**, which is the proof
none of them was doing work: removing a live directive would have raised it.

(`--fix` leaves a whitespace-only line where each directive was rather than
deleting the line, so Prettier has to follow the fixer.)

### 2. The four `prefer-const` the fixer declines

`--fix` only converts a `let` whose declaration and initialiser sit together.
These four declare in one place and assign in another, so they were moved by
hand. Each is assigned exactly once and thereafter only read, or mutated through
its properties.

### 3. The 11 `no-case-declarations`

None are auto-fixable. A `const` declared in an unbraced `case` is hoisted to the
whole `switch`, so it is visible — in the temporal dead zone — from every sibling
case. Each case body is now braced.

Reviewed individually rather than braced blindly, since the rule exists to catch
a leak that may already have been relied upon. None had been: every declaration
is read only inside its own case, and **the diff adds and removes no `break` or
`return` line in any of the four files**, so control flow is untouched.

### 4. Two findings from the stand-in review

CodeRabbit reviewed this on a stand-in PR before it was opened here, and both
findings sat on lines the `prefer-const` pass had rewritten — so both were
leaving a lint error inside a lint-cleanup change.

`app.facade.watchSKLogin` captured `lastCookie` in an IIFE and never read it.
The intent was clearly to fire only on a change, but the comparison was never
written, so the callback set `skAuthChange` on every 2s tick. That has always
been harmless: `skAuthChange` is an Angular signal, and `set()` with an unchanged
value is a no-op under default `Object.is` equality, so the effect — which calls
`handleSKAuthChange()` and refreshes Signal K login status — does not re-run. The
signal already does what the missing comparison would have. Dropping the capture
lets the IIFE collapse with it.

`stream-api` carried `: any` on four `Message` factory results. `Message` is
declared in that same file and returns object literals, so removing the
annotations lets them infer from the factory — a deletion, not a typing exercise.
`sValue` is deliberately left as `any`: under this tsconfig an inferred `{}` is
just as permissive, so clearing it there would remove a lint error without adding
a single constraint. Typing it honestly needs a declared subscription-entry
interface, which is phase 5.

### Verification

614 tests / 69 files pass, `build:all` clean, Prettier gate clean.
No behaviour change is intended anywhere in this PR.

### Noticed in passing, not addressed here

`fbmap-interact.service.ts` `case 'Polygon'`: the empty-geometry guard sets
`this.draw.coordinates = []` but does not return, so execution falls through to
`p[0].map(...)` and throws when `p` is empty. Pre-existing, not an ESLint
finding, and fixing it is a behaviour change — worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code consistency and safety by using immutable local values where appropriate.
  - Added clearer scoping for map, drawing, and chart processing logic.
- **Chores**
  - Removed obsolete lint-suppression comments across the application.
  - Simplified internal variable declarations without changing functionality.
- **Bug Fixes**
  - No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->