### PR TITLE
fix(map): resolve the vessel centre offset against the pending view rotation

### DIFF
--- a/src/app/app.facade.spec.ts
+++ b/src/app/app.facade.spec.ts
@@ -258,3 +258,54 @@ describe('AppFacade nautical-mile short-distance formatting (#474)', () => {
     expect(app.formatValueForDisplay(2000, 'm')).toBe('1.1nmi');
   });
 });
+
+describe('AppFacade.calcMapCenter pending rotation (#715)', () => {
+  // A viewport one "unit" square about [0, 0]; the exact ground distances do
+  // not matter, only that the offset resolves to a direction on the ground.
+  const setup = () => {
+    TestBed.configureTestingModule({});
+    const app = TestBed.inject(AppFacade);
+    app.config.map.center = [0, 0];
+    app.mapExtent.set([-0.01, -0.01, 0.01, 0.01]);
+    app.mapViewTopCenter.set([0, 0.01]);
+    app.mapViewRightCenter.set([0.01, 0]);
+    // What move-end last reported — the map has not rotated yet as far as the
+    // app-level signal is concerned.
+    app.mapViewRotation.set(0);
+    // Pure "look ahead" offset: map centre half a screen up from the vessel.
+    app.config.map.centerOffset = { x: 0, y: 50 };
+    // `active` is null until a vessel is selected; follow mode tracks self.
+    app.data.vessels.active = app.data.vessels.self;
+    app.data.vessels.active.position = [0, 0];
+    return app;
+  };
+
+  it('resolves a screen-up offset to due north when the view is unrotated', () => {
+    const [lon, lat] = setup().calcMapCenter();
+    expect(lat).toBeGreaterThan(0);
+    expect(Math.abs(lon)).toBeLessThan(1e-6);
+  });
+
+  // The regression. rotateMap() sets the map's rotation and centerVessel() runs
+  // in the SAME render, but app.mapViewRotation is not refreshed until OL fires
+  // move-end. Resolving against the stale signal puts the centre due north while
+  // the view renders rotated a quarter turn, so the vessel lands rotated off its
+  // screen-fixed spot. Passing the pending rotation must win over the signal.
+  it('resolves against the pending rotation, not the stale move-end rotation', () => {
+    const app = setup();
+    const stale = app.calcMapCenter();
+    // Screen-up is world-west once the view is rotated a quarter turn.
+    const [lon, lat] = app.calcMapCenter(true, 0, Math.PI / 2);
+    expect(lon).toBeLessThan(0);
+    expect(Math.abs(lat)).toBeLessThan(1e-6);
+    expect([lon, lat]).not.toEqual(stale);
+  });
+
+  it('still falls back to the move-end rotation when none is supplied', () => {
+    const app = setup();
+    app.mapViewRotation.set(Math.PI / 2);
+    const [lon, lat] = app.calcMapCenter();
+    expect(lon).toBeLessThan(0);
+    expect(Math.abs(lat)).toBeLessThan(1e-6);
+  });
+});

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -906,7 +906,7 @@ export class AppFacade extends InfoService {
    * reported an extent — the viewport signals hold [0, 0] until then, which
    * would size the offset against the distance to null island.
    */
-  private mapViewport(): MapViewport | null {
+  private mapViewport(rotation?: number): MapViewport | null {
     if (!this.mapExtent().length) {
       return null;
     }
@@ -919,7 +919,10 @@ export class AppFacade extends InfoService {
         this.config.map.center as Position,
         this.mapViewTopCenter()
       ),
-      rotation: this.mapViewRotation()
+      // mapViewRotation() is only written on move-end, so it lags a rotation the
+      // caller is applying in this same render; `rotation` lets it pass that
+      // pending value in. See calcMapCenter().
+      rotation: rotation ?? this.mapViewRotation()
     };
   }
 
@@ -929,12 +932,21 @@ export class AppFacade extends InfoService {
    * @param zoomShift zoom levels about to be applied; when non-zero the centre is
    * computed for the post-zoom viewport so the offset stays fixed on screen
    * through the zoom rather than snapping back after it.
+   * @param rotation the view rotation the centre should be resolved against,
+   * for a caller that is applying a new rotation in the same render as this
+   * centre. Omitted, the last rotation move-end reported is used — which is a
+   * frame behind in heading-up, leaving the vessel rotated off its screen-fixed
+   * spot by the per-update heading change (#715).
    */
-  calcMapCenter(applyOffset = true, zoomShift = 0): Position {
+  calcMapCenter(
+    applyOffset = true,
+    zoomShift = 0,
+    rotation?: number
+  ): Position {
     const position = this.data.vessels.active.position;
     const offset = this.config.map.centerOffset;
     const viewport =
-      applyOffset && (offset.x || offset.y) ? this.mapViewport() : null;
+      applyOffset && (offset.x || offset.y) ? this.mapViewport(rotation) : null;
     if (!viewport) {
       return position;
     }

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -2096,7 +2096,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
     if (this.movingMap && !this.offsetSuppressed && !this.userPanned) {
       const offset = this.app.config.map.centerOffset;
       if (offset.x || offset.y) {
-        this.mapCenterPositon.set(this.app.calcMapCenter(true, next - current));
+        this.mapCenterPositon.set(
+          this.app.calcMapCenter(true, next - current, this.mapRotation())
+        );
       }
     }
     this.mapZoomLevel.set(next);
@@ -2119,7 +2121,18 @@ export class FBMapComponent implements OnInit, OnDestroy {
       // arriving mid-drag would snatch the chart back from the user.
       return;
     }
-    const pos = this.app.calcMapCenter(!this.offsetSuppressed);
+    // Resolve the offset against the rotation being applied in THIS render, not
+    // the one move-end last reported. rotateMap() runs immediately before this
+    // and only sets the local mapRotation signal; app.mapViewRotation is not
+    // refreshed until OpenLayers renders and fires move-end. Using the stale
+    // value leaves the vessel rotated about the screen centre by the per-update
+    // heading change — invisible in north-up, where the rotation is always 0,
+    // and a constant jitter in heading-up (#715).
+    const pos = this.app.calcMapCenter(
+      !this.offsetSuppressed,
+      0,
+      this.mapRotation()
+    );
     this.mapCenterPositon.update(() => pos);
   }
 


### PR DESCRIPTION
## The problem

In **heading-up** follow mode with a **vessel centre offset** set by panning (`map.panBehavior: 'offset'`), the vessel does not hold its panned on-screen position. It oscillates around that spot by tens of pixels, with the whole chart swinging along, returning to place rather than drifting away.

In **north-up the feature is exactly correct**, which is why this was never caught.

## The cause

`AppFacade.calcMapCenter()` resolves the offset through `mapViewport()`, which takes its rotation from the app-level `mapViewRotation()` signal. That signal is written in **exactly one place** — `onMapMoveEnd()`.

But on every vessel update the map component runs, synchronously:

```ts
this.rotateMap();          // sets the component's LOCAL mapRotation signal
if (this.movingMap) {
  this.centerVessel();     // calcMapCenter() -> reads the app-level mapViewRotation()
}
```

`rotateMap()` sets only the local `mapRotation` signal bound to `[rotation]`; `app.mapViewRotation` is not refreshed until OpenLayers renders and fires move-end. So the new centre was computed against the **previous frame's rotation** while the new rotation was applied in the same render, leaving the vessel rotated about the screen centre by the per-update heading change.

North-up pins the rotation at 0, so the stale value always equalled the current one — the defect is structurally invisible there.

## The change

`calcMapCenter(applyOffset, zoomShift, rotation?)` takes an optional rotation for a caller applying a new rotation in the same render, and passes it to `mapViewport()`. `centerVessel()` and `zoomMap()` supply `this.mapRotation()`.

Omitted, it still falls back to the move-end rotation, so no other caller changes behaviour. `applyPanGesture()` deliberately keeps the existing path — it runs inside `onMapMoveEnd()` *after* `mapViewRotation` has been updated from the event, so its value is already current.

## Verification

New specs in `app.facade.spec.ts` covering the pending rotation, the unrotated case, and the fallback. Red→green confirmed: with the fix reverted, exactly the regression test fails and the two guards still pass. Full suite green (617 tests, 69 files).

Measured against a replay of real NMEA 2000 data: a 43%/50% offset puts the vessel **416 px** from the screen centre, and the observed **51 px** excursion matches that radius times the measured per-update COG change (p90 **6.78°**). After the change the vessel holds its spot.

## Notes

- The severity depends on the offset size (the error scales linearly with the offset radius) and on how noisy the rotation source is. `units.preferredPaths.heading` defaults to `navigation.courseOverGroundTrue`, so heading-up is really COG-up — see #704. Fixing that reduces the visible symptom substantially **without** addressing this defect, which still scales with the per-update rotation change during any real turn.
- A separate problem surfaced while investigating: `onMapMoveEnd` can stall for 10–12 s while following, freezing every viewport value derived from it. It makes this worse whenever it bites, but it has no established root cause and may be an artifact of the replay used to measure it. Tracked in #716; untouched here.

Closes #715


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map centering during zoom and vessel-following movements.
  * Current map rotation is now applied immediately, preventing incorrect vessel offsets caused by stale rotation data.
  * Added regression coverage for rotated and unrotated viewport positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->