### PR TITLE
fix(vessels): resolve vessel orientation from the best available source

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -181,9 +181,24 @@ export function cleanConfig(
     settings.units.preferredPaths = {
       tws: 'environment.wind.speedTrue',
       twd: 'environment.wind.directionTrue',
-      heading: 'navigation.courseOverGroundTrue',
+      heading: 'auto',
       course: 'navigation.courseGreatCircle'
     };
+  }
+  // Orientation defaulted to COG, which points the boat at GPS noise when it is
+  // stationary (#704, #338). Move existing installs onto 'auto' once: a stored
+  // value equal to the old default was almost never a deliberate choice, but
+  // after this runs a genuine choice of COG must stick, hence the one-time
+  // flag rather than an unconditional coercion.
+  // @todo remove (implemented) v2.32.0
+  if (!settings.units.autoHeadingApplied) {
+    if (
+      settings.units.preferredPaths.heading ===
+      'navigation.courseOverGroundTrue'
+    ) {
+      settings.units.preferredPaths.heading = 'auto';
+    }
+    settings.units.autoHeadingApplied = true;
   }
   if (typeof settings.units.useServerPrefs === 'undefined') {
     settings.units.useServerPrefs = false;
@@ -524,9 +539,10 @@ export function defaultConfig(): IAppConfig {
       preferredPaths: {
         tws: 'environment.wind.speedTrue',
         twd: 'environment.wind.directionTrue',
-        heading: 'navigation.courseOverGroundTrue',
+        heading: 'auto',
         course: 'navigation.courseGreatCircle'
       },
+      autoHeadingApplied: true,
       useServerPrefs: false
     },
     map: {

--- a/src/app/modules/settings/components/signalk-preferredpaths.component.ts
+++ b/src/app/modules/settings/components/signalk-preferredpaths.component.ts
@@ -14,6 +14,7 @@ import {
 import { MatRadioModule } from '@angular/material/radio';
 
 import { AppFacade } from 'src/app/app.facade';
+import { AUTO_ORIENTATION } from 'src/app/modules/skstream/orientation';
 
 @Component({
   selector: 'signalk-preferred-paths',
@@ -39,7 +40,7 @@ import { AppFacade } from 'src/app/app.facade';
                     [checked]="path === item[1].current"
                     (change)="item[1].current = pathopt.value; save(true)"
                   >
-                    {{ path.split('.').slice(-1) }}
+                    {{ pathLabel(path) }}
                   </mat-radio-button>
                 </div>
               }
@@ -79,6 +80,7 @@ export class SignalKPreferredPathsComponent {
     heading: {
       name: 'Heading / COG',
       choices: [
+        AUTO_ORIENTATION,
         'navigation.courseOverGroundTrue',
         'navigation.courseOverGroundMagnetic',
         'navigation.headingTrue',
@@ -97,6 +99,13 @@ export class SignalKPreferredPathsComponent {
   private app = inject(AppFacade);
 
   constructor() {}
+
+  /** Radio label: 'Automatic' for the auto option, else the path's last segment. */
+  protected pathLabel(path: string): string {
+    return path === AUTO_ORIENTATION
+      ? 'Automatic'
+      : path.split('.').slice(-1)[0];
+  }
 
   ngOnInit() {
     this.initEntries();
@@ -117,7 +126,9 @@ export class SignalKPreferredPathsComponent {
       const i = x[1];
       // ** fill available paths from received path data **
       i['choices'].forEach((c) => {
-        if (this.availPaths.has(c)) {
+        // 'auto' is not a Signal K path, so it never appears in the received
+        // path data — offer it regardless of what the server publishes.
+        if (c === AUTO_ORIENTATION || this.availPaths.has(c)) {
           i['available'].push(c);
         }
       });

--- a/src/app/modules/skresources/resource-classes.ts
+++ b/src/app/modules/skresources/resource-classes.ts
@@ -246,6 +246,13 @@ export class SKVessel extends SKTargetBase {
   heading: number;
   headingTrue: number = null;
   headingMagnetic: number = null;
+  // Local receipt times for the heading sources, stamped in the stream worker
+  // (only it sees per-path deltas). Automatic orientation needs to know a
+  // heading is still arriving, not merely that a value was received once —
+  // headingTrue can stop while headingMagnetic continues (e.g. variation goes
+  // away), so the two are stamped separately.
+  headingTrueUpdatedAt = 0;
+  headingMagneticUpdatedAt = 0;
   performance = {
     beatAngle: null,
     gybeAngle: null

--- a/src/app/modules/skstream/orientation.spec.ts
+++ b/src/app/modules/skstream/orientation.spec.ts
@@ -1,0 +1,146 @@
+import { expect, describe, it, vi, afterEach } from 'vitest';
+import {
+  HEADING_MAX_AGE_MS,
+  MIN_COG_SOG,
+  resolveOrientation
+} from './orientation';
+import { SKVessel } from '../skresources/resource-classes';
+
+// Orientation drives the vessel icon, the heading line, course-up map rotation
+// and the reference bearing for a wind angle. It defaulted to COG, so a boat
+// at anchor pointed at GPS noise and the heading line sat on top of the COG
+// line (#704, and #338 before it). Guard the source precedence and both
+// guards that keep it from flapping.
+describe('resolveOrientation — automatic source selection (#704)', () => {
+  const NOW = 1_700_000_000_000;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** A vessel with fresh heading + COG, as a boat under way reports. */
+  const vessel = (over: Partial<SKVessel> = {}): SKVessel => {
+    const v = new SKVessel();
+    v.headingTrueUpdatedAt = NOW;
+    v.headingMagneticUpdatedAt = NOW;
+    Object.assign(v, over);
+    return v;
+  };
+
+  const at = (t = NOW) => vi.spyOn(Date, 'now').mockReturnValue(t);
+
+  it('prefers a fresh heading over COG', () => {
+    at();
+    const v = vessel({ headingTrue: 1.5, cogTrue: 3, sog: 5 });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(1.5);
+  });
+
+  it('falls back to magnetic heading when true heading is absent', () => {
+    at();
+    const v = vessel({ headingMagnetic: 2.2, cogTrue: 3, sog: 5 });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(2.2);
+  });
+
+  // headingTrue can stop while headingMagnetic keeps arriving (variation goes
+  // away), which is why the two receipt times are stamped separately.
+  it('falls back to magnetic when only true heading has gone stale', () => {
+    at();
+    const v = vessel({
+      headingTrue: 1.5,
+      headingMagnetic: 2.2,
+      headingTrueUpdatedAt: NOW - HEADING_MAX_AGE_MS - 1
+    });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(2.2);
+  });
+
+  it('uses COG when no heading is reported at all', () => {
+    at();
+    const v = vessel({ cogTrue: 3, sog: 5 });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(3);
+  });
+
+  it('falls back to COG once the heading goes stale', () => {
+    at();
+    const v = vessel({
+      headingTrue: 1.5,
+      headingMagnetic: 1.5,
+      cogTrue: 3,
+      sog: 5,
+      headingTrueUpdatedAt: NOW - HEADING_MAX_AGE_MS - 1,
+      headingMagneticUpdatedAt: NOW - HEADING_MAX_AGE_MS - 1
+    });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(3);
+  });
+
+  it('keeps using a heading that is old but still within the window', () => {
+    at();
+    const v = vessel({
+      headingTrue: 1.5,
+      cogTrue: 3,
+      sog: 5,
+      headingTrueUpdatedAt: NOW - HEADING_MAX_AGE_MS
+    });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(1.5);
+  });
+
+  // The bug as reported: stationary, valid heading present, icon follows COG.
+  it('does not follow COG noise when stationary with a valid heading', () => {
+    at();
+    const v = vessel({ headingTrue: 1.5, cogTrue: 3, sog: 0 });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(1.5);
+  });
+
+  // Freezing rather than switching is what stops a boat drifting across the
+  // threshold from oscillating between sources.
+  it('holds the last orientation when heading is stale and SOG is below the gate', () => {
+    at();
+    const v = vessel({
+      cogTrue: 3,
+      sog: MIN_COG_SOG - 0.01,
+      orientation: 1.2
+    });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(1.2);
+  });
+
+  it('uses COG at exactly the SOG gate', () => {
+    at();
+    const v = vessel({ cogTrue: 3, sog: MIN_COG_SOG, orientation: 1.2 });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(3);
+  });
+
+  it('holds the last orientation when nothing is reported', () => {
+    at();
+    const v = vessel({ orientation: 1.2 });
+
+    resolveOrientation(v);
+
+    expect(v.orientation).toBe(1.2);
+  });
+});

--- a/src/app/modules/skstream/orientation.ts
+++ b/src/app/modules/skstream/orientation.ts
@@ -1,0 +1,73 @@
+/***********************************
+Vessel orientation source resolution
+***********************************/
+import { SKVessel } from 'src/app/modules/skresources/resource-classes';
+
+/** `preferredPaths.heading` value selecting automatic orientation resolution. */
+export const AUTO_ORIENTATION = 'auto';
+
+/**
+ * How long a heading stays usable after the last heading delta.
+ *
+ * Heading sources report fast (PGN 127250 is nominally 10Hz, and a fluxgate or
+ * satellite compass arrives sub-second through Signal K), so 10s is ~100x the
+ * normal interval. The asymmetry is deliberate: too short and a stalled stream
+ * flips orientation to COG and back, which is visible on screen as a flapping
+ * icon; too long merely holds a dead compass's last heading a few extra
+ * seconds, which nobody notices. Bias long.
+ */
+export const HEADING_MAX_AGE_MS = 10000;
+
+/**
+ * SOG below which COG is GPS noise rather than a direction of travel.
+ * 0.2572 m/s is ~0.5kn — the figure suggested in #338.
+ */
+export const MIN_COG_SOG = 0.2572;
+
+/** Deltas that can change the automatic orientation result. */
+export const ORIENTATION_SOURCE_PATHS = new Set([
+  'navigation.headingTrue',
+  'navigation.headingMagnetic',
+  'navigation.courseOverGroundTrue',
+  'navigation.courseOverGroundMagnetic',
+  'navigation.speedOverGround'
+]);
+
+/**
+ * Resolve vessel orientation from the best source currently available.
+ *
+ * Orientation drives the vessel icon, the heading line, course-up map rotation
+ * and the reference bearing for a wind *angle*, so heading takes precedence
+ * over COG: heading is where the bow points, which is what all four represent,
+ * and its divergence from COG is the leeway/set the display exists to show.
+ * Defaulting to COG collapsed the heading and COG lines onto each other and
+ * spun the icon at anchor (#704, and #338 before it).
+ *
+ * COG stands in only when no fresh heading is reported, and then only while
+ * actually making way — below MIN_COG_SOG it is GPS noise.
+ *
+ * When nothing qualifies the previous orientation is held rather than reset:
+ * the bow has not moved, and freezing avoids the oscillation a boat drifting
+ * across the SOG threshold would otherwise show.
+ */
+export function resolveOrientation(d: SKVessel) {
+  const now = Date.now();
+  if (
+    d.headingTrue !== null &&
+    now - d.headingTrueUpdatedAt <= HEADING_MAX_AGE_MS
+  ) {
+    d.orientation = d.headingTrue;
+    return;
+  }
+  if (
+    d.headingMagnetic !== null &&
+    now - d.headingMagneticUpdatedAt <= HEADING_MAX_AGE_MS
+  ) {
+    d.orientation = d.headingMagnetic;
+    return;
+  }
+  const cog = d.cogTrue ?? d.cogMagnetic;
+  if (typeof cog === 'number' && (d.sog ?? 0) >= MIN_COG_SOG) {
+    d.orientation = cog;
+  }
+}

--- a/src/app/modules/skstream/skstream.worker.spec.ts
+++ b/src/app/modules/skstream/skstream.worker.spec.ts
@@ -140,3 +140,57 @@ describe('skstream.worker handleStreamEvent — watchdog on disconnect (#695)', 
     expect(alarmUpdates()).toHaveLength(1);
   });
 });
+
+// Orientation is resolved in the worker because only it sees per-path deltas.
+// With the shipped default the self icon followed COG, so a boat at anchor
+// pointed at GPS noise while a valid heading sat unused on the bus (#704).
+// Guard the delta-level contract: heading deltas stamp a receipt time, and an
+// unset/auto preference orients by heading rather than COG.
+describe('skstream.worker processVessel — orientation source (#704)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stamps the receipt time when a true heading delta arrives', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const vessel = new SKVessel();
+
+    processVessel(vessel, { path: 'navigation.headingTrue', value: 1.5 }, true);
+
+    expect(vessel.headingTrueUpdatedAt).toBe(1_700_000_000_000);
+  });
+
+  it('stamps the magnetic receipt time separately', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const vessel = new SKVessel();
+
+    processVessel(
+      vessel,
+      { path: 'navigation.headingMagnetic', value: 2.2 },
+      true
+    );
+
+    expect(vessel.headingMagneticUpdatedAt).toBe(1_700_000_000_000);
+    expect(vessel.headingTrueUpdatedAt).toBe(0);
+  });
+
+  it('orients by heading, not COG, when stationary', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const vessel = new SKVessel();
+
+    processVessel(
+      vessel,
+      { path: 'navigation.speedOverGround', value: 0 },
+      true
+    );
+    processVessel(vessel, { path: 'navigation.headingTrue', value: 1.5 }, true);
+    // COG noise at anchor must not steal the icon.
+    processVessel(
+      vessel,
+      { path: 'navigation.courseOverGroundTrue', value: 3 },
+      true
+    );
+
+    expect(vessel.orientation).toBe(1.5);
+  });
+});

--- a/src/app/modules/skstream/skstream.worker.ts
+++ b/src/app/modules/skstream/skstream.worker.ts
@@ -20,6 +20,11 @@ import {
 import { SimplifyAP } from 'simplify-ts';
 import { Convert } from 'src/app/lib/convert';
 import { PathValue } from 'src/app/types';
+import {
+  AUTO_ORIENTATION,
+  ORIENTATION_SOURCE_PATHS,
+  resolveOrientation
+} from './orientation';
 
 interface AisStatus {
   updated: { [key: string]: boolean };
@@ -983,15 +988,23 @@ export function processVessel(d: SKVessel, v: any, isSelf = false) {
   // ** heading **
   else if (v.path === 'navigation.headingTrue') {
     d.headingTrue = v.value;
+    d.headingTrueUpdatedAt = Date.now();
   } else if (v.path === 'navigation.headingMagnetic') {
     d.headingMagnetic = v.value;
+    d.headingMagneticUpdatedAt = Date.now();
   }
 
-  // use preferred heading value for orientation **
-  if (
-    typeof preferredPaths['heading'] !== 'undefined' &&
-    v.path === preferredPaths['heading']
-  ) {
+  // ** orientation **
+  // 'auto' (the default) resolves the best available source; an explicit path
+  // selection is honoured verbatim so a user can still lock orientation to one
+  // path. preferredPaths is empty until the config message arrives, so an
+  // unset preference resolves automatically too.
+  const headingPref = preferredPaths['heading'];
+  if (typeof headingPref === 'undefined' || headingPref === AUTO_ORIENTATION) {
+    if (ORIENTATION_SOURCE_PATHS.has(v.path)) {
+      resolveOrientation(d);
+    }
+  } else if (v.path === headingPref) {
     d.orientation = v.value;
   }
 

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -130,9 +130,13 @@ export interface IAppConfig {
     preferredPaths: {
       tws: string;
       twd: string;
+      /** A Signal K path, or 'auto' to resolve the best available source. */
       heading: string;
       course: string;
     };
+    /** One-time marker for the COG -> 'auto' orientation migration (#704). */
+    // @todo remove (implemented) v2.32.0
+    autoHeadingApplied: boolean;
     useServerPrefs: boolean;
   };
   map: {

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -2400,6 +2400,21 @@
           on more than one Signal K path. This panel is where you choose which
           one Freeboard uses for <i>True Wind Speed</i>,
           <i>True Wind Direction</i> and <i>Heading / COG</i>.<br />
+          <i>Heading / COG</i> sets the direction your vessel is pointed on the
+          chart &mdash; the vessel icon, the heading line, the chart rotation in
+          <i>Heading Up</i> mode, and the reference used when wind is published
+          as an angle rather than a direction.<br />
+          It defaults to <b>Automatic</b>, which uses the best source available
+          at the time: true heading, then magnetic heading, then COG. Heading is
+          preferred because it is where the bow is pointing &mdash; the
+          difference between it and the course vector is your leeway and set.
+          COG is only used when no heading has been received for 10 seconds
+          <i>and</i> you are making more than about 0.5 knots, since a
+          stationary vessel's COG is GPS noise and would make the icon spin. If
+          neither is available the last known direction is held rather than
+          reset.<br />
+          Select a specific path instead if you want the direction locked to
+          that one value.<br />
           <img
             src="./img/settings_paths.png"
             style="height: 200px"

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -2423,9 +2423,10 @@
           Select the path you want used for each value. Your selection applies
           immediately.<br />
           <i
-            >Note: Only paths present in the data stream received from the
-            Signal K server are offered. If none are, Freeboard still lists its
-            default path for that value.
+            >Note: <b>Automatic</b> is always offered. Explicit paths are
+            offered only when they are present in the data stream received from
+            the Signal K server. If none are, Freeboard still lists its default
+            path for that value.
           </i>
           <hr />
 


### PR DESCRIPTION
## The problem

`units.preferredPaths.heading` defaults to `navigation.courseOverGroundTrue`, so the self vessel's orientation tracks COG. A stationary vessel's COG is GPS noise, so at anchor or on the dock the boat icon points in a random direction while a valid heading sits unused on the bus.

That value drives more than the icon:

- the **vessel icon** rotation;
- the **heading line** (`fb-map.component.ts` builds it from `orientation`, while the COG line comes from `cogTrue`). Both lines are on by default, so out of the box they render **collinear** — the heading line carries no information on a fresh install;
- **course-up map rotation** (`rotateMap()`), so heading-up is really COG-up;
- the reference bearing when true wind is published as an **angle** rather than a direction (`Convert.angleToDirection(v.value, d.orientation)`). A wind angle is measured from the bow, so a COG reference is wrong by the leeway/set angle.

The self vessel was also inconsistent with every other vessel on the same chart: `skstream.facade.ts` already resolves AIS targets as `headingTrue ?? headingMagnetic ?? cogTrue ?? cogMagnetic`.

Reported twice — #704, and #338 before it, which was closed on the "change your settings" workaround rather than a fix.

## The change

Add `'auto'` as a `preferredPaths.heading` value and make it the default. It resolves `headingTrue` → `headingMagnetic` → COG.

Heading takes precedence because it is where the bow points, which is what all four consumers represent, and its divergence from COG is the leeway and set the display exists to show. COG stands in only when no heading has arrived for **10s** *and* SOG is above **~0.5kn**; below that it is noise. When nothing qualifies the previous orientation is **held** rather than reset, so a vessel drifting across the SOG threshold does not oscillate between sources.

Both thresholds are constants rather than settings. A heading-fallback threshold is invisible when it is working correctly, so there is no observation a user could make that would tell them to change it — and the complaint in #338 was that this area already asks the user too much.

True and magnetic receipt times are stamped **separately**: `headingTrue` can stop while `headingMagnetic` continues (variation goes away, the case raised in #338), and a shared stamp would keep the dead source looking fresh.

An explicit path selection is still honoured verbatim, so orientation can be locked to one path where there is a reason to. `Automatic` is offered unconditionally in Settings → Preferred Paths, since it is not a Signal K path and so never appears in the received path data.

Existing installs are migrated once, behind a `units.autoHeadingApplied` flag: `cleanConfig()` only seeds `preferredPaths` when it is undefined, so a default change alone would reach new installs only — and everyone affected is by definition an existing install. The flag is what makes a *genuine* later choice of COG stick instead of being flipped back on every reload.

The online help now also states what `Heading / COG` controls, which #338 raised and which was never addressed.

## Verification

New `orientation.spec.ts` (11 tests: source precedence, per-source staleness, the SOG gate boundary, the freeze) plus 3 delta-level tests in `skstream.worker.spec.ts`. Red→green confirmed: with the fix reverted, exactly the 3 new worker tests fail (`Expected 1.5, Received 0` on the stationary case) and the 7 pre-existing ones still pass. Full suite green — 630 tests, 70 files.

Tested against a replay of real NMEA 2000 data on a local server.

## Notes

- Rebased onto #717. The two meet at `rotateMap()`: #717 fixed the *stale rotation* the centre offset resolved against, and this reduces the *magnitude* of per-update rotation change feeding it, since heading-up is now driven by a compass heading rather than COG (#717 measured p90 6.78° of per-update change from the COG source). Independent fixes; both improvements are visible together.
- `orientation.ts` is a separate module rather than living in `skstream.worker.ts` so the settings component can import `AUTO_ORIENTATION` without pulling the worker entry into the main bundle.

Closes #704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Automatic** heading option that selects the best available orientation source.
  * Automatic orientation prioritizes true heading, then magnetic heading, with COG used when appropriate.
  * Added safeguards for stale or unavailable data while preserving the last valid orientation.
  * Updated settings to offer Automatic regardless of available data sources.

* **Bug Fixes**
  * Existing heading preferences are migrated safely to the new Automatic default.

* **Documentation**
  * Updated help content to explain heading and COG selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->