### PR TITLE
docs(lessons): note that a rate-limit report can be stale

### DIFF
--- a/docs/freeboard/DEV-LESSONS-LEARNED.md
+++ b/docs/freeboard/DEV-LESSONS-LEARNED.md
@@ -880,10 +880,14 @@ is the cheapest way to plan a follow-up push.
 
 Compute the deadline from the notice comment's `updated_at`, not from
 when you read it, and allow a small buffer; if it is refused again, a fresh
-notice with a fresh figure appears, so repeat against that. And remember the
-green **CodeRabbit** status check means "the integration ran", not "a review
-happened" — it is green for a rate-limited non-review too, with the description
-reading *Review rate limited*.
+notice with a fresh figure appears, so repeat against that. For the same reason
+a rate-limit report can be **stale**: `cr-status.sh` reads whichever notice is on
+the PR, so a `CR-STATUS: RATE-LIMITED` left from an earlier round still shows long
+after its window closed. Treat it as current only when the `WINDOW-OPENS` line is
+in the future — printed in the past (`-1 min from now`) it is history, and the
+real state is "not triggered yet". And remember the green **CodeRabbit** status
+check means "the integration ran", not "a review happened" — it is green for a
+rate-limited non-review too, with the description reading *Review rate limited*.
 
 ### If you stage PRs on your own fork first, CodeRabbit will not review them
 


### PR DESCRIPTION
Adds four lines to the existing *Waiting on a CodeRabbit review* section.

`cr-status.sh` reports whichever rate-limit notice is present on the PR, so a `CR-STATUS: RATE-LIMITED` left over from an earlier round keeps showing long after that window has closed. A poller that treats `RATE-LIMITED` as a terminal state then stops on stale information and reports a verdict against a window that has already passed — which is how a review that had not yet been triggered got reported as rate-limited while #718 was being monitored.

The tell is already in the tool's own output: `WINDOW-OPENS` is printed relative to now, so a past value (`-1 min from now`) marks the notice as history rather than current state.

Kept as an addition to the existing section rather than a new entry — the surrounding advice (compute the deadline from the notice's `updated_at`, expect a fresh figure on a second refusal) already covers the moving-window behaviour; this is the one case it does not name.

@coderabbitai ignore
