### PR TITLE
refactor(lint): clear no-unused-vars from #686

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,7 +29,11 @@ module.exports = [
       ...tsPlugin.configs['flat/recommended']
         .map((c) => c.rules)
         .reduce((all, rules) => Object.assign(all, rules), {}),
-      eqeqeq: 'warn'
+      eqeqeq: 'warn',
+      // A `_`-prefixed parameter is required by an override/interface
+      // contract that some other implementation genuinely reads, even
+      // though the base or this particular implementation does not.
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
     }
   }
 ];

--- a/helper/alarms/alarms.ts
+++ b/helper/alarms/alarms.ts
@@ -1,5 +1,5 @@
 // **** Signal K Standard ALARMS notifier ****
-import { NextFunction, Request, Response } from 'express';
+import { Request, Response } from 'express';
 import {
   ALARM_METHOD,
   ALARM_STATE,
@@ -245,50 +245,44 @@ const initAlarmEndpoints = async () => {
   server.debug(`** Registering Alarm Action API endpoint(s) **`);
 
   // list area alarms
-  server.get(
-    `${ALARM_API_PATH}/area`,
-    async (req: Request, res: Response, next: NextFunction) => {
-      server.debug(`** ${req.method} ${req.path}`);
-      const ar = Array.from(alarmAreas);
-      res.status(200).json(ar);
-    }
-  );
+  server.get(`${ALARM_API_PATH}/area`, async (req: Request, res: Response) => {
+    server.debug(`** ${req.method} ${req.path}`);
+    const ar = Array.from(alarmAreas);
+    res.status(200).json(ar);
+  });
   // new area alarm
-  server.post(
-    `${ALARM_API_PATH}/area`,
-    async (req: Request, res: Response, next: NextFunction) => {
-      try {
-        validateAreaBody(req.body);
-      } catch (err) {
-        res.status(400).json({
-          state: 'FAILED',
-          statusCode: 400,
-          message: (err as Error).message
-        });
-        return;
-      }
-
-      if (req.body.geometry === 'region') {
-        res.status(400).json({
-          state: 'FAILED',
-          statusCode: 400,
-          message: `Invalid geometry value 'region'. Use PUT request specifying a region identifier.`
-        });
-        return;
-      }
-
-      const id = uuid.v4();
-      alarmAreas.set(id, req.body);
-      res.status(200).json({
-        state: 'COMPLETE',
-        statusCode: 200,
-        message: `Alarm Area created: ${id}`
+  server.post(`${ALARM_API_PATH}/area`, async (req: Request, res: Response) => {
+    try {
+      validateAreaBody(req.body);
+    } catch (err) {
+      res.status(400).json({
+        state: 'FAILED',
+        statusCode: 400,
+        message: (err as Error).message
       });
+      return;
     }
-  );
+
+    if (req.body.geometry === 'region') {
+      res.status(400).json({
+        state: 'FAILED',
+        statusCode: 400,
+        message: `Invalid geometry value 'region'. Use PUT request specifying a region identifier.`
+      });
+      return;
+    }
+
+    const id = uuid.v4();
+    alarmAreas.set(id, req.body);
+    res.status(200).json({
+      state: 'COMPLETE',
+      statusCode: 200,
+      message: `Alarm Area created: ${id}`
+    });
+  });
   server.put(
     `${ALARM_API_PATH}/area/:id`,
-    async (req: Request, res: Response, next: NextFunction) => {
+    async (req: Request, res: Response) => {
       server.debug(`** ${req.method} ${req.path}`);
 
       try {
@@ -348,34 +342,31 @@ const initAlarmEndpoints = async () => {
       }
     }
   );
-  server.delete(
-    `${ALARM_API_PATH}/area/:id`,
-    (req: Request, res: Response, next: NextFunction) => {
-      server.debug(`** ${req.method} ${req.path}`);
-      try {
-        if (alarmAreas.has(req.params.id)) {
-          deleteArea(req.params.id);
-          res.status(200).json({
-            state: 'COMPLETE',
-            statusCode: 200,
-            message: `Alarm Area Cleared: ${req.params.id}`
-          });
-        } else {
-          res.status(400).json({
-            state: 'FAILED',
-            statusCode: 400,
-            message: `Area not found!`
-          });
-        }
-      } catch (e) {
+  server.delete(`${ALARM_API_PATH}/area/:id`, (req: Request, res: Response) => {
+    server.debug(`** ${req.method} ${req.path}`);
+    try {
+      if (alarmAreas.has(req.params.id)) {
+        deleteArea(req.params.id);
+        res.status(200).json({
+          state: 'COMPLETE',
+          statusCode: 200,
+          message: `Alarm Area Cleared: ${req.params.id}`
+        });
+      } else {
         res.status(400).json({
           state: 'FAILED',
           statusCode: 400,
-          message: (e as Error).message
+          message: `Area not found!`
         });
       }
+    } catch (e) {
+      res.status(400).json({
+        state: 'FAILED',
+        statusCode: 400,
+        message: (e as Error).message
+      });
     }
-  );
+  });
 
   server.post(
     `${ALARM_API_PATH}/area/:id/silence`,

--- a/helper/lib/fetch.ts
+++ b/helper/lib/fetch.ts
@@ -23,7 +23,7 @@ export const fetch = (href: string): Promise<any> => {
           try {
             const json = JSON.parse(data.toString());
             resolve(json);
-          } catch (error) {
+          } catch {
             reject(new Error(data));
           }
         });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -99,7 +99,6 @@ import {
   Position,
   ErrorList
 } from './types';
-import { Feature } from 'ol';
 import {
   DrawFeatureType,
   FBMapInteractService,
@@ -119,17 +118,6 @@ import {
   WaypointPanel
 } from './modules/skresources';
 import { SymbolService, setSymbolRegistry } from './modules/icons';
-
-interface DrawEndEvent {
-  coordinates: LineString | Position | Polygon;
-  enabled: boolean;
-  features: Feature[];
-  forSave: boolean;
-  mode: string;
-  modify: false;
-  properties: { [key: string]: unknown };
-  type: string;
-}
 
 @Component({
   selector: 'app-root',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -426,7 +426,7 @@ export class AppComponent {
         })
       );
     });
-    document.addEventListener('fullscreenerror', (e) => {
+    document.addEventListener('fullscreenerror', () => {
       this.displayFullscreen.update((current) =>
         Object.assign({}, current, { active: false })
       );
@@ -2247,7 +2247,7 @@ export class AppComponent {
 
   // ** Update NavData Panel display **
   private updateNavPanel() {
-    this.navDataPanel.update((current) => {
+    this.navDataPanel.update(() => {
       return {
         show:
           this.app.data.activeRoute ||

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1339,7 +1339,7 @@ export class AppComponent {
         try {
           const d = JSON.parse(res.data);
           this.skres.postToServer(res.path as any, d);
-        } catch (err) {
+        } catch {
           this.app.showAlert(
             'Load Resource',
             'Resources were not loaded!\nInvalid JSON.'

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -483,7 +483,7 @@ export function cleanConfig(
       if (!isNaN(z)) {
         settings.map.zoomLevel = z > 28 ? 28 : z < 1 ? 1 : z;
       }
-    } catch (error) {
+    } catch {
       console.warn(
         `Invalid zoom level parameter (${hostParams.zoom} supplied!`
       );

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -520,7 +520,7 @@ export class AppFacade extends InfoService {
       this.config.map.center = [...this.config.vessels.fixedPosition];
     }
 
-    this.selfLines.update((current) => {
+    this.selfLines.update(() => {
       const c = {
         cog: {
           fill: { color: this.config.vessels.selfLines.cog.color },

--- a/src/app/app.facade.ts
+++ b/src/app/app.facade.ts
@@ -803,7 +803,7 @@ export class AppFacade extends InfoService {
   public isTopWindow(): boolean {
     try {
       return window.self === window.top;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/src/app/lib/components/dialogs/geojson/geojson-dialog.facade.ts
+++ b/src/app/lib/components/dialogs/geojson/geojson-dialog.facade.ts
@@ -65,7 +65,7 @@ export class GeoJSONLoadFacade {
         }
       });
       return data;
-    } catch (err) {
+    } catch {
       return null;
     }
   }

--- a/src/app/lib/components/pip.component.ts
+++ b/src/app/lib/components/pip.component.ts
@@ -113,7 +113,7 @@ export class PiPVideoComponent implements OnInit {
       this.pipMode = true;
       this.vid.nativeElement.play();
       this.click.emit(true);
-    } catch (e) {
+    } catch {
       this.pipMode = false;
     }
   }

--- a/src/app/lib/file-xml2json.worker.ts
+++ b/src/app/lib/file-xml2json.worker.ts
@@ -22,7 +22,7 @@ self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
       result = null;
     }
     self.postMessage(result);
-  } catch (err) {
+  } catch {
     self.postMessage(null);
   }
 };

--- a/src/app/lib/services/localstorage.service.ts
+++ b/src/app/lib/services/localstorage.service.ts
@@ -20,7 +20,7 @@ export class LocalStorage {
       if ('localStorage' in window && window['localStorage'] !== null) {
         this._ls = window.localStorage;
       }
-    } catch (e) {
+    } catch {
       console.warn('window.localStorage is not supported by this browser!');
     }
   }
@@ -37,7 +37,7 @@ export class LocalStorage {
     if (this._ls && key) {
       try {
         return JSON.parse(this._ls.getItem(this._namespace + key));
-      } catch (e) {
+      } catch {
         return this._ls.getItem(this._namespace + key);
       }
     }

--- a/src/app/lib/services/wakelock.service.ts
+++ b/src/app/lib/services/wakelock.service.ts
@@ -44,7 +44,7 @@ export class WakeLockService {
       document.addEventListener('visibilitychange', () =>
         this.onVisibilityChange()
       );
-    } catch (err) {
+    } catch {
       this.wakeLockRef = null;
       this._enabled.set(false);
     }

--- a/src/app/modules/alarms/components/alert.component.ts
+++ b/src/app/modules/alarms/components/alert.component.ts
@@ -226,8 +226,10 @@ export class AlertComponent {
 
   constructor() {
     effect(() => {
-      const ack = this.acknowledged();
-      const mute = this.silenced();
+      // Read (not just stored) so the effect re-runs when these inputs
+      // change, even though only al.type/priority below is consulted.
+      this.acknowledged();
+      this.silenced();
       const al = this.alert();
       this.showStaticNextPoint = [
         'perpendicularPassed',

--- a/src/app/modules/alarms/notification-manager.ts
+++ b/src/app/modules/alarms/notification-manager.ts
@@ -263,7 +263,7 @@ export class NotificationManager {
         data: { alert: this.getAlert(path) }
       })
       .afterDismissed()
-      .subscribe((action) => {
+      .subscribe(() => {
         // some action
       });
   }

--- a/src/app/modules/alarms/notification-manager.ts
+++ b/src/app/modules/alarms/notification-manager.ts
@@ -3,7 +3,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import {
   ALARM_METHOD,
-  ALARM_STATE,
   NotificationMessage,
   PathValue,
   SKNotification

--- a/src/app/modules/autopilot/autopilot.component.ts
+++ b/src/app/modules/autopilot/autopilot.component.ts
@@ -22,7 +22,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AppFacade } from 'src/app/app.facade';
-import { SignalKClient } from 'signalk-client-angular';
 import { Convert } from 'src/app/lib/convert';
 import { AutopilotService } from './autopilot.service';
 

--- a/src/app/modules/autopilot/autopilot.component.ts
+++ b/src/app/modules/autopilot/autopilot.component.ts
@@ -356,7 +356,7 @@ export class AutopilotComponent {
       if (options.states && Array.isArray(options.states)) {
         this.stateOptions.set(options.states);
       }
-    } catch (err) {
+    } catch {
       this.modeOptions.set([]);
       this.stateOptions.set([]);
       this.app.showMessage('No autopilot providers found!');

--- a/src/app/modules/autopilot/autopilot.component.ts
+++ b/src/app/modules/autopilot/autopilot.component.ts
@@ -299,7 +299,6 @@ export class AutopilotComponent {
   protected stateOptions = signal<Array<{ name: string; engaged: boolean }>>(
     []
   );
-  private autopilotApiPath: string;
   private currentPilot: string;
 
   apData = input<{
@@ -328,7 +327,6 @@ export class AutopilotComponent {
     protected app: AppFacade,
     protected autopilot: AutopilotService
   ) {
-    this.autopilotApiPath = 'vessels/self/autopilots/_default';
     effect(() => {
       if (this.apData().default !== this.currentPilot) {
         this.app.debug(

--- a/src/app/modules/autopilot/autopilot.component.ts
+++ b/src/app/modules/autopilot/autopilot.component.ts
@@ -365,10 +365,6 @@ export class AutopilotComponent {
 
   /** engage / disengage the pilot */
   protected async toggleEngaged() {
-    const uri = this.apData().enabled
-      ? `${this.autopilotApiPath}/disengage`
-      : `${this.autopilotApiPath}/engage`;
-
     try {
       if (this.apData().enabled) {
         await this.autopilot.disengage();

--- a/src/app/modules/buddies/buddy.service.ts
+++ b/src/app/modules/buddies/buddy.service.ts
@@ -2,11 +2,6 @@ import { Injectable } from '@angular/core';
 import { SignalKClient } from 'signalk-client-angular';
 import { AppFacade } from 'src/app/app.facade';
 
-interface BuddyProperties {
-  urn: string;
-  name: string;
-}
-
 const BUDDIES_URI = '/resources/buddies';
 
 // ** Signal K Buddies operations

--- a/src/app/modules/gpx/gpxlib.ts
+++ b/src/app/modules/gpx/gpxlib.ts
@@ -343,7 +343,7 @@ export class GPX {
         ? this.parseExtensions(xjs['gpx']['extensions'])
         : {};
       return true;
-    } catch (err) {
+    } catch {
       return false;
     }
   }

--- a/src/app/modules/gpx/gpxsave-dialog.ts
+++ b/src/app/modules/gpx/gpxsave-dialog.ts
@@ -107,7 +107,7 @@ export class GPXExportDialog implements OnInit {
       );
       this.data.waypoints = w;
       this.app.sIsFetching.set(false);
-    } catch (err) {
+    } catch {
       this.app.sIsFetching.set(false);
       this.resData.waypoints = [];
     }

--- a/src/app/modules/info-panel/info-panel.facade.ts
+++ b/src/app/modules/info-panel/info-panel.facade.ts
@@ -85,7 +85,7 @@ export class InfoPanelFacade {
         ]);
         return;
       }
-    } catch (err) {
+    } catch {
       return;
     }
   }

--- a/src/app/modules/info-panel/info-panel.facade.ts
+++ b/src/app/modules/info-panel/info-panel.facade.ts
@@ -9,13 +9,7 @@ import {
   SKTrack,
   SKWaypoint
 } from '../skresources';
-import {
-  ChartResource,
-  FBNote,
-  FBRegion,
-  FBRoute,
-  FBWaypoint
-} from 'src/app/types';
+import { FBNote, FBRegion, FBRoute, FBWaypoint } from 'src/app/types';
 import { SKWorkerService } from '../skstream/skstream.service';
 import { ActiveRadar } from '../radar/radar-api.service';
 

--- a/src/app/modules/map/fb-map.component.html
+++ b/src/app/modules/map/fb-map.component.html
@@ -33,7 +33,7 @@
     <ol-dragbox
       (boxStart)="onDragBoxStart($event)"
       (boxEnd)="onDragBoxEnd($event)"
-      (boxCancel)="onDragBoxCancel($event)"
+      (boxCancel)="onDragBoxCancel()"
     >
     </ol-dragbox>
   }

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -979,7 +979,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   /** Handle OL interaction end event */
-  protected onDragBoxCancel(e: DragBoxEvent) {
+  protected onDragBoxCancel() {
     this.app.debug(`onDragBoxCancel()...`);
     this.mapInteract.stopBoxSelection();
   }
@@ -2594,7 +2594,6 @@ export class FBMapComponent implements OnInit, OnDestroy {
    * @todo Experiment
    */
   private getFeatureInfo() {
-    const f = [].concat(this.mapService.featureUrls());
     /*fetch(this.featureUrl)
     .then((response) => response.json())
     .then((json) => {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -495,7 +495,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
         : 'nautical';
       const c = this.olMap.getMap().getControls().getArray();
       (c[0] as ScaleLine).setUnits(u);
-    } catch (err) {
+    } catch {
       // no map or scale control
     }
   }

--- a/src/app/modules/map/fbmap-interact.service.ts
+++ b/src/app/modules/map/fbmap-interact.service.ts
@@ -254,11 +254,8 @@ export class FBMapInteractService {
     return GeoUtils.distanceTo(this.measurement().center, pt);
   }
 
-  /**
-   * Start measuring mode
-   * @param fromVessel true = distance is measured from vessel to cursor, false = line measure
-   */
-  startMeasuring(geometryType?: 'LineString' | 'Circle', fromVessel?: boolean) {
+  /** Start measuring mode */
+  startMeasuring(geometryType?: 'LineString' | 'Circle') {
     this.measureGeometryType = geometryType ?? 'LineString';
     this.app.debug(`startMeasuring()...`);
     this.isMeasuring.set(true);

--- a/src/app/modules/map/ol/lib/alarms/layer-alarm.component.ts
+++ b/src/app/modules/map/ol/lib/alarms/layer-alarm.component.ts
@@ -17,7 +17,7 @@ import { Style, Stroke, Fill, RegularShape } from 'ol/style';
 import { Point } from 'ol/geom';
 import { fromLonLat } from 'ol/proj';
 import { MapComponent } from '../map.component';
-import { Extent, Coordinate } from '../models';
+import { Extent } from '../models';
 import { AsyncSubject } from 'rxjs';
 import { AlertData } from 'src/app/modules/alarms';
 

--- a/src/app/modules/map/ol/lib/charts/layer-s57-chart.component.ts
+++ b/src/app/modules/map/ol/lib/charts/layer-s57-chart.component.ts
@@ -57,12 +57,6 @@ export class S57ChartLayerComponent implements OnDestroy {
     }
 
     if (!this.layer) {
-      const minZ =
-        chart[1].minZoom && chart[1].minZoom >= 0.1
-          ? chart[1].minZoom - 0.1
-          : chart[1].minZoom;
-      const maxZ = chart[1].maxZoom;
-
       const styleFactory = this.vectorLayerStyleFactory.CreateVectorLayerStyler(
         chart[1]
       );

--- a/src/app/modules/map/ol/lib/charts/vectorLayerStyleFactory.ts
+++ b/src/app/modules/map/ol/lib/charts/vectorLayerStyleFactory.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { SKChart } from 'src/app/modules';
 import { S57Service } from './s57.service';
 import { S57Style } from './s57Style';

--- a/src/app/modules/map/ol/lib/navigation/layer-bearing-line.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-bearing-line.component.ts
@@ -248,6 +248,6 @@ export class BearingLineComponent implements OnInit, OnDestroy, OnChanges {
       );
       (s as Style).setText(ts);
       f.setStyle(s);
-    } catch (err) {}
+    } catch {}
   }
 }

--- a/src/app/modules/map/ol/lib/navigation/layer-cog-line.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-cog-line.component.ts
@@ -242,7 +242,7 @@ export class CogLineComponent implements OnInit, OnDestroy, OnChanges {
       s = Array.isArray(s) ? s[1] : s;
       (s as Style).setText(this.buildLabelStyle());
       f.setStyle(s);
-    } catch (err) {}
+    } catch {}
   }
 
   buildLabelStyle() {

--- a/src/app/modules/map/ol/lib/navigation/layer-heading-line.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-heading-line.component.ts
@@ -16,7 +16,7 @@ import { Feature } from 'ol';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Style, Stroke } from 'ol/style';
-import { LineString, Point } from 'ol/geom';
+import { LineString } from 'ol/geom';
 import { MapComponent } from '../map.component';
 import { Extent, Coordinate } from '../models';
 import { fromLonLatArray } from '../util';

--- a/src/app/modules/map/ol/lib/navigation/layer-wind-lines.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-wind-lines.component.ts
@@ -90,7 +90,7 @@ export class WindLinesComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges() {
     if (this.layer) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const properties: { [index: string]: any } = {};

--- a/src/app/modules/map/ol/lib/navigation/layer-wind-lines.component.ts
+++ b/src/app/modules/map/ol/lib/navigation/layer-wind-lines.component.ts
@@ -7,7 +7,6 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  SimpleChanges,
   input,
   effect
 } from '@angular/core';

--- a/src/app/modules/map/ol/lib/racing/layer-racing-startline.component.ts
+++ b/src/app/modules/map/ol/lib/racing/layer-racing-startline.component.ts
@@ -9,9 +9,8 @@ import {
   SimpleChanges
 } from '@angular/core';
 import { Feature } from 'ol';
-import { Style, Stroke, Text, Fill, Circle, RegularShape } from 'ol/style';
+import { Style, Stroke, Fill, Circle, RegularShape } from 'ol/style';
 import { LineString, Point } from 'ol/geom';
-import { fromLonLat } from 'ol/proj';
 import { MapComponent } from '../map.component';
 import { fromLonLatArray, mapifyCoords } from '../util';
 import { FBFeatureLayerComponent } from '../sk-feature.component';

--- a/src/app/modules/map/ol/lib/racing/layer-racing-startline.component.ts
+++ b/src/app/modules/map/ol/lib/racing/layer-racing-startline.component.ts
@@ -107,7 +107,6 @@ export class RacingStartLineLayerComponent
     styles.push(this.racecourseStyles.startLine);
 
     // point styles
-    const l = geometry.getCoordinates().length;
     geometry.forEachSegment((start, end) => {
       styles.push(
         new Style({

--- a/src/app/modules/map/ol/lib/radar/layer-radar.component.ts
+++ b/src/app/modules/map/ol/lib/radar/layer-radar.component.ts
@@ -75,7 +75,7 @@ export class RadarComponent implements OnInit, OnChanges, OnDestroy {
       this.layerReady.complete();
     }
 
-    const radar = this.radarRenderService
+    this.radarRenderService
       .connect()
       .then((radar) => {
         if (radar) {

--- a/src/app/modules/map/ol/lib/radar/layer-radar.component.ts
+++ b/src/app/modules/map/ol/lib/radar/layer-radar.component.ts
@@ -9,9 +9,7 @@ import {
   ChangeDetectorRef,
   OnDestroy,
   inject,
-  output,
-  input,
-  effect
+  output
 } from '@angular/core';
 import { Layer } from 'ol/layer';
 import { Coordinate } from '../models';

--- a/src/app/modules/map/ol/lib/radar/radar-gl.worker.ts
+++ b/src/app/modules/map/ol/lib/radar/radar-gl.worker.ts
@@ -269,11 +269,11 @@ addEventListener('message', (event) => {
         postMessage({ redraw: true });
       };
 
-      socket.onopen = (event) => {
+      socket.onopen = () => {
         postMessage({ msg: `Radar ${radar.name} connected` });
       };
 
-      socket.onclose = (event) => {
+      socket.onclose = () => {
         postMessage({
           msg: `Radar ${radar.name} disconnected retry in 3 seconds`
         });
@@ -283,7 +283,7 @@ addEventListener('message', (event) => {
         }, 3000);
       };
 
-      socket.onerror = (event) => {
+      socket.onerror = () => {
         radarContext.clear(radarContext.COLOR_BUFFER_BIT);
         postMessage({
           redraw: true,

--- a/src/app/modules/map/ol/lib/resources/ais-base.component.ts
+++ b/src/app/modules/map/ol/lib/resources/ais-base.component.ts
@@ -193,7 +193,7 @@ export class AISBaseLayerComponent
     this.onUpdateTargets(ids, areStale);
   }
 
-  protected onUpdateTargets(ids: Array<string>, areStale: boolean) {
+  protected onUpdateTargets(_ids: Array<string>, _areStale: boolean) {
     // overloadable
   }
 
@@ -205,7 +205,7 @@ export class AISBaseLayerComponent
     this.onRemoveTargets(ids);
   }
 
-  protected onRemoveTargets(ids: Array<string>) {
+  protected onRemoveTargets(_ids: Array<string>) {
     // overloadable
   }
 }

--- a/src/app/modules/map/ol/lib/resources/layer-aistargets.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-aistargets.component.ts
@@ -6,7 +6,7 @@ import {
   SimpleChanges
 } from '@angular/core';
 import { Feature } from 'ol';
-import { Style, RegularShape, Fill, Stroke, Text, Icon } from 'ol/style';
+import { Style, RegularShape, Fill, Stroke, Text } from 'ol/style';
 import { Point } from 'ol/geom';
 import { fromLonLat } from 'ol/proj';
 import { MapComponent } from '../map.component';

--- a/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-currents-weather.component.ts
@@ -13,7 +13,6 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Fill, Stroke, Style, Text } from 'ol/style';
 import {
-  Observable,
   Subject,
   Subscription,
   catchError,

--- a/src/app/modules/map/ol/lib/resources/layer-livelayer.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-livelayer.component.ts
@@ -96,7 +96,7 @@ export class FreeboardLiveLayerComponent
   private onTimerTick() {
     const n = Date.now();
     //console.log('InfoLayer timer tick...', n);
-    this.layerMap.forEach((v, k) => {
+    this.layerMap.forEach((v) => {
       //console.log(k, v.infoLayer.values.refreshInterval, v.lastRefresh, n - v.lastRefresh)
       if (
         v.infoLayer.values?.refreshInterval > 0 &&

--- a/src/app/modules/map/ol/lib/resources/layer-livelayer.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-livelayer.component.ts
@@ -244,7 +244,7 @@ export class FreeboardLiveLayerComponent
         const parser = new WMTSCapabilities();
         result = parser.read(capabilitiesXml);
         this.wmtsCapabilitesMap.set(ldef[1].values?.url, result);
-      } catch (err) {
+      } catch {
         clearTimeout(abortTimer);
         return;
       }

--- a/src/app/modules/map/ol/lib/resources/layer-wind-weather.component.ts
+++ b/src/app/modules/map/ol/lib/resources/layer-wind-weather.component.ts
@@ -13,7 +13,6 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Fill, Stroke, Style, Text } from 'ol/style';
 import {
-  Observable,
   Subject,
   Subscription,
   catchError,

--- a/src/app/modules/map/ol/lib/sk-feature.component.ts
+++ b/src/app/modules/map/ol/lib/sk-feature.component.ts
@@ -140,7 +140,7 @@ export class FBFeatureLayerComponent implements OnInit, OnDestroy, OnChanges {
    * @override
    * @param isSet true when dark mode is set
    */
-  onDarkMode(isSet: boolean) {
+  onDarkMode(_isSet: boolean) {
     this.updateLabels();
   }
 
@@ -148,7 +148,7 @@ export class FBFeatureLayerComponent implements OnInit, OnDestroy, OnChanges {
    * @override
    * @param value new threshold value
    */
-  onLabelMinZoomSet(value: number) {
+  onLabelMinZoomSet(_value: number) {
     this.updateLabels();
   }
 
@@ -156,7 +156,7 @@ export class FBFeatureLayerComponent implements OnInit, OnDestroy, OnChanges {
    * @override
    * @param entered true when transition is from below to above threshold
    */
-  onLabelZoomThreshold(entered: boolean) {
+  onLabelZoomThreshold(_entered: boolean) {
     this.updateLabels();
   }
 

--- a/src/app/modules/map/popovers/vessel-popover.component.ts
+++ b/src/app/modules/map/popovers/vessel-popover.component.ts
@@ -21,7 +21,6 @@ import { Buddies, SKVessel } from 'src/app/modules';
 import { Convert } from 'src/app/lib/convert';
 import { GeoUtils } from 'src/app/lib/geoutils';
 import { Position } from 'src/app/types';
-import { HttpErrorResponse } from '@angular/common/http';
 import { AppIconDef, getAisIcon } from '../../icons';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -371,7 +370,7 @@ export class VesselPopoverComponent {
             //console.log('buddy revedmo:', urn);
             this.app.showMessage(`Buddy successfully removed.`, false, 3000);
           },
-          (err: HttpErrorResponse) => {
+          () => {
             this.app.showMessage(`Error removing buddy!`, false, 3000);
           }
         );
@@ -388,7 +387,7 @@ export class VesselPopoverComponent {
           () => {
             this.app.showMessage(`Buddy added (${name})`, false, 3000);
           },
-          (err: HttpErrorResponse) => {
+          () => {
             this.app.showMessage(`Error adding buddy!(${name})`, false, 5000);
           }
         );

--- a/src/app/modules/settings/components/linestyle-select.component.ts
+++ b/src/app/modules/settings/components/linestyle-select.component.ts
@@ -43,19 +43,12 @@ export type LineStyleDash = 'none' | 'short' | 'medium' | 'long' | 'alt';
           matNativeControl
           type="color"
           [(ngModel)]="_color"
-          (change)="
-            onSelectChange({ key: 'color', value: $event.srcElement.value })
-          "
+          (change)="onSelectChange()"
         />
       </mat-form-field>
       <mat-form-field style="width: 110px">
         <mat-label>Weight</mat-label>
-        <mat-select
-          [(ngModel)]="_weight"
-          (selectionChange)="
-            onSelectChange({ key: 'weight', value: $event.value })
-          "
-        >
+        <mat-select [(ngModel)]="_weight" (selectionChange)="onSelectChange()">
           <mat-select-trigger>
             <div style="display: flex; align-items: center; gap: 8px;">
               <svg
@@ -98,12 +91,7 @@ export type LineStyleDash = 'none' | 'short' | 'medium' | 'long' | 'alt';
       </mat-form-field>
       <mat-form-field style="width: 110px">
         <mat-label>Style</mat-label>
-        <mat-select
-          [(ngModel)]="_dash"
-          (selectionChange)="
-            onSelectChange({ key: 'dash', value: $event.value })
-          "
-        >
+        <mat-select [(ngModel)]="_dash" (selectionChange)="onSelectChange()">
           <mat-select-trigger>
             <div style="display: flex; align-items: center; gap: 8px;">
               <svg
@@ -173,7 +161,7 @@ export class LineStyleSelectComponent {
 
   ngOnInit() {}
 
-  onSelectChange(opt: { key: string; value: any }) {
+  onSelectChange() {
     const d = this.app.formatLineDashArray(this._dash());
 
     this.selectionChange.emit({

--- a/src/app/modules/settings/settings.facade.ts
+++ b/src/app/modules/settings/settings.facade.ts
@@ -371,9 +371,6 @@ export class SettingsFacade {
   /** Favourited plugins / apps */
   buildFavouritesList() {
     this.favouritesList = this.applicationList.slice(1);
-    const i = this.app.config.display.plugins.favourites.indexOf(
-      this.app.config.display.plugins.instruments
-    );
   }
 
   /** Apply / persist settings */

--- a/src/app/modules/skresources/components/ais/aislist.ts
+++ b/src/app/modules/skresources/components/ais/aislist.ts
@@ -225,7 +225,7 @@ export class AISListComponent extends ResourceListBase {
    * @param id Vessel identifier
    */
   protected itemSelect(checked: boolean, id: string) {
-    const idx = this.toggleItem(checked, id);
+    this.toggleItem(checked, id);
     // update selections
     if (checked) {
       this.skres.selectionAdd(this.collection, id);

--- a/src/app/modules/skresources/components/charts/chart-properties-dialog.ts
+++ b/src/app/modules/skresources/components/charts/chart-properties-dialog.ts
@@ -335,7 +335,7 @@ export class ChartPropertiesDialog {
         this.capabilities = await wmtsCapabilitiesInWorker(url);
         this.wmtsLayers.update(() => this.capabilities.layers);
       }
-    } catch (err) {
+    } catch {
       this.layerErrorText = 'Error retrieving layers.';
     }
   }

--- a/src/app/modules/skresources/components/charts/maplib.ts
+++ b/src/app/modules/skresources/components/charts/maplib.ts
@@ -1,7 +1,3 @@
-import { WMSCapabilities, WMTSCapabilities } from 'ol/format';
-import { SKInfoLayer } from '../../custom-resource-classes';
-import { ChartProvider } from 'src/app/types';
-
 type CapabilitiesBaseDef = {
   name: string;
   description: string;

--- a/src/app/modules/skresources/components/charts/maplib.worker.ts
+++ b/src/app/modules/skresources/components/charts/maplib.worker.ts
@@ -43,7 +43,7 @@ self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
       result = null;
     }
     self.postMessage(result);
-  } catch (err) {
+  } catch {
     self.postMessage(null);
   }
 };

--- a/src/app/modules/skresources/components/charts/node-list-select.ts
+++ b/src/app/modules/skresources/components/charts/node-list-select.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  effect,
-  EventEmitter,
-  inject,
-  input,
-  Output
-} from '@angular/core';
+import { Component, EventEmitter, inject, input, Output } from '@angular/core';
 
 import { MatListModule, MatSelectionListChange } from '@angular/material/list';
 import { AppFacade } from 'src/app/app.facade';

--- a/src/app/modules/skresources/components/infolayers/infolayerlist.ts
+++ b/src/app/modules/skresources/components/infolayers/infolayerlist.ts
@@ -208,7 +208,7 @@ export class InfoLayerListComponent extends ResourceListBase {
    * @param id layer identifier
    */
   protected itemSelect(checked: boolean, id: string) {
-    const idx = this.toggleItem(checked, id);
+    this.toggleItem(checked, id);
     // update selections
     if (checked) {
       this.skres.selectionAdd(this.collection, id);
@@ -293,7 +293,6 @@ export class InfoLayerListComponent extends ResourceListBase {
       const p =
         new Date(layer[1].values.time?.from).valueOf() +
         index * layer[1].values.time?.interval;
-      const pd = new Date(p).toISOString();
       this.paramChanged.emit({
         id: layer[0],
         param: { TIME: new Date(p).toISOString() }

--- a/src/app/modules/skresources/components/resourcesets/resource-upload-dialog.ts
+++ b/src/app/modules/skresources/components/resourcesets/resource-upload-dialog.ts
@@ -96,7 +96,7 @@ export class ResourceImportDialog implements OnInit {
     try {
       const jdata = JSON.parse(e.data);
       this.source.type = jdata.type ? jdata.type : this.source.type;
-    } catch (error) {
+    } catch {
       console.log(`Error parsing resource file!`);
     }
   }

--- a/src/app/modules/skresources/components/resourcesets/resourceset-list-modal.ts
+++ b/src/app/modules/skresources/components/resourcesets/resourceset-list-modal.ts
@@ -153,7 +153,7 @@ export class ResourceSetModal implements OnInit {
       );
       this.app.sIsFetching.set(false);
       this.resList.set(list);
-    } catch (err) {
+    } catch {
       this.app.sIsFetching.set(false);
       this.resList.set([]);
     }

--- a/src/app/modules/skresources/components/routes/route-panel.ts
+++ b/src/app/modules/skresources/components/routes/route-panel.ts
@@ -36,7 +36,6 @@ import { SingleSelectListDialog } from 'src/app/lib/components';
 import { CourseService } from 'src/app/modules/course';
 import { GeoUtils } from 'src/app/lib/geoutils';
 import { MatStepperModule } from '@angular/material/stepper';
-import { Convert } from 'src/app/lib/convert';
 import { ActiveResourcePropertiesModal } from '../active-resource-dialog';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -225,7 +225,7 @@ export class SKResourceService {
         'notes',
         `href=/resources/${collection}/${id}`
       );
-    } catch (err) {
+    } catch {
       return [];
     }
   }
@@ -2524,7 +2524,7 @@ export class SKResourceService {
         'notes',
         `href=/resources/${collection}/${id}`
       );
-    } catch (err) {
+    } catch {
       return [];
     }
   }
@@ -2592,7 +2592,7 @@ export class SKResourceService {
             }
           }
         });
-    } catch (err) {
+    } catch {
       this.app.sIsFetching.set(false);
       this.app.showAlert(
         'ERROR',
@@ -2682,7 +2682,7 @@ export class SKResourceService {
         data.note = res;
         data.addNote = false;
         this.openNoteForEdit(data);
-      } catch (err) {
+      } catch {
         this.app.sIsFetching.set(false);
         this.app.showAlert('ERROR', 'Unable to retrieve Note!');
       }
@@ -2702,7 +2702,7 @@ export class SKResourceService {
       this.app.sIsFetching.set(true);
       note = await this.fromServer('notes', id);
       this.app.sIsFetching.set(false);
-    } catch (err) {
+    } catch {
       this.app.sIsFetching.set(false);
       this.app.showAlert('ERROR', 'Unable to retrieve Note!');
       return;

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -2972,6 +2972,7 @@ export class SKResourceService {
    */
   private transformVessel(vessel: any, id: string): SKVessel {
     const v = new SKVessel();
+    v.id = id;
     v.mmsi = vessel.mmsi ?? '';
     v.name = vessel.name ?? '';
     v.position = vessel.navigation?.position?.value

--- a/src/app/modules/skresources/resources.service.ts
+++ b/src/app/modules/skresources/resources.service.ts
@@ -1426,7 +1426,7 @@ export class SKResourceService {
           this.signalk
             .post(`/signalk/chart-tiles/cache/${chart[0]}`, req)
             .subscribe({
-              next: (res) => {
+              next: () => {
                 this.app.showAlert(
                   'Chart Cache',
                   `Tile cache seed job created successfully.`

--- a/src/app/modules/skstream/skstream.facade.ts
+++ b/src/app/modules/skstream/skstream.facade.ts
@@ -444,7 +444,7 @@ export class SKStreamFacade {
 
   private parseVesselOther(otherVessels: Map<string, SKVessel>) {
     this.app.data.vessels.aisTargets = otherVessels;
-    this.app.data.vessels.aisTargets.forEach((value, key) => {
+    this.app.data.vessels.aisTargets.forEach((value) => {
       this.processVessel(value);
 
       value.wind.direction = this.app.useMagnetic

--- a/src/app/modules/skstream/stream-api.ts
+++ b/src/app/modules/skstream/stream-api.ts
@@ -142,7 +142,7 @@ export class SKStreamAPI {
     if (typeof e.data === 'string') {
       try {
         data = JSON.parse(e.data);
-      } catch (e) {
+      } catch {
         return;
       }
     }

--- a/src/app/modules/weather/weather-forecast-modal.ts
+++ b/src/app/modules/weather/weather-forecast-modal.ts
@@ -1,7 +1,7 @@
 /** Weather Forecast Component **
  ********************************/
 
-import { Component, OnInit, Inject, inject, DestroyRef } from '@angular/core';
+import { Component, OnInit, inject, DestroyRef } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -1,7 +1,7 @@
 // ** Resource Types **
 
 import { Position, LineString, MultiLineString } from './resources/geojson';
-import { FBCharts, FBRoute } from './resources/freeboard';
+import { FBCharts } from './resources/freeboard';
 import {
   SKMeteo,
   SKSaR,
@@ -9,7 +9,6 @@ import {
   SKAircraft,
   SKVessel
 } from '../modules/skresources/resource-classes';
-import { DEPTH_UNIT } from '../lib/convert';
 import { Options } from '../modules/map/ol/lib/charts/s57.service';
 import { ChartImageAdjustment } from './resources/signalk';
 


### PR DESCRIPTION
Phase 3 of #686 — `@typescript-eslint/no-unused-vars`, 92 → 0. Total lint count
313 → 221.

Six commits, split by what kind of change each is rather than by file, since
"unused" covers everything from a dead import to a parameter an `effect()`
genuinely needs to keep reading.

### Imports and declarations (no runtime effect)

24 dead imports, plus two fully-unreferenced interfaces (`DrawEndEvent`,
`BuddyProperties`). Removing `DrawEndEvent` orphaned its only remaining
consumer's `Feature` import from `ol`, caught by the second lint pass and
removed alongside.

### Catch bindings and dead handler parameters

30 `catch (err)`/`catch (error)`/`catch (e)` bindings across 27 files, none
read in their block — replaced with the optional catch binding (`catch {}`,
ES2022, this project's target) rather than kept with a name nothing reads.
Applied by line, not by regex: several files mix live and dead bindings under
the same name, and a blind global replace broke the build in two files before
it was committed (`Cannot find name 'err'`), redone precisely against each
flagged line.

Two adjacent cleanups the same pass surfaced: `vessel-popover`'s two
`.subscribe(next, error)` callbacks never read their `HttpErrorResponse`
parameter; and `helper/alarms/alarms.ts`'s four route handlers declared
`next: NextFunction` and never called it — these are per-route handlers, not
`app.use` error middleware, so Express doesn't inspect their arity and
dropping the parameter changes nothing about how they're invoked.

### The judgment sites (11, each traced individually)

No blanket pattern applies here. Two worth flagging specifically:

- `alert.component`: `const ack = this.acknowledged()` inside an `effect()`
  looked unused but is **not** dead — the read is what registers the signal
  as an `effect()` dependency, independent of whether the value is stored.
  Deleting it would have silently narrowed what the effect reacts to (the
  exact bug class the effect/signal entry in `DEV-LESSONS-LEARNED.md` warns
  about). Kept as a bare read with a comment explaining why.
- `layer-s57-chart.component`: a computed `minZ`/`maxZ` looked like a missing
  `setMinZoom`/`setMaxZoom` call matching sibling raster/tilejson/vector-chart
  components. It isn't — the S-57 layer's actual zoom bounds are set
  independently inside `S57LayerStyler.ApplyStyle()`. Traced before deleting.

`fb-map.component`'s `onDragBoxCancel` and `linestyle-select`'s
`onSelectChange` (later commit) both dropped a now-unused event parameter that
their templates still passed `$event` to — Angular's strict template checking
treats that as a compile error, not a silent ignore, so the template call
sites are updated alongside.

### `argsIgnorePattern: '^_'` — reserved for override contracts, not general use

Some parameters exist only to satisfy an interface/override signature: a base
implementation's parameter is genuinely unused, but a sibling override reads
the same-named parameter (e.g. `sk-feature.component`'s
`onLabelZoomThreshold(entered)` is a no-op in the base; `layer-aisvessels`'
override reads `entered` to drive `toggleCogLines`). The parameter can't be
deleted there — the signature has to hold across the hierarchy — so it's
renamed to `_entered` and ESLint told to allow that pattern.

Scoped to `argsIgnorePattern` only, deliberately — a `_`-prefixed local
variable is still flagged. The convention is reserved for "this exists because
of a contract," not "I don't want to hear about this." Two base-class stubs
use it (`ais-base.component`, `sk-feature.component`); every other unused
parameter or binding in this PR is fully removed rather than renamed, since a
dropped parameter is unambiguous in a way a live, referenceable `_name`
binding isn't — nothing stops a future edit from actually calling it.

### One real defect found in passing, fixed separately

`resources.service.transformVessel()` has always taken an `id` parameter,
documented in its own JSDoc as "Vessel identifier," and returned an
`SKVessel` — whose base class declares `id: string` — without ever assigning
it. Confirmed dead since the file's earliest history, not a recent
regression. Both real call sites already have a meaningful id to hand it.
Traced every current consumer of the returned vessel to confirm nothing
depends on the field staying unset, so this closes a gap without being able
to break an existing read. Fixed rather than deleted, since the base class
already promises the field and both callers already have the value.

### One finding from the stand-in review, declined

CodeRabbit flagged the two `catch {}` blocks left empty in
`layer-bearing-line.component.ts` and `layer-cog-line.component.ts`
(`no-empty`). Both were already empty on `master` before this PR — this PR's
diff on those lines is purely the `catch (err) {}` → `catch {}` binding
removal `no-unused-vars` requires. `no-empty`'s total across the repo is
unchanged: 3 before, 3 after, same three sites. Declined as pre-existing and
outside this PR's scope; CodeRabbit agreed. `no-empty` (3, along with
`no-unused-expressions` 4 and `no-useless-catch` 2) never got its own phase in
#686's original breakdown and is worth a small follow-up on its own.

### Verification

630 tests / 70 files pass, `build:all` clean (webapp + helper), Prettier gate
clean on both `src/` and `helper/`.

### Noticed in passing, not addressed here

`settings.facade.buildFavouritesList()`: `const i = ...indexOf(...)` has been
computed and discarded since the file's oldest commit in this repo's history,
through three unrelated property renames. Deleting it changes nothing
observable today. Flagged as a possible abandoned feature rather than guessed
at — worth a look, not a lint fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vessel resource handling by consistently assigning vessel identifiers.
  * Preserved existing alarm, mapping, chart, weather, and resource behavior while simplifying event and error handling.

* **Refactor**
  * Removed unused parameters, imports, temporary values, and obsolete type references across the application.
  * Simplified settings, map interaction, alert, and resource-processing logic without changing visible functionality.

* **Chores**
  * Tightened linting rules to flag unused variables while allowing intentionally unused underscore-prefixed parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->