### PR TITLE
fix(alarms): register endpoints synchronously so failures reach doStartup

### DIFF
--- a/helper/alarms/alarms.ts
+++ b/helper/alarms/alarms.ts
@@ -241,7 +241,11 @@ const handleDeltaMessage = (delta: Delta) => {
   });
 };
 
-const initAlarmEndpoints = async () => {
+// Not async: the body registers routes synchronously (the only `await` below
+// is inside a route handler, which runs per-request). Marking it async made
+// the call in initAlarms() a floating promise, so anything thrown here became
+// an unhandled rejection that bypassed doStartup()'s try/catch entirely.
+const initAlarmEndpoints = () => {
   server.debug(`** Registering Alarm Action API endpoint(s) **`);
 
   // list area alarms


### PR DESCRIPTION
## Summary

`master` is red. Every non-armv7 job in
[run 33705699610](https://github.com/SignalK/freeboard-sk/actions/runs/33705699610)
fails the plugin-ci lifecycle check with:

```
::error::Lifecycle: unhandled rejection: server.get is not a function
```

This fixes the cause in the helper plugin. It is a one-word change plus a
comment.

## What is actually wrong

`initAlarmEndpoints()` is declared `async` but does no asynchronous work of its
own — the single `await` inside it is in a route handler, which runs
per-request, not during registration. `initAlarms()` then calls it **without
awaiting**, so the result is a floating promise.

That silently defeats the plugin's own error handling. `doStartup()` wraps
startup in a `try`/`catch` that reports through `setPluginError()`, but a
rejected floating promise never travels that path — anything thrown while
registering the alarm endpoints escapes as an unhandled rejection instead of
being caught and reported. The `try`/`catch` looks like it covers endpoint
registration and does not.

Dropping `async` removes the promise, so a throw propagates synchronously into
the existing `try`/`catch`.

## Why this is not a behaviour change

An `async` function body already runs synchronously up to its first `await`, and
there is none here — so registration ordering is identical. On a running server
`server.get()` exists and nothing throws, so this changes nothing in production.
What changes is only where a failure *would* go if one ever occurred: into the
handler that was always meant to receive it.

## Why it surfaced now

Nothing in Freeboard changed. `ci.yml` floats on
`SignalK/signalk-server/.github/workflows/plugin-ci.yml@master`, and that shared
workflow gained an async crash trap (`process.on('unhandledRejection')`) in
SignalK/signalk-server@a9dc80e6 on 2026-09-02. #720's own PR run predates that
commit and was green; the merge run picked it up.

The CI mock app provides no Express routing surface (no `get`/`post`/`use`), so
registration throws there. The floating promise is what turned that into a
process-level rejection rather than a caught, reported startup error — so this
is a true positive about the plugin, not CI noise.

## Verification

Extracted the lifecycle check's own script from the shared workflow and ran it
locally against the built plugin:

| | result |
|---|---|
| `master` (861ff935) | **fails**, exit 1 — reproduces the CI error exactly |
| this branch | **passes**, exit 0 |

Also confirmed `npm run format:check` clean, and that `eslint helper/alarms/alarms.ts`
reports the same 4 pre-existing `no-explicit-any` violations before and after
(those are #686 phase 5).

## Follow-up, not in this PR

The lifecycle check prints `Plugin lifecycle (start/stop/restart) is clean` and
exits 0 even while the plugin logs `error: Started with errors!` and registers
zero endpoints — it never consults `setPluginError()`. Reported separately
upstream, along with the mock lacking a routing surface.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
