### PR TITLE
feat(map): resume follow mode after a configurable idle period

### DIFF
--- a/features/changelog.json
+++ b/features/changelog.json
@@ -73,5 +73,6 @@
   { "feature": null, "kind": "skip", "date": "2026-05-23", "title": "perf(s57): cache derived text-style config across features", "reason": "performance work — no change to what the user can do" },
   { "feature": null, "kind": "skip", "date": "2026-04-04", "title": "perf: defer S57 chart symbols loading until first use", "reason": "performance work — no change to what the user can do" },
   { "feature": "chart-list", "pr": 680, "kind": "enhanced", "since": "v3.1.0", "date": "2026-08-08", "title": "feat(charts): re-order charts from the chart list itself" },
-  { "feature": "chart-zoom-limits", "pr": 679, "kind": "enhanced", "since": "v3.1.0", "date": "2026-08-08", "title": "feat(charts): add a per-chart minimum zoom level" }
+  { "feature": "chart-zoom-limits", "pr": 679, "kind": "enhanced", "since": "v3.1.0", "date": "2026-08-08", "title": "feat(charts): add a per-chart minimum zoom level" },
+  { "feature": "follow-vessel", "kind": "enhanced", "date": "2026-09-02", "title": "feat(map): resume follow mode after a configurable idle period" }
 ]

--- a/features/changelog.json
+++ b/features/changelog.json
@@ -74,5 +74,5 @@
   { "feature": null, "kind": "skip", "date": "2026-04-04", "title": "perf: defer S57 chart symbols loading until first use", "reason": "performance work — no change to what the user can do" },
   { "feature": "chart-list", "pr": 680, "kind": "enhanced", "since": "v3.1.0", "date": "2026-08-08", "title": "feat(charts): re-order charts from the chart list itself" },
   { "feature": "chart-zoom-limits", "pr": 679, "kind": "enhanced", "since": "v3.1.0", "date": "2026-08-08", "title": "feat(charts): add a per-chart minimum zoom level" },
-  { "feature": "follow-vessel", "kind": "enhanced", "date": "2026-09-02", "title": "feat(map): resume follow mode after a configurable idle period" }
+  { "feature": "follow-vessel", "pr": 726, "kind": "enhanced", "date": "2026-09-02", "title": "feat(map): resume follow mode after a configurable idle period" }
 ]

--- a/features/follow-vessel.md
+++ b/features/follow-vessel.md
@@ -67,3 +67,20 @@ follow mode is on:
 - **Do nothing** — follow mode stays on and the vessel returns to its usual position on
   the next position update. Worth choosing at the helm, where a stray touch shouldn't
   disturb the view.
+
+### Getting follow mode back on its own
+
+Choosing **Exit Follow Mode** reveals a companion setting, **Resume Following After**.
+Leave it at **Never** and nothing changes — follow mode stays off until you press the
+button. Pick a delay instead and the chart hands itself back: pan across to look at what
+is ahead, and once you have left it alone that long the boat returns to the screen on its
+own.
+
+The wait measures idle time, not time since the pan. Every pan and every zoom starts it
+over, so you can take as long as you like looking around and the chart only comes back
+once you have actually stopped. Turning follow mode off with the button is left alone —
+that stays off, so you can still park the chart somewhere deliberately.
+
+Worth setting when the display is out of easy reach, or when whoever is watching it would
+rather not hunt for the Follow button: a quick pan to check the water ahead, then back to
+the boat without touching anything.

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1059,6 +1059,7 @@
               (activate)="activateRoute($event)"
               (deactivate)="clearDestination()"
               (exitMovingMap)="toggleMoveMap($event)"
+              (resumeMovingMap)="resumeMoveMap()"
               (focusVessel)="switchActiveVessel($event)"
               (info)="featureProperties($event)"
               (menuItemSelected)="handleContextMenuSelection($event)"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -489,6 +489,14 @@ export class AppComponent {
     this.focusMap();
   }
 
+  /** Follow mode resumed by the idle timer after a pan released it (#714). */
+  protected resumeMoveMap() {
+    this.app.uiConfig.update((current) => {
+      return Object.assign({}, current, { mapMove: true });
+    });
+    this.focusMap();
+  }
+
   protected toggleNorthUp() {
     this.app.uiConfig.update((current) => {
       return Object.assign({}, current, { mapNorthUp: !current.mapNorthUp });

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -149,6 +149,9 @@ export function cleanConfig(
     settings.map.panBehavior = legacyPanBehavior(legacy.lockMoveMap);
     delete legacy.lockMoveMap;
   }
+  if (typeof settings.map.refollowDelay !== 'number') {
+    settings.map.refollowDelay = 0;
+  }
   if (typeof settings.map.popoverMulti === 'undefined') {
     settings.map.popoverMulti = false;
   }
@@ -550,6 +553,7 @@ export function defaultConfig(): IAppConfig {
       center: [0, 0],
       rotation: 0,
       panBehavior: 'offset',
+      refollowDelay: 0,
       animate: false,
       labelsMinZoom: 8,
       doubleClickZoom: false, // true=zoom

--- a/src/app/lib/refollow-timer.spec.ts
+++ b/src/app/lib/refollow-timer.spec.ts
@@ -113,18 +113,39 @@ describe('RefollowTimer', () => {
 });
 
 describe('isRefollowActivity', () => {
+  const HERE: [number, number] = [24.7, 59.7];
+
   it('counts a zoom as activity', () => {
-    expect(isRefollowActivity({ zoomChanged: true })).toBe(true);
+    expect(isRefollowActivity({ lonlat: HERE, zoomChanged: true }, HERE)).toBe(
+      true
+    );
+  });
+
+  it('counts a move of the centre as activity even with no zoom change', () => {
+    // OpenLayers' keyboardpan moves the view with the arrow keys: it fires a
+    // move-end but emits no pointerdrag and changes no zoom, so the centre is
+    // the only evidence that the user panned.
+    expect(
+      isRefollowActivity({ lonlat: [24.8, 59.7], zoomChanged: false }, HERE)
+    ).toBe(true);
+    expect(
+      isRefollowActivity({ lonlat: [24.7, 59.8], zoomChanged: false }, HERE)
+    ).toBe(true);
   });
 
   it('does NOT count a rotation-only move-end as activity', () => {
     // Heading-up re-rotates the chart on every heading update, follow mode on or
-    // off, and each rotation ends in its own move-end carrying zoomChanged
-    // false. Counting those held the countdown open forever (#714).
-    expect(isRefollowActivity({ zoomChanged: false })).toBe(false);
+    // off, and each rotation ends in its own move-end — same centre, same zoom.
+    // Counting those held the countdown open forever (#714).
+    expect(isRefollowActivity({ lonlat: HERE, zoomChanged: false }, HERE)).toBe(
+      false
+    );
   });
 
-  it('does NOT count a move-end that reports no zoom state', () => {
+  it('does NOT count the first move-end, which has no previous centre', () => {
+    expect(isRefollowActivity({ lonlat: HERE, zoomChanged: false }, null)).toBe(
+      false
+    );
     expect(isRefollowActivity({})).toBe(false);
   });
 });
@@ -142,14 +163,39 @@ describe('RefollowTimer under a heading-up chart (#714 regression)', () => {
     const timer = new RefollowTimer(onExpire);
     timer.arm(5);
 
+    const helm: [number, number] = [24.7, 59.7];
     for (let second = 0; second < 10; second++) {
-      const rotationOnlyMoveEnd = { zoomChanged: false };
-      if (isRefollowActivity(rotationOnlyMoveEnd)) {
+      const rotationOnlyMoveEnd = { lonlat: helm, zoomChanged: false };
+      if (isRefollowActivity(rotationOnlyMoveEnd, helm)) {
         timer.reset();
       }
       vi.advanceTimersByTime(1000);
     }
 
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('an arrow-key pan during the countdown still defers the resume', () => {
+    // keyboardpan produces no pointerdrag, so the move-end's centre is the only
+    // signal that the user panned. Without it the chart could snatch itself back
+    // mid-pan.
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+    timer.arm(5);
+
+    vi.advanceTimersByTime(4000);
+    if (
+      isRefollowActivity(
+        { lonlat: [24.8, 59.7], zoomChanged: false },
+        [24.7, 59.7]
+      )
+    ) {
+      timer.reset();
+    }
+    vi.advanceTimersByTime(4000);
+    expect(onExpire).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
     expect(onExpire).toHaveBeenCalledTimes(1);
   });
 

--- a/src/app/lib/refollow-timer.spec.ts
+++ b/src/app/lib/refollow-timer.spec.ts
@@ -1,0 +1,171 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { isRefollowActivity, RefollowTimer } from './refollow-timer';
+
+describe('RefollowTimer', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('resumes follow mode once the delay elapses', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+
+    timer.arm(5);
+    expect(timer.armed).toBe(true);
+
+    vi.advanceTimersByTime(4999);
+    expect(onExpire).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+    expect(timer.armed).toBe(false);
+  });
+
+  it('never arms for a zero delay — the backward-compatible default', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+
+    timer.arm(0);
+
+    expect(timer.armed).toBe(false);
+    vi.advanceTimersByTime(60000);
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('measures idle time — further activity restarts the countdown', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+
+    timer.arm(5);
+    vi.advanceTimersByTime(4000);
+    timer.reset(); // a pan or zoom lands 1s before it would have fired
+    vi.advanceTimersByTime(4000);
+    expect(onExpire).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores activity while not armed', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+
+    timer.reset();
+
+    expect(timer.armed).toBe(false);
+    vi.advanceTimersByTime(60000);
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('cancels a running countdown, and does not restart on later activity', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+
+    timer.arm(5);
+    vi.advanceTimersByTime(2000);
+    timer.cancel(); // e.g. the user tapped Follow themselves
+    expect(timer.armed).toBe(false);
+
+    timer.reset();
+    vi.advanceTimersByTime(60000);
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('fires once only — a spent countdown cannot be restarted by activity', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+
+    timer.arm(5);
+    vi.advanceTimersByTime(5000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+
+    timer.reset();
+    vi.advanceTimersByTime(60000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arming replaces the countdown already running', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+
+    timer.arm(30);
+    vi.advanceTimersByTime(20000);
+    timer.arm(5);
+
+    vi.advanceTimersByTime(4999);
+    expect(onExpire).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('never arms for a delay that is not a usable number', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+
+    timer.arm(NaN);
+    expect(timer.armed).toBe(false);
+
+    timer.arm(-5);
+    expect(timer.armed).toBe(false);
+
+    vi.advanceTimersByTime(60000);
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+});
+
+describe('isRefollowActivity', () => {
+  it('counts a zoom as activity', () => {
+    expect(isRefollowActivity({ zoomChanged: true })).toBe(true);
+  });
+
+  it('does NOT count a rotation-only move-end as activity', () => {
+    // Heading-up re-rotates the chart on every heading update, follow mode on or
+    // off, and each rotation ends in its own move-end carrying zoomChanged
+    // false. Counting those held the countdown open forever (#714).
+    expect(isRefollowActivity({ zoomChanged: false })).toBe(false);
+  });
+
+  it('does NOT count a move-end that reports no zoom state', () => {
+    expect(isRefollowActivity({})).toBe(false);
+  });
+});
+
+describe('RefollowTimer under a heading-up chart (#714 regression)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('still resumes while rotation-only move-ends keep arriving', () => {
+    // The failing case from the boat: pan to release follow mode, then let the
+    // vessel carry on under way so heading-up fires a move-end every second.
+    // Feeding those to reset() pushed the deadline out on every one of them and
+    // follow mode never came back.
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+    timer.arm(5);
+
+    for (let second = 0; second < 10; second++) {
+      const rotationOnlyMoveEnd = { zoomChanged: false };
+      if (isRefollowActivity(rotationOnlyMoveEnd)) {
+        timer.reset();
+      }
+      vi.advanceTimersByTime(1000);
+    }
+
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('a zoom during the countdown still defers the resume', () => {
+    const onExpire = vi.fn();
+    const timer = new RefollowTimer(onExpire);
+    timer.arm(5);
+
+    vi.advanceTimersByTime(4000);
+    if (isRefollowActivity({ zoomChanged: true })) {
+      timer.reset();
+    }
+    vi.advanceTimersByTime(4000);
+    expect(onExpire).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/lib/refollow-timer.ts
+++ b/src/app/lib/refollow-timer.ts
@@ -1,0 +1,77 @@
+/**
+ * Re-arms follow mode a configurable idle period after a pan released it.
+ *
+ * Only the `exit` pan behaviour releases follow mode by panning, so only that
+ * behaviour arms this timer (#714). The countdown measures *idle* time: every
+ * settled pan or zoom restarts it, so the display has to sit still for the whole
+ * delay before the vessel is followed again. A delay of zero never arms, which
+ * is the default and preserves the pre-#714 behaviour.
+ *
+ * Deliberately turning follow mode off with the Follow button does NOT arm it —
+ * a manual "off" has to stay off, or it could not be expressed at all.
+ */
+export class RefollowTimer {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private delayMs = 0;
+
+  /** @param onExpire run once the display has been idle for the whole delay. */
+  constructor(private onExpire: () => void) {}
+
+  /** True while a countdown is running. */
+  get armed(): boolean {
+    return this.timer !== null;
+  }
+
+  /**
+   * Start the countdown, replacing any countdown already running.
+   * @param delaySeconds idle period before follow mode resumes; <= 0 never arms.
+   */
+  arm(delaySeconds: number) {
+    this.cancel();
+    if (!Number.isFinite(delaySeconds) || delaySeconds <= 0) {
+      return;
+    }
+    this.delayMs = delaySeconds * 1000;
+    this.start();
+  }
+
+  /** Restart the countdown after further activity. No-op when not armed. */
+  reset() {
+    if (!this.armed) {
+      return;
+    }
+    this.start();
+  }
+
+  /** Stop the countdown. Safe to call when not armed. */
+  cancel() {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private start() {
+    this.cancel();
+    this.timer = setTimeout(() => {
+      // One-shot: clear before notifying so `armed` reads false to the callback
+      // and any activity it triggers cannot restart a spent countdown.
+      this.timer = null;
+      this.onExpire();
+    }, this.delayMs);
+  }
+}
+
+/**
+ * Whether a settled map move restarts the idle countdown.
+ *
+ * Only a zoom does. A heading-up chart re-rotates on every heading update — and
+ * it does so whether or not follow mode is on, because `rotateMap()` is not
+ * gated on it — so each heading change ends in its own move-end. Treating every
+ * move-end as activity therefore holds the countdown open indefinitely on a
+ * vessel under way, and follow mode never comes back (#714). A pan is reported
+ * separately by the pointer-drag handler, where it is unambiguously the user.
+ */
+export function isRefollowActivity(move: { zoomChanged?: boolean }): boolean {
+  return move.zoomChanged === true;
+}

--- a/src/app/lib/refollow-timer.ts
+++ b/src/app/lib/refollow-timer.ts
@@ -63,15 +63,35 @@ export class RefollowTimer {
 }
 
 /**
- * Whether a settled map move restarts the idle countdown.
+ * Whether a settled map move restarts the idle countdown — i.e. whether the
+ * user moved the chart, as opposed to the chart moving by itself.
  *
- * Only a zoom does. A heading-up chart re-rotates on every heading update — and
- * it does so whether or not follow mode is on, because `rotateMap()` is not
- * gated on it — so each heading change ends in its own move-end. Treating every
- * move-end as activity therefore holds the countdown open indefinitely on a
- * vessel under way, and follow mode never comes back (#714). A pan is reported
- * separately by the pointer-drag handler, where it is unambiguously the user.
+ * A change of zoom or of centre is the user; a change of *rotation alone* is
+ * not. A heading-up chart re-rotates on every heading update whether or not
+ * follow mode is on, because `rotateMap()` is not gated on it, so each heading
+ * change ends in its own move-end. Counting those holds the countdown open
+ * indefinitely on a vessel under way and follow mode never comes back (#714).
+ * Rotation moves neither centre nor zoom, so testing those two excludes it.
+ *
+ * Testing the centre — rather than trusting the pointer-drag handler to report
+ * every pan — is what covers panning that never produces a pointer drag, above
+ * all OpenLayers' `keyboardpan`: the arrow keys move the view and fire a
+ * move-end, but emit no `pointerdrag` and change no zoom.
+ *
+ * @param move the settled move
+ * @param previousCenter centre before it; null/absent on the first move-end
  */
-export function isRefollowActivity(move: { zoomChanged?: boolean }): boolean {
-  return move.zoomChanged === true;
+export function isRefollowActivity(
+  move: { lonlat?: number[]; zoomChanged?: boolean },
+  previousCenter?: number[] | null
+): boolean {
+  if (move.zoomChanged === true) {
+    return true;
+  }
+  if (!previousCenter || !move.lonlat) {
+    return false;
+  }
+  return (
+    move.lonlat[0] !== previousCenter[0] || move.lonlat[1] !== previousCenter[1]
+  );
 }

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -316,6 +316,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
    * map centre becomes the new vessel centre offset. */
   private userPanned = false;
   private offsetGraceTimer;
+  /** Map centre as of the last move-end, so the next one can tell a pan (the
+   * user) from a rotation (heading-up turning the chart on its own). */
+  private lastMoveCenter: Position | null = null;
   /** Brings follow mode back once the display has been idle for the configured
    * delay after a pan released it (#714). Never armed unless that delay is set. */
   private refollow = new RefollowTimer(() =>
@@ -730,12 +733,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
       }
     }
 
-    // A zoom restarts the idle countdown; a rotation-only move-end must not
-    // (#714) — see isRefollowActivity. Panning is signalled by
-    // onMapPointerDrag() instead, where it is unambiguously the user.
-    if (isRefollowActivity(e)) {
+    // A pan or zoom restarts the idle countdown; a rotation-only move-end must
+    // not (#714) — see isRefollowActivity. Testing the centre here is what
+    // catches a pan that emits no pointer drag, such as the arrow keys.
+    if (isRefollowActivity(e, this.lastMoveCenter)) {
       this.refollow.reset();
     }
+    this.lastMoveCenter = e.lonlat as Position;
 
     this.drawVesselLines();
     if (!this.movingMap) {

--- a/src/app/modules/map/fb-map.component.ts
+++ b/src/app/modules/map/fb-map.component.ts
@@ -51,6 +51,7 @@ import { Convert, TARGET_UNIT } from 'src/app/lib/convert';
 import { GeoUtils, Angle } from 'src/app/lib/geoutils';
 import { zoomKeyDirection } from 'src/app/lib/zoom-keys';
 import { zoomDisplayText } from 'src/app/lib/zoom-display';
+import { isRefollowActivity, RefollowTimer } from 'src/app/lib/refollow-timer';
 import { computeCursorEta, CursorEtaInfo } from './cursor-eta';
 import { CursorPin, tapFadeMs, TAP_MAX_DURATION } from './cursor-marker';
 import {
@@ -223,6 +224,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   @Output() deactivate: EventEmitter<string> = new EventEmitter();
   @Output() info: EventEmitter<IResource> = new EventEmitter();
   @Output() exitMovingMap: EventEmitter<boolean> = new EventEmitter();
+  @Output() resumeMovingMap: EventEmitter<void> = new EventEmitter();
   @Output() focusVessel: EventEmitter<string> = new EventEmitter();
   @Output() menuItemSelected: EventEmitter<string> = new EventEmitter();
 
@@ -314,6 +316,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
    * map centre becomes the new vessel centre offset. */
   private userPanned = false;
   private offsetGraceTimer;
+  /** Brings follow mode back once the display has been idle for the configured
+   * delay after a pan released it (#714). Never armed unless that delay is set. */
+  private refollow = new RefollowTimer(() =>
+    // Armed from a pointer drag, so the expiry fires outside the Angular zone;
+    // re-enter it so resuming follow mode propagates to the UI.
+    this.ngZone.run(() => this.resumeMovingMap.emit())
+  );
   /** True while the vessel is held dead centre just after follow mode is
    * turned on (see startOffsetGrace). */
   private offsetSuppressed = false;
@@ -430,6 +439,7 @@ export class FBMapComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.stopSaveTimer();
     this.stopOffsetGrace();
+    this.refollow.cancel();
     this.cursorPin.release();
     this.obsList.forEach((i) => i.unsubscribe());
   }
@@ -451,6 +461,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
     }
     if (changes && changes.movingMap && !changes.movingMap.firstChange) {
       if (changes.movingMap.currentValue) {
+        // Following again — by the Follow button or by the timer below — so the
+        // countdown has nothing left to do. Only the `false` branch may leave it
+        // armed: that is the pan-triggered exit that armed it in the first place.
+        this.refollow.cancel();
         this.startSaveTimer();
         this.startOffsetGrace();
       } else {
@@ -716,6 +730,13 @@ export class FBMapComponent implements OnInit, OnDestroy {
       }
     }
 
+    // A zoom restarts the idle countdown; a rotation-only move-end must not
+    // (#714) — see isRefollowActivity. Panning is signalled by
+    // onMapPointerDrag() instead, where it is unambiguously the user.
+    if (isRefollowActivity(e)) {
+      this.refollow.reset();
+    }
+
     this.drawVesselLines();
     if (!this.movingMap) {
       // debounce: a flurry of pans/zooms collapses into one save
@@ -782,6 +803,10 @@ export class FBMapComponent implements OnInit, OnDestroy {
   }
 
   protected onMapPointerDrag() {
+    // A drag is the user, so it restarts the idle countdown — before the
+    // follow-mode guard below, because every pan AFTER the one that released
+    // follow mode arrives with follow already off and must still count (#714).
+    this.refollow.reset();
     if (!this.app.uiConfig().mapMove) {
       return;
     }
@@ -789,6 +814,9 @@ export class FBMapComponent implements OnInit, OnDestroy {
       // pointer-drag runs outside the Angular zone (see MapComponent); re-enter
       // so exiting "move map" mode propagates to the UI. Rare one-off transition.
       this.ngZone.run(() => this.exitMovingMap.emit(true));
+      // The pan that releases follow mode also starts the idle countdown that
+      // brings it back (#714). Further drags and zooms restart it above.
+      this.refollow.arm(this.app.config.map.refollowDelay);
     } else if (this.app.config.map.panBehavior === 'offset') {
       // Follow mode stays on; onMapMoveEnd() captures the new look-ahead once
       // the drag settles.

--- a/src/app/modules/settings/components/settings-dialog.css
+++ b/src/app/modules/settings/components/settings-dialog.css
@@ -35,6 +35,14 @@
   padding-right: 15px;
   flex: 1 1 auto;
 }
+/* A row item stacking a control with its dependent sub-control. The stack is
+   wider at max-content than a single control, so under the default
+   `flex-basis: auto` it wraps onto a line of its own — where `flex-grow: 1`
+   then stretches it across the whole card. An explicit basis keeps the pair in
+   its column, directly beneath the control it depends on. */
+.settings .setting-card-row-item.setting-card-row-stack {
+  flex-basis: 220px;
+}
 /* A label shared by several related inputs, standing in for the mat-label a
    single control would carry. An empty one is a spacer keeping a neighbouring
    single control's box level with the group's boxes. */

--- a/src/app/modules/settings/components/settings-dialog.html
+++ b/src/app/modules/settings/components/settings-dialog.html
@@ -553,7 +553,11 @@
                       Keep tiles visible on max zoom
                     </mat-checkbox>
                   </div>
-                  <div class="setting-card-row-item">
+                  <!-- One stacked item, not two row items: a `setting-card-row-item`
+                       that wraps gets a line to itself and is stretched across the
+                       whole card. Stacking keeps the dependent control directly
+                       beneath its parent, in the same column. -->
+                  <div class="setting-card-row-item setting-card-row-stack">
                     <mat-form-field style="width: 100%">
                       <mat-label>Map Pan When Following</mat-label>
                       <mat-select
@@ -566,6 +570,20 @@
                         }
                       </mat-select>
                     </mat-form-field>
+                    @if(facade.settings.map.panBehavior === 'exit') {
+                    <mat-form-field style="width: 100%">
+                      <mat-label>Resume Following After</mat-label>
+                      <mat-select
+                        [(ngModel)]="facade.settings.map.refollowDelay"
+                        (selectionChange)="persistModel()"
+                        matTooltip="Resume following the vessel once the chart has been left idle for this long."
+                      >
+                        @for(i of options.map.refollowDelay; track i[0]) {
+                        <mat-option [value]="i[0]">{{i[1]}}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
+                    }
                   </div>
                 </div>
               </mat-card-content>

--- a/src/app/modules/settings/settings.facade.ts
+++ b/src/app/modules/settings/settings.facade.ts
@@ -94,6 +94,15 @@ export class SettingsOptions {
       ['exit', 'Exit Follow Mode'],
       ['none', 'Do nothing']
     ]),
+    refollowDelay: new Map<number, string>([
+      [0, 'Never'],
+      [5, '5 secs'],
+      [10, '10 secs'],
+      [15, '15 secs'],
+      [20, '20 secs'],
+      [30, '30 secs'],
+      [60, '60 secs']
+    ]),
     s57: {
       graphicsStyle: new Map([
         ['Simplified', 'Simplified'],

--- a/src/app/types/index.d.ts
+++ b/src/app/types/index.d.ts
@@ -144,6 +144,7 @@ export interface IAppConfig {
     center: Position;
     rotation: number;
     panBehavior: MapPanBehavior; // what panning the chart does while following the vessel
+    refollowDelay: number; // secs of idle before a pan-released follow mode resumes; 0 = never
     animate: boolean;
     labelsMinZoom: number;
     doubleClickZoom: boolean; // true=zoom

--- a/src/assets/help/index.html
+++ b/src/assets/help/index.html
@@ -2482,7 +2482,14 @@
                   position the vessel on screen by eye. The offset is saved and
                   used from then on.
                 </li>
-                <li><b>Exit Follow Mode</b>: Panning turns follow mode off.</li>
+                <li>
+                  <b>Exit Follow Mode</b>: Panning turns follow mode off.
+                  Choosing this reveals <b>Resume Following After</b>, which
+                  turns follow mode back on once the chart has been left idle
+                  for the selected period; each pan or zoom restarts the wait.
+                  <b>Never</b> (the default) leaves follow mode off until you
+                  turn it back on.
+                </li>
                 <li>
                   <b>Do nothing</b>: Follow mode stays on and the vessel returns
                   to its usual position on the next position update.


### PR DESCRIPTION
Panning with the **Exit Follow Mode** pan behavior releases follow mode and leaves it released, so getting back to the vessel takes a deliberate tap on Follow. That is fine at the helm, but not for a crew member running with the toolbar buttons hidden who just wants to look ahead for a moment — as described in #714, where the alternative is zooming out, looking, and zooming back in.

This adds a **Resume Following After** delay next to that pan behavior. A pan that releases follow mode starts an idle countdown; when it elapses the chart follows the vessel again.

## What changes for the user?

A new **Settings → Map → Resume Following After** control, shown only when **Map Pan When Following** is set to *Exit Follow Mode*. Pick a delay (5–60 seconds) and the chart hands itself back that long after you stop touching it. The default is **Never**, so nothing changes unless you opt in.

- Only a **pan** arms the countdown. Turning follow off with the Follow button leaves it off — otherwise there would be no way to express "stay unfollowed" at all.
- A **pan or zoom** restarts it, so the chart has to sit idle for the whole delay before following resumes.

## Why a rotation is not activity

The countdown measures *user* idle time, not "no view change at all" — and getting that wrong is the whole difficulty here.

`rotateMap()` runs on every vessel update and is **not** gated on follow mode, so a heading-up chart re-rotates on each heading change and every rotation ends in its own `moveend`. Counting those as activity holds the countdown open indefinitely on a vessel under way, and follow mode never returns. This is invisible on a stationary vessel — it passed a bench test and failed immediately on a moving boat — which is why it is pinned by a test rather than a manual check.

`isRefollowActivity()` draws the line: a change of **centre or zoom** is the user; a change of rotation alone is not, since rotating moves neither.

## Testing

- `RefollowTimer` unit tests: arming, zero/invalid delay never arming, idle reset, cancel, one-shot expiry, re-arm.
- `isRefollowActivity()` tests plus two regression cases — a stream of rotation-only move-ends must not defer the resume, and a keyboard pan must. Reverting either fix turns the matching tests red.
- Full suite green (645 tests); verified in a running Freeboard against live vessel data, under way in heading-up.

## Note on scope — keyboard panning

CodeRabbit raised on the origin stand-in that OpenLayers' `keyboardpan` emits no `pointerdrag`, so arrow-key pans were invisible to this feature. Half of that is fixed here and half is deliberately out of scope:

**Fixed** — the countdown now tests the move-end's **centre** rather than trusting the pointer-drag handler to report every pan, so an arrow-key pan restarts it like any other. This also covers any future pan that produces no pointer drag. (The pointer-drag reset stays alongside it: it fires *mid-gesture*, before any move-end, so a slow drag cannot expire under the user's finger.)

**Not fixed, deliberately** — an arrow-key pan also does not *exit* follow mode under the Exit Follow Mode behavior. That is true, but pre-existing on master and untouched by this PR: `onMapPointerDrag` has always been the sole exit path. It is in fact broader than follow-exit — arrow-key panning bypasses the *Map Pan When Following* setting entirely, so *Set Follow Offset* is equally unreachable from the keyboard. Fixing it means changing what that setting does for keyboard users and is a separate logical change, now filed as #725.

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional **Resume Following After** setting for map follow mode.
  * Follow mode can automatically resume after a configurable idle period following a pan.
  * Panning or zooming restarts the idle countdown; manually disabling follow mode keeps it off.
  * Added delay options from **Never** through **60 seconds**, with **Never** as the default.

* **Documentation**
  * Updated in-app help and feature documentation to explain the new setting and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->